### PR TITLE
Add the composer, drafts, and local comparisons to the desktop app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,6 +1735,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-clipboard-manager",
  "tauri-specta",
+ "tempfile",
 ]
 
 [[package]]

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,6 +12,11 @@
     "tauri": "tauri"
   },
   "dependencies": {
+    "@codemirror/commands": "6.11.0",
+    "@codemirror/lang-markdown": "6.5.2",
+    "@codemirror/language": "6.12.4",
+    "@codemirror/state": "6.7.2",
+    "@codemirror/view": "6.43.10",
     "@tanstack/react-virtual": "^3.14.10",
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.3",

--- a/apps/desktop/pnpm-lock.yaml
+++ b/apps/desktop/pnpm-lock.yaml
@@ -8,6 +8,21 @@ importers:
 
   .:
     dependencies:
+      '@codemirror/commands':
+        specifier: 6.11.0
+        version: 6.11.0
+      '@codemirror/lang-markdown':
+        specifier: 6.5.2
+        version: 6.5.2
+      '@codemirror/language':
+        specifier: 6.12.4
+        version: 6.12.4
+      '@codemirror/state':
+        specifier: 6.7.2
+        version: 6.7.2
+      '@codemirror/view':
+        specifier: 6.43.10
+        version: 6.43.10
       '@tanstack/react-virtual':
         specifier: ^3.14.10
         version: 3.14.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -84,6 +99,36 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
+  '@codemirror/autocomplete@6.20.3':
+    resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}
+
+  '@codemirror/commands@6.11.0':
+    resolution: {integrity: sha512-/K4Rl5BN0OtTiPWmJCdqODu38XnDMsDxKY5rgrPnCkutPTJf2wVbkoixLfealF5Kwse/s8P8M5jAiURiwSwnFA==}
+
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-html@6.4.12':
+    resolution: {integrity: sha512-pw2ReWKUqSkbvh76RAT4NYxiogRu+PWkR2ukAwO9uOgrm8uipkzjtKKtNpyeAQwHOqxEeSvAXZ6vr3AfyB9y/w==}
+
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/lang-markdown@6.5.2':
+    resolution: {integrity: sha512-AwBOdkWYuA//WcM0xO5PfHPUcmz/O2i5o0Nsg1U69SII/loCJlFI1Romd9xp2HYb1kYJRGZotyqRghuHH5n8Kw==}
+
+  '@codemirror/language@6.12.4':
+    resolution: {integrity: sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==}
+
+  '@codemirror/lint@6.9.7':
+    resolution: {integrity: sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==}
+
+  '@codemirror/state@6.7.2':
+    resolution: {integrity: sha512-U3RiPX62Wl/Gx4ftQ7UxLlloSfsFTQqKa+7vFBYteZGCzkp6oBqcsD7iSwniWRGobCAmDcwZSY+Six3+3ztdfg==}
+
+  '@codemirror/view@6.43.10':
+    resolution: {integrity: sha512-vVWLvd4fKWYN/pMcwUrg6dWeublxmSz+V+52ZjW3h64IVN9cRUYLk5Km4JDT9vifxAFfDtNOIFxKYENthcolJQ==}
+
   '@csstools/color-helpers@6.1.1':
     resolution: {integrity: sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==}
     engines: {node: '>=20.19.0'}
@@ -131,6 +176,30 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.6.0':
     resolution: {integrity: sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==}
+
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/css@1.3.6':
+    resolution: {integrity: sha512-YJE78Wcg+zX8f10hiHWQ4Az48Qr/c13eId0VtRQYLBpxHDmDeSrXIlkbl+fJGW42rWC/uoUco9mhBZeVWP/A1g==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/html@1.3.13':
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
+
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
+  '@lezer/markdown@1.7.2':
+    resolution: {integrity: sha512-iTkYvoVcKt3WkeL7qUDyXHONZEwLio4wj8KTNi2dnjQEXBZKMV63BpQrPqfsM+OkvuRbiSTAcycYAsQzLhRNoQ==}
+
+  '@marijn/find-cluster-break@1.0.4':
+    resolution: {integrity: sha512-Wy0V7+SGUjnF9/TkiM1hKVDPj7jKXduPNboMVtHTA8dySMURWqfg/JZ9E2Sq8JgSJmkl7k7Qe9FLeMSrSraWmQ==}
 
   '@oxc-project/types@0.147.0':
     resolution: {integrity: sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==}
@@ -563,6 +632,9 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  crelt@1.0.7:
+    resolution: {integrity: sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==}
+
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
@@ -798,6 +870,9 @@ packages:
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -924,6 +999,9 @@ packages:
       jsdom:
         optional: true
 
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -987,6 +1065,86 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
+  '@codemirror/autocomplete@6.20.3':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.2
+      '@codemirror/view': 6.43.10
+      '@lezer/common': 1.5.2
+
+  '@codemirror/commands@6.11.0':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.2
+      '@codemirror/view': 6.43.10
+      '@lezer/common': 1.5.2
+
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.2
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.6
+
+  '@codemirror/lang-html@6.4.12':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.2
+      '@codemirror/view': 6.43.10
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.6
+      '@lezer/html': 1.3.13
+
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/lint': 6.9.7
+      '@codemirror/state': 6.7.2
+      '@codemirror/view': 6.43.10
+      '@lezer/common': 1.5.2
+      '@lezer/javascript': 1.5.4
+
+  '@codemirror/lang-markdown@6.5.2':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-html': 6.4.12
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.2
+      '@codemirror/view': 6.43.10
+      '@lezer/common': 1.5.2
+      '@lezer/markdown': 1.7.2
+
+  '@codemirror/language@6.12.4':
+    dependencies:
+      '@codemirror/state': 6.7.2
+      '@codemirror/view': 6.43.10
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.7':
+    dependencies:
+      '@codemirror/state': 6.7.2
+      '@codemirror/view': 6.43.10
+      crelt: 1.0.7
+
+  '@codemirror/state@6.7.2':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.4
+
+  '@codemirror/view@6.43.10':
+    dependencies:
+      '@codemirror/state': 6.7.2
+      crelt: 1.0.7
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
+
   '@csstools/color-helpers@6.1.1': {}
 
   '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
@@ -1014,6 +1172,41 @@ snapshots:
   '@exodus/bytes@1.15.1': {}
 
   '@jridgewell/sourcemap-codec@1.6.0': {}
+
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/css@1.3.6':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/html@1.3.13':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/markdown@1.7.2':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+
+  '@marijn/find-cluster-break@1.0.4': {}
 
   '@oxc-project/types@0.147.0': {}
 
@@ -1295,6 +1488,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  crelt@1.0.7: {}
+
   css-tree@3.2.1:
     dependencies:
       mdn-data: 2.27.1
@@ -1503,6 +1698,8 @@ snapshots:
 
   std-env@4.2.0: {}
 
+  style-mod@4.1.3: {}
+
   symbol-tree@3.2.4: {}
 
   tinybench@2.9.0: {}
@@ -1591,6 +1788,8 @@ snapshots:
       jsdom: 30.0.1
     transitivePeerDependencies:
       - msw
+
+  w3c-keyname@2.2.8: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -27,5 +27,8 @@ tauri-specta = { version = "=2.0.0-rc.25", features = ["derive", "typescript"] }
 specta = "=2.0.0-rc.25"
 specta-typescript = "=0.0.12"
 
+[dev-dependencies]
+tempfile = "3"
+
 [lints]
 workspace = true

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1,8 +1,12 @@
 //! Tauri commands exposed to the frontend, and the specta builder that types them.
 
-use std::sync::Mutex;
+use std::sync::{
+    Mutex,
+    atomic::{AtomicBool, Ordering},
+};
 
 use app::{SessionPhase, lock};
+use domain::DiffSide;
 use session::{ReviewStorage, SessionRequest};
 use tauri::ipc::Channel;
 use tauri_specta::collect_commands;
@@ -15,29 +19,56 @@ pub fn specta_builder() -> tauri_specta::Builder<tauri::Wry> {
     tauri_specta::Builder::<tauri::Wry>::new().commands(collect_commands![
         open_session,
         select_file,
-        toggle_viewed
+        toggle_viewed,
+        describe_session,
+        edit_draft,
+        discard_draft,
+        reanchor_draft,
     ])
 }
 
-/// Loads the demo session into `model`, reporting each stage's label to `report`.
+/// Loads `request` into `model`, reporting each stage's label to `report`.
 ///
 /// Takes the reporter as a plain callback so it can be tested without a Tauri channel.
-fn run_load(model: &Mutex<app::SessionModel>, report: &dyn Fn(&str)) {
-    let result = session::load(&SessionRequest::Demo, &ReviewStorage::Disabled, &|stage| {
+fn run_load(
+    model: &Mutex<app::SessionModel>,
+    request: &SessionRequest,
+    storage: &ReviewStorage,
+    report: &dyn Fn(&str),
+) {
+    let result = session::load(request, storage, &|stage| {
         let _ = lock(model).set_stage(stage.label());
         report(stage.label());
     });
     lock(model).finish(result);
 }
 
-/// Loads the demo session into `model`, unless it has already finished loading.
+/// Loads `request` into `model`, letting exactly one concurrent caller do it.
 ///
-/// What makes `open_session` idempotent under a repeated call, such as React
-/// `StrictMode`'s double mount effect.
-fn load_if_pending(model: &Mutex<app::SessionModel>, report: &dyn Fn(&str)) {
-    if lock(model).is_loading() {
-        run_load(model, report);
+/// `load_started` is swapped exactly once; the caller that loses the race
+/// waits for the winner's load to finish rather than returning early, which is
+/// what keeps `open_session`'s later `phase()` read honest under a repeated
+/// call, such as React `StrictMode`'s double mount effect.
+fn load_if_pending(
+    model: &Mutex<app::SessionModel>,
+    load_started: &AtomicBool,
+    request: &SessionRequest,
+    storage: &ReviewStorage,
+    report: &dyn Fn(&str),
+) {
+    if load_started.swap(true, Ordering::AcqRel) {
+        // Bounded so a loader that dies without finishing fails loudly here.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_mins(10);
+        while lock(model).is_loading() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the winning loader never finished"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        return;
     }
+    run_load(model, request, storage, report);
 }
 
 fn select_file_on_model(
@@ -56,10 +87,14 @@ fn select_file_on_model(
     }
     // A same-index call reports false; that is a no-op, not a failure.
     guard.select_file(index);
+    let write_failure = guard.draft_write_failure();
     let SessionPhase::Ready(review) = guard.phase() else {
         unreachable!("select_file cannot move the model out of Ready")
     };
-    Ok(dto::project_file(review.session(), index).expect("index bounds-checked above"))
+    let mut detail =
+        dto::project_file(review.session(), index).expect("index bounds-checked above");
+    detail.drafts.write_failure = write_failure;
+    Ok(detail)
 }
 
 fn toggle_viewed_on_model(
@@ -76,7 +111,123 @@ fn toggle_viewed_on_model(
     Ok(dto::project_sidebar(review.session()))
 }
 
-/// Loads the demo review session, reporting each stage on `on_stage` as it goes.
+/// Projects the drafts on `file_index` from an already-locked, `Ready` model.
+///
+/// # Panics
+///
+/// Panics if the model is not `Ready`. Every caller here has just checked that
+/// under the same lock.
+fn drafts_snapshot(model: &app::SessionModel, file_index: usize) -> dto::DraftsDto {
+    let write_failure = model.draft_write_failure();
+    let SessionPhase::Ready(review) = model.phase() else {
+        unreachable!("checked Ready under the same lock")
+    };
+    let mut drafts = dto::project_drafts(review.session(), file_index);
+    drafts.write_failure = write_failure;
+    drafts
+}
+
+/// Edits the draft over `start.min(end)..=start.max(end)` of `file_index`,
+/// entirely under one lock so the check against the selected file and the
+/// mutation it guards cannot straddle a file switch.
+///
+/// A `file_index` that no longer names the selected file is a late command
+/// for a file the reviewer has since left. It is dropped rather than applied
+/// to whatever is now selected. `accepted` comes back `false` and `drafts`
+/// reflects the file that actually is selected.
+fn edit_draft_on_model(
+    model: &Mutex<app::SessionModel>,
+    file_index: usize,
+    start: usize,
+    end: usize,
+    body: String,
+) -> Result<dto::DraftEditOutcomeDto, dto::SessionFailureDto> {
+    let mut guard = lock(model);
+    let selected = match guard.phase() {
+        SessionPhase::Ready(review) => review.session().selected_file_index(),
+        SessionPhase::Loading { .. } | SessionPhase::Failed(_) => {
+            return Err(dto::command_failure("the session is not ready"));
+        }
+    };
+    if file_index != selected {
+        return Ok(dto::DraftEditOutcomeDto {
+            accepted: false,
+            drafts: drafts_snapshot(&guard, selected),
+        });
+    }
+    let accepted = guard.draft_edited(start.min(end)..=start.max(end), body);
+    Ok(dto::DraftEditOutcomeDto {
+        accepted,
+        drafts: drafts_snapshot(&guard, selected),
+    })
+}
+
+/// Discards the draft on `row` of `file_index`, dropped silently when
+/// `file_index` is no longer selected. See [`edit_draft_on_model`].
+fn discard_draft_on_model(
+    model: &Mutex<app::SessionModel>,
+    file_index: usize,
+    row: usize,
+) -> Result<dto::DraftsDto, dto::SessionFailureDto> {
+    let mut guard = lock(model);
+    let selected = match guard.phase() {
+        SessionPhase::Ready(review) => review.session().selected_file_index(),
+        SessionPhase::Loading { .. } | SessionPhase::Failed(_) => {
+            return Err(dto::command_failure("the session is not ready"));
+        }
+    };
+    if file_index == selected {
+        // A false return means the row held no draft; that is a no-op, not a failure.
+        guard.draft_discarded(row);
+    }
+    Ok(drafts_snapshot(&guard, selected))
+}
+
+/// Moves the stale draft identified by `(path, side, line)` onto `row` of
+/// `file_index`, dropped silently when `file_index` is no longer selected.
+/// See [`edit_draft_on_model`].
+///
+/// The triple takes the place of the private key `Drafts` indexes stale drafts
+/// by; this looks the matching anchor up from the selected file's own stale
+/// drafts rather than trusting one reconstructed from IPC input.
+fn reanchor_draft_on_model(
+    model: &Mutex<app::SessionModel>,
+    file_index: usize,
+    path: &str,
+    side: DiffSide,
+    line: u32,
+    row: usize,
+) -> Result<dto::DraftsDto, dto::SessionFailureDto> {
+    let mut guard = lock(model);
+    let selected = match guard.phase() {
+        SessionPhase::Ready(review) => review.session().selected_file_index(),
+        SessionPhase::Loading { .. } | SessionPhase::Failed(_) => {
+            return Err(dto::command_failure("the session is not ready"));
+        }
+    };
+    if file_index != selected {
+        return Ok(drafts_snapshot(&guard, selected));
+    }
+    let SessionPhase::Ready(review) = guard.phase() else {
+        unreachable!("checked Ready above")
+    };
+    let stale = review
+        .session()
+        .drafts()
+        .for_path(path)
+        .find(|draft| draft.is_stale && draft.anchor.side == side && draft.anchor.line == line)
+        .map(|draft| draft.anchor.clone());
+    let Some(stale) = stale else {
+        return Err(dto::command_failure("that draft is no longer stale"));
+    };
+    if !guard.draft_reanchored(&stale, row) {
+        return Err(dto::command_failure("that row cannot hold a comment"));
+    }
+    Ok(drafts_snapshot(&guard, selected))
+}
+
+/// Loads the review session the window was opened with, reporting each stage on
+/// `on_stage` as it goes.
 ///
 /// # Errors
 ///
@@ -88,16 +239,19 @@ pub async fn open_session(
     state: tauri::State<'_, ManagedSession>,
     on_stage: Channel<String>,
 ) -> Result<dto::SessionSnapshotDto, dto::SessionFailureDto> {
-    let model = std::sync::Arc::clone(&state.0);
+    let model = std::sync::Arc::clone(&state.model);
+    let load_started = std::sync::Arc::clone(&state.load_started);
+    let request = state.request.clone();
+    let storage = state.storage.clone();
     tauri::async_runtime::spawn_blocking(move || {
-        load_if_pending(&model, &|stage| {
+        load_if_pending(&model, &load_started, &request, &storage, &|stage| {
             let _ = on_stage.send(stage.to_owned());
         });
     })
     .await
     .expect("the load task should not panic");
 
-    let guard = lock(&state.0);
+    let guard = lock(&state.model);
     match guard.phase() {
         SessionPhase::Ready(review) => Ok(dto::project_snapshot(review.session())),
         SessionPhase::Failed(failure) => Err(failure.into()),
@@ -105,6 +259,19 @@ pub async fn open_session(
             unreachable!("finish() always leaves the model Ready or Failed")
         }
     }
+}
+
+/// The request's own description, shown by the loading screen before anything
+/// about the target session is known.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn describe_session(state: tauri::State<'_, ManagedSession>) -> String {
+    describe_session_on_request(&state.request)
+}
+
+fn describe_session_on_request(request: &SessionRequest) -> String {
+    request.description()
 }
 
 /// Switches the displayed file and returns its rows.
@@ -119,7 +286,7 @@ pub async fn select_file(
     state: tauri::State<'_, ManagedSession>,
     index: u32,
 ) -> Result<dto::FileDetailDto, dto::SessionFailureDto> {
-    select_file_on_model(&state.0, index as usize)
+    select_file_on_model(&state.model, index as usize)
 }
 
 /// Marks the selected file viewed, or unmarks it, and returns the fresh sidebar.
@@ -133,18 +300,171 @@ pub async fn select_file(
 pub fn toggle_viewed(
     state: tauri::State<'_, ManagedSession>,
 ) -> Result<dto::SidebarDto, dto::SessionFailureDto> {
-    toggle_viewed_on_model(&state.0)
+    toggle_viewed_on_model(&state.model)
+}
+
+/// Edits the draft over rows `start..=end` of `file_index`. Persists the new
+/// text on every call. That is what makes a keystroke survive a crash.
+///
+/// # Errors
+///
+/// Returns a failure when the session is not ready. An unanchorable span is not
+/// an error. It comes back as `accepted: false` on the outcome, and neither is a
+/// `file_index` that has since been navigated away from; the outcome reflects
+/// the file that is actually selected.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn edit_draft(
+    state: tauri::State<'_, ManagedSession>,
+    file_index: u32,
+    start: u32,
+    end: u32,
+    body: String,
+) -> Result<dto::DraftEditOutcomeDto, dto::SessionFailureDto> {
+    edit_draft_on_model(
+        &state.model,
+        file_index as usize,
+        start as usize,
+        end as usize,
+        body,
+    )
+}
+
+/// Discards the draft on `row` of `file_index`.
+///
+/// # Errors
+///
+/// Returns a failure when the session is not ready.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn discard_draft(
+    state: tauri::State<'_, ManagedSession>,
+    file_index: u32,
+    row: u32,
+) -> Result<dto::DraftsDto, dto::SessionFailureDto> {
+    discard_draft_on_model(&state.model, file_index as usize, row as usize)
+}
+
+/// Moves a stale draft, named by the position it was written against, onto
+/// `row` of `file_index`.
+///
+/// # Errors
+///
+/// Returns a failure when the session is not ready, no stale draft matches
+/// `(path, side, line)`, or `row` cannot carry a comment.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn reanchor_draft(
+    state: tauri::State<'_, ManagedSession>,
+    file_index: u32,
+    path: String,
+    side: dto::DiffSideDto,
+    line: u32,
+    row: u32,
+) -> Result<dto::DraftsDto, dto::SessionFailureDto> {
+    reanchor_draft_on_model(
+        &state.model,
+        file_index as usize,
+        &path,
+        side.into(),
+        line,
+        row as usize,
+    )
 }
 
 #[cfg(test)]
 mod tests {
+    use std::{ffi::OsStr, path::Path, process::Command, sync::Arc, thread};
+
+    use tempfile::TempDir;
+
     use super::*;
+
+    /// A sink whose writes always fail, for exercising `draft_write_failure`.
+    struct FailingSink;
+
+    impl domain::ReviewStateSink for FailingSink {
+        fn save(&self, _anchor: &domain::DiffAnchor, _body: &str) {}
+        fn discard(&self, _anchor: &domain::DiffAnchor) {}
+        fn save_summary(&self, _head_sha: &str, _body: &str) {}
+        fn save_provenance(
+            &self,
+            _anchor: &domain::DiffAnchor,
+            _provenance: &domain::FindingProvenance,
+        ) {
+        }
+        fn dismiss_finding(&self, _head_sha: &str, _fingerprint: &str) {}
+        fn clear_submitted(&self, _head_sha: &str, _anchors: &[domain::DiffAnchor]) {}
+        fn failure(&self) -> Option<String> {
+            Some("disk is full".to_owned())
+        }
+    }
 
     fn loaded_model() -> Mutex<app::SessionModel> {
         let model = Mutex::new(app::SessionModel::loading(
             SessionRequest::Demo.description(),
         ));
-        run_load(&model, &|_stage| {});
+        run_load(
+            &model,
+            &SessionRequest::Demo,
+            &ReviewStorage::Disabled,
+            &|_stage| {},
+        );
+        model
+    }
+
+    /// A repository with a `main` branch and a `feature` branch that adds
+    /// `feature.txt` as four addition lines in one hunk, which is enough to
+    /// exercise both single-row and span drafts.
+    fn temporary_repository() -> TempDir {
+        let repository = TempDir::new().unwrap();
+        let path = repository.path();
+        git(path, ["init", "--quiet", "--initial-branch=main"]);
+        git(path, ["config", "user.name", "ZReview Test"]);
+        git(path, ["config", "user.email", "zreview@example.invalid"]);
+        std::fs::write(path.join("shared.txt"), "fork point\n").unwrap();
+        git(path, ["add", "."]);
+        git(path, ["commit", "--quiet", "-m", "fork point"]);
+        git(path, ["checkout", "--quiet", "-b", "feature"]);
+        std::fs::write(
+            path.join("feature.txt"),
+            "line one\nline two\nline three\nline four\n",
+        )
+        .unwrap();
+        git(path, ["add", "."]);
+        git(path, ["commit", "--quiet", "-m", "feature"]);
+        git(path, ["checkout", "--quiet", "main"]);
+        repository
+    }
+
+    fn git<I, S>(repository: &Path, args: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(repository)
+            .args(args)
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
+
+    fn local_request(repository: &TempDir) -> SessionRequest {
+        SessionRequest::LocalComparison {
+            repository: repository.path().to_path_buf(),
+            base: "main".to_owned(),
+            head: "feature".to_owned(),
+        }
+    }
+
+    fn local_model(request: &SessionRequest, storage: &ReviewStorage) -> Mutex<app::SessionModel> {
+        let model = Mutex::new(app::SessionModel::loading(request.description()));
+        run_load(&model, request, storage, &|_stage| {});
         model
     }
 
@@ -154,9 +474,14 @@ mod tests {
             SessionRequest::Demo.description(),
         ));
         let stages = Mutex::new(Vec::new());
-        run_load(&model, &|stage| {
-            stages.lock().unwrap().push(stage.to_owned());
-        });
+        run_load(
+            &model,
+            &SessionRequest::Demo,
+            &ReviewStorage::Disabled,
+            &|stage| {
+                stages.lock().unwrap().push(stage.to_owned());
+            },
+        );
 
         assert_eq!(*stages.lock().unwrap(), vec!["Starting".to_owned()]);
         assert!(matches!(lock(&model).phase(), SessionPhase::Ready(_)));
@@ -166,11 +491,64 @@ mod tests {
     fn load_if_pending_does_not_reload_a_ready_model() {
         let model = loaded_model();
         toggle_viewed_on_model(&model).expect("session is ready");
+        // Standing in for a `load_started` a prior real `open_session` call
+        // already flipped. This model was made Ready by `run_load` directly,
+        // never through `load_if_pending`.
+        let load_started = AtomicBool::new(true);
 
-        load_if_pending(&model, &|_stage| {
-            panic!("a ready model must not be reloaded");
-        });
+        load_if_pending(
+            &model,
+            &load_started,
+            &SessionRequest::Demo,
+            &ReviewStorage::Disabled,
+            &|_stage| {
+                panic!("a ready model must not be reloaded");
+            },
+        );
 
+        let guard = lock(&model);
+        let SessionPhase::Ready(review) = guard.phase() else {
+            panic!("model should still be ready");
+        };
+        assert_eq!(dto::project_sidebar(review.session()).viewed_count, 1);
+    }
+
+    /// `load_started` exists so two callers racing to open the same window
+    /// only ever run the loader once.
+    #[test]
+    fn load_if_pending_lets_exactly_one_concurrent_caller_load() {
+        let model = Arc::new(Mutex::new(app::SessionModel::loading(
+            SessionRequest::Demo.description(),
+        )));
+        let load_started = Arc::new(AtomicBool::new(false));
+        let stage_reports = Arc::new(Mutex::new(0_u32));
+
+        let handles = (0..2)
+            .map(|_| {
+                let model = Arc::clone(&model);
+                let load_started = Arc::clone(&load_started);
+                let stage_reports = Arc::clone(&stage_reports);
+                thread::spawn(move || {
+                    load_if_pending(
+                        &model,
+                        &load_started,
+                        &SessionRequest::Demo,
+                        &ReviewStorage::Disabled,
+                        &|_stage| *stage_reports.lock().unwrap() += 1,
+                    );
+                })
+            })
+            .collect::<Vec<_>>();
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        // The demo reports exactly one stage; a second load would double this.
+        assert_eq!(*stage_reports.lock().unwrap(), 1);
+        assert!(matches!(lock(&model).phase(), SessionPhase::Ready(_)));
+
+        // Well-formed afterward. Nothing still racing clobbers a mutation made now.
+        toggle_viewed_on_model(&model).expect("session is ready");
         let guard = lock(&model);
         let SessionPhase::Ready(review) = guard.phase() else {
             panic!("model should still be ready");
@@ -201,6 +579,29 @@ mod tests {
         assert_eq!(error.summary, "could not select that file");
     }
 
+    /// `select_file` is how the frontend learns about drafts on the file it
+    /// just switched to, so the sink's failure has to ride along with it too.
+    #[test]
+    fn select_file_on_model_carries_the_sinks_write_failure() {
+        let repository = temporary_repository();
+        let loaded = session::load(
+            &local_request(&repository),
+            &ReviewStorage::Disabled,
+            &|_| {},
+        )
+        .expect("the repository loads");
+        let model = Mutex::new(app::SessionModel::loading("test"));
+        lock(&model).finish(Ok(domain::LoadedSession {
+            session: loaded.session,
+            review_sink: Some(Box::new(FailingSink)),
+            submitter: None,
+        }));
+
+        let detail = select_file_on_model(&model, 0).expect("index zero is in range");
+
+        assert_eq!(detail.drafts.write_failure.as_deref(), Some("disk is full"));
+    }
+
     #[test]
     fn toggle_viewed_on_model_round_trips_through_sidebar_dto() {
         let model = loaded_model();
@@ -210,6 +611,17 @@ mod tests {
 
         let sidebar = toggle_viewed_on_model(&model).expect("session is ready");
         assert_eq!(sidebar.viewed_count, 0);
+    }
+
+    #[test]
+    fn describe_session_on_request_defers_to_the_requests_own_description() {
+        let request = SessionRequest::LocalComparison {
+            repository: Path::new("/tmp/repository").to_path_buf(),
+            base: "main".to_owned(),
+            head: "feature".to_owned(),
+        };
+
+        assert_eq!(describe_session_on_request(&request), request.description());
     }
 
     #[test]
@@ -228,6 +640,289 @@ mod tests {
         assert_eq!(
             generated, committed,
             "bindings.ts is stale; regenerate it from specta_builder()"
+        );
+    }
+
+    #[test]
+    fn edit_draft_on_model_creates_a_draft_at_the_row() {
+        let repository = temporary_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+
+        let outcome =
+            edit_draft_on_model(&model, 0, 0, 0, "needs a test".to_owned()).expect("session ready");
+
+        assert!(outcome.accepted);
+        assert_eq!(outcome.drafts.anchored.len(), 1);
+        assert_eq!(outcome.drafts.anchored[0].row, 0);
+        assert_eq!(outcome.drafts.anchored[0].body, "needs a test");
+        assert!(!outcome.drafts.anchored[0].is_proposed);
+    }
+
+    /// A range is keyed at its last row, the same place GitHub anchors it.
+    #[test]
+    fn edit_draft_on_model_anchors_a_span_at_its_end_row() {
+        let repository = temporary_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+
+        let outcome =
+            edit_draft_on_model(&model, 0, 0, 2, "this block".to_owned()).expect("session ready");
+
+        assert!(outcome.accepted);
+        assert_eq!(outcome.drafts.anchored.len(), 1);
+        assert_eq!(outcome.drafts.anchored[0].row, 2);
+    }
+
+    /// A span given backwards is normalized before it reaches the domain, so
+    /// it behaves exactly like the same span given forwards.
+    #[test]
+    fn edit_draft_on_model_normalizes_an_inverted_span() {
+        let repository = temporary_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+
+        let outcome =
+            edit_draft_on_model(&model, 0, 3, 1, "inverted".to_owned()).expect("session ready");
+        assert!(outcome.accepted);
+        assert_eq!(outcome.drafts.anchored.len(), 1);
+        assert_eq!(outcome.drafts.anchored[0].row, 3);
+
+        let drafts = discard_draft_on_model(&model, 0, 3).expect("session ready");
+        assert!(drafts.anchored.is_empty());
+    }
+
+    #[test]
+    fn edit_draft_on_model_removes_the_draft_when_emptied() {
+        let repository = temporary_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+        edit_draft_on_model(&model, 0, 0, 0, "oops".to_owned()).unwrap();
+
+        let outcome = edit_draft_on_model(&model, 0, 0, 0, String::new()).expect("session ready");
+
+        assert!(outcome.accepted);
+        assert!(outcome.drafts.anchored.is_empty());
+    }
+
+    #[test]
+    fn edit_draft_on_model_reports_unaccepted_for_a_row_outside_the_diff() {
+        let repository = temporary_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+
+        let outcome =
+            edit_draft_on_model(&model, 0, 999, 999, "nowhere".to_owned()).expect("session ready");
+
+        assert!(!outcome.accepted);
+        assert!(outcome.drafts.anchored.is_empty());
+    }
+
+    #[test]
+    fn edit_draft_on_model_is_unaccepted_on_the_demo_session() {
+        let model = loaded_model();
+
+        let outcome = edit_draft_on_model(&model, 0, 0, 0, "nowhere to anchor".to_owned())
+            .expect("session ready");
+
+        assert!(
+            !outcome.accepted,
+            "the demo session has no head to anchor against"
+        );
+    }
+
+    /// A late edit for a file the reviewer has since left is dropped, not
+    /// applied to whatever is now selected.
+    #[test]
+    fn edit_draft_on_model_drops_an_edit_for_a_file_that_is_no_longer_selected() {
+        let repository = temporary_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+
+        let outcome = edit_draft_on_model(&model, 1, 0, 0, "late edit".to_owned())
+            .expect("dropped, not erred");
+
+        assert!(!outcome.accepted);
+        assert_eq!(outcome.drafts.file_index, 0);
+        assert!(outcome.drafts.anchored.is_empty());
+    }
+
+    #[test]
+    fn discard_draft_on_model_removes_a_draft() {
+        let repository = temporary_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+        edit_draft_on_model(&model, 0, 0, 0, "throwaway".to_owned()).unwrap();
+
+        let drafts = discard_draft_on_model(&model, 0, 0).expect("session ready");
+
+        assert!(drafts.anchored.is_empty());
+    }
+
+    /// A row with no draft is a no-op, not a failure.
+    #[test]
+    fn discard_draft_on_model_on_an_empty_row_still_succeeds() {
+        let repository = temporary_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+
+        let drafts = discard_draft_on_model(&model, 0, 0).expect("session ready");
+
+        assert!(drafts.anchored.is_empty());
+    }
+
+    /// A late discard for a file the reviewer has since left must not touch
+    /// whatever is now selected.
+    #[test]
+    fn discard_draft_on_model_drops_a_discard_for_a_file_that_is_no_longer_selected() {
+        let repository = temporary_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+        edit_draft_on_model(&model, 0, 0, 0, "keep me".to_owned()).unwrap();
+
+        let drafts = discard_draft_on_model(&model, 1, 0).expect("dropped, not erred");
+
+        assert_eq!(drafts.file_index, 0);
+        assert_eq!(
+            drafts.anchored.len(),
+            1,
+            "the late discard must not touch it"
+        );
+    }
+
+    /// The whole point of persistence. What was typed comes back after the
+    /// session that typed it is gone.
+    #[test]
+    fn edit_draft_on_model_persists_and_restores_across_a_reload() {
+        let repository = temporary_repository();
+        let data = TempDir::new().unwrap();
+        let storage = ReviewStorage::At(data.path().join("review-data.sqlite3"));
+
+        {
+            let model = local_model(&local_request(&repository), &storage);
+            edit_draft_on_model(&model, 0, 0, 0, "worth keeping".to_owned()).unwrap();
+            // Dropping joins the writer thread, so the write has landed.
+        }
+
+        let model = local_model(&local_request(&repository), &storage);
+        let guard = lock(&model);
+        let SessionPhase::Ready(review) = guard.phase() else {
+            panic!("session should be ready");
+        };
+        let draft = review.session().draft_at(0, 0).expect("it should restore");
+        assert_eq!(draft.body, "worth keeping");
+        assert!(!draft.is_stale);
+        assert!(review.session().warnings().is_empty());
+    }
+
+    /// Advancing the branch's head, without touching the file the draft is on,
+    /// still invalidates it. A draft's anchor is pinned to the exact head it was
+    /// written against, not merely to a line number.
+    #[test]
+    fn reanchor_draft_on_model_moves_a_restored_stale_draft() {
+        let repository = temporary_repository();
+        let data = TempDir::new().unwrap();
+        let storage = ReviewStorage::At(data.path().join("review-data.sqlite3"));
+
+        {
+            let model = local_model(&local_request(&repository), &storage);
+            edit_draft_on_model(&model, 0, 0, 0, "stale note".to_owned()).unwrap();
+        }
+
+        let path = repository.path();
+        git(path, ["checkout", "--quiet", "feature"]);
+        std::fs::write(path.join("other.txt"), "unrelated\n").unwrap();
+        git(path, ["add", "."]);
+        git(path, ["commit", "--quiet", "-m", "advance"]);
+        git(path, ["checkout", "--quiet", "main"]);
+
+        let model = local_model(&local_request(&repository), &storage);
+        {
+            let guard = lock(&model);
+            let SessionPhase::Ready(review) = guard.phase() else {
+                panic!("session should be ready");
+            };
+            assert_eq!(review.session().drafts().stale_count(), 1);
+            assert!(
+                review
+                    .session()
+                    .warnings()
+                    .iter()
+                    .any(|warning| warning.summary.contains("no longer match this diff")),
+                "unexpected warnings: {:?}",
+                review.session().warnings(),
+            );
+        }
+
+        // Moved onto a different row than it was written against, on purpose.
+        let drafts = reanchor_draft_on_model(&model, 0, "feature.txt", DiffSide::Right, 1, 1)
+            .expect("the stale draft should move onto row 1");
+
+        assert!(drafts.stale.is_empty());
+        assert_eq!(drafts.anchored.len(), 1);
+        assert_eq!(drafts.anchored[0].row, 1);
+        assert_eq!(drafts.anchored[0].body, "stale note");
+    }
+
+    #[test]
+    fn reanchor_draft_on_model_reports_a_key_that_matches_no_stale_draft() {
+        let repository = temporary_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+
+        let error =
+            reanchor_draft_on_model(&model, 0, "feature.txt", DiffSide::Right, 999, 0).unwrap_err();
+
+        assert_eq!(error.summary, "that draft is no longer stale");
+    }
+
+    /// The key matches a real stale draft, but the row it is asked to move to
+    /// cannot itself carry a comment.
+    #[test]
+    fn reanchor_draft_on_model_reports_when_the_target_row_cannot_hold_a_comment() {
+        let repository = temporary_repository();
+        let data = TempDir::new().unwrap();
+        let storage = ReviewStorage::At(data.path().join("review-data.sqlite3"));
+
+        {
+            let model = local_model(&local_request(&repository), &storage);
+            edit_draft_on_model(&model, 0, 0, 0, "stale note".to_owned()).unwrap();
+        }
+
+        let path = repository.path();
+        git(path, ["checkout", "--quiet", "feature"]);
+        std::fs::write(path.join("other.txt"), "unrelated\n").unwrap();
+        git(path, ["add", "."]);
+        git(path, ["commit", "--quiet", "-m", "advance"]);
+        git(path, ["checkout", "--quiet", "main"]);
+
+        let model = local_model(&local_request(&repository), &storage);
+
+        let error =
+            reanchor_draft_on_model(&model, 0, "feature.txt", DiffSide::Right, 1, 999).unwrap_err();
+
+        assert_eq!(error.summary, "that row cannot hold a comment");
+    }
+
+    /// A late reanchor for a file the reviewer has since left must not move
+    /// anything.
+    #[test]
+    fn reanchor_draft_on_model_drops_a_reanchor_for_a_file_that_is_no_longer_selected() {
+        let repository = temporary_repository();
+        let data = TempDir::new().unwrap();
+        let storage = ReviewStorage::At(data.path().join("review-data.sqlite3"));
+
+        {
+            let model = local_model(&local_request(&repository), &storage);
+            edit_draft_on_model(&model, 0, 0, 0, "stale note".to_owned()).unwrap();
+        }
+
+        let path = repository.path();
+        git(path, ["checkout", "--quiet", "feature"]);
+        std::fs::write(path.join("other.txt"), "unrelated\n").unwrap();
+        git(path, ["add", "."]);
+        git(path, ["commit", "--quiet", "-m", "advance"]);
+        git(path, ["checkout", "--quiet", "main"]);
+
+        let model = local_model(&local_request(&repository), &storage);
+
+        let drafts = reanchor_draft_on_model(&model, 1, "feature.txt", DiffSide::Right, 1, 1)
+            .expect("dropped, not erred");
+
+        assert_eq!(
+            drafts.stale.len(),
+            1,
+            "the late reanchor must not have moved it"
         );
     }
 }

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -4,8 +4,11 @@
 //! `&SessionFailure`) and returns a value, which is what keeps them testable
 //! without a running app.
 
-use domain::{DiffFile, DiffLineKind, FileStatus, ReviewSession, SessionFailure, SessionSource};
-use serde::Serialize;
+use domain::{
+    DiffFile, DiffLineKind, DiffSide, EmptyDiffReason, FileStatus, ReviewSession, SessionFailure,
+    SessionSource,
+};
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, specta::Type)]
 pub enum FileStatusDto {
@@ -51,6 +54,30 @@ impl From<DiffLineKind> for DiffLineKindDto {
     }
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, specta::Type)]
+pub enum DiffSideDto {
+    Left,
+    Right,
+}
+
+impl From<DiffSide> for DiffSideDto {
+    fn from(side: DiffSide) -> Self {
+        match side {
+            DiffSide::Left => Self::Left,
+            DiffSide::Right => Self::Right,
+        }
+    }
+}
+
+impl From<DiffSideDto> for DiffSide {
+    fn from(side: DiffSideDto) -> Self {
+        match side {
+            DiffSideDto::Left => Self::Left,
+            DiffSideDto::Right => Self::Right,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Serialize, specta::Type)]
 pub struct FileSummaryDto {
     pub index: u32,
@@ -77,6 +104,7 @@ pub struct SessionSnapshotDto {
     pub title: String,
     pub subtitle: String,
     pub sidebar: SidebarDto,
+    pub warnings: Vec<SessionFailureDto>,
 }
 
 #[derive(Clone, Debug, Serialize, specta::Type)]
@@ -91,8 +119,61 @@ pub struct RowDto {
     /// always equals its line index.
     pub hunk_header: Option<String>,
     pub thread_count: u32,
-    pub has_draft: bool,
-    pub draft_is_proposed: bool,
+}
+
+/// A draft resolved to the row it is drawn on.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct AnchoredDraftDto {
+    pub row: u32,
+    pub body: String,
+    pub is_proposed: bool,
+}
+
+/// A draft whose anchor no longer resolves against the current diff.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct StaleDraftDto {
+    pub path: String,
+    pub side: DiffSideDto,
+    pub line: u32,
+    pub body: String,
+    /// Where the draft used to sit, formatted for display, e.g. "was RIGHT line 42".
+    pub location: String,
+}
+
+/// Every draft that belongs to one file, projected for a per-keystroke response.
+///
+/// Deliberately narrow. Refetching a whole [`FileDetailDto`] on every keystroke
+/// would re-send up to 100,000 rows for a single character typed.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct DraftsDto {
+    pub file_index: u32,
+    pub anchored: Vec<AnchoredDraftDto>,
+    pub stale: Vec<StaleDraftDto>,
+    pub file_draft_count: u32,
+    pub write_failure: Option<String>,
+}
+
+/// The outcome of an edit, discard, or reanchor on the composer.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct DraftEditOutcomeDto {
+    pub accepted: bool,
+    pub drafts: DraftsDto,
+}
+
+/// Why a file shows no diff rows.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct EmptyReasonDto {
+    pub label: String,
+    pub detail: String,
+}
+
+impl From<EmptyDiffReason> for EmptyReasonDto {
+    fn from(reason: EmptyDiffReason) -> Self {
+        Self {
+            label: reason.label().to_owned(),
+            detail: reason.detail().to_owned(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Serialize, specta::Type)]
@@ -100,6 +181,8 @@ pub struct FileDetailDto {
     pub index: u32,
     pub path: String,
     pub rows: Vec<RowDto>,
+    pub drafts: DraftsDto,
+    pub empty_reason: Option<EmptyReasonDto>,
 }
 
 #[derive(Clone, Debug, Serialize, specta::Type)]
@@ -181,6 +264,7 @@ pub fn project_snapshot(session: &ReviewSession) -> SessionSnapshotDto {
         title,
         subtitle,
         sidebar: project_sidebar(session),
+        warnings: session.warnings().iter().map(Into::into).collect(),
     }
 }
 
@@ -225,12 +309,13 @@ pub fn project_file(session: &ReviewSession, index: usize) -> Option<FileDetailD
         index: as_u32(index),
         path: file.path.to_string(),
         rows,
+        drafts: project_drafts(session, index),
+        empty_reason: file.empty_reason().map(Into::into),
     })
 }
 
 fn project_row(session: &ReviewSession, file_index: usize, file: &DiffFile, row: usize) -> RowDto {
     let line = &file.lines[row];
-    let draft = session.draft_at(file_index, row);
     RowDto {
         kind: line.kind.into(),
         old_line: line.old_line,
@@ -238,13 +323,59 @@ fn project_row(session: &ReviewSession, file_index: usize, file: &DiffFile, row:
         text: line.text.to_string(),
         hunk_header: file.hunk_header_at(row).map(ToString::to_string),
         thread_count: as_u32(session.comments().threads_at(file_index, row).len()),
-        has_draft: draft.is_some(),
-        draft_is_proposed: draft.is_some_and(domain::DraftComment::is_proposed),
+    }
+}
+
+/// Every draft on one file, resolved to its row where it still anchors, cheap
+/// regardless of file size since it walks this file's drafts, never its rows.
+///
+/// # Panics
+///
+/// Panics if `file_index` is out of range. Every caller already holds a session
+/// whose selected or requested file is known to exist.
+#[must_use]
+pub fn project_drafts(session: &ReviewSession, file_index: usize) -> DraftsDto {
+    let file = session
+        .files()
+        .get(file_index)
+        .expect("file_index is bounds-checked by the caller");
+    let anchors = session.anchors();
+    let mut anchored = Vec::new();
+    let mut stale = Vec::new();
+    for draft in session.drafts().for_path(&file.path) {
+        if draft.is_stale {
+            stale.push(StaleDraftDto {
+                path: draft.anchor.path.to_string(),
+                side: draft.anchor.side.into(),
+                line: draft.anchor.line,
+                body: draft.body.clone(),
+                location: format!("was {} line {}", draft.anchor.side, draft.anchor.line),
+            });
+        } else if let Some(location) = anchors.and_then(|index| index.resolve(&draft.anchor).ok()) {
+            anchored.push(AnchoredDraftDto {
+                row: as_u32(location.row),
+                body: draft.body.clone(),
+                is_proposed: draft.is_proposed(),
+            });
+        }
+    }
+    anchored.sort_by_key(|draft| draft.row);
+    let file_draft_count = as_u32(anchored.len() + stale.len());
+    DraftsDto {
+        file_index: as_u32(file_index),
+        anchored,
+        stale,
+        file_draft_count,
+        write_failure: None,
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use domain::DiffFile;
+
     use super::*;
 
     fn demo_session() -> ReviewSession {
@@ -255,6 +386,23 @@ mod tests {
         )
         .expect("the generated fixture always loads")
         .session
+    }
+
+    /// A session anchored against a head commit, so it can hold drafts.
+    fn anchored_session() -> ReviewSession {
+        let head_sha: Arc<str> = "a".repeat(40).into();
+        let mut file = DiffFile::demo(40);
+        file.path = "src/review.rs".into();
+        ReviewSession::new(
+            SessionSource::LocalComparison {
+                repository_root: std::path::PathBuf::from("/tmp/repository"),
+                base_sha: Arc::clone(&head_sha),
+                diff_base_sha: Arc::clone(&head_sha),
+                head_sha,
+            },
+            vec![file].into(),
+        )
+        .unwrap()
     }
 
     #[test]
@@ -336,5 +484,78 @@ mod tests {
     #[test]
     fn short_sha_does_not_panic_on_a_short_string() {
         assert_eq!(short_sha("abc"), "abc");
+    }
+
+    #[test]
+    fn project_drafts_lists_anchored_and_stale_drafts_on_the_files_path() {
+        let mut session = anchored_session();
+        session.set_draft(0, 6, "needs a test");
+        let stale = domain::DiffAnchor {
+            path: "src/review.rs".into(),
+            side: domain::DiffSide::Right,
+            line: 9_999,
+            start_line: None,
+            head_sha: "a".repeat(40).into(),
+        };
+        session.restore_drafts([(stale, "written last week".to_owned())]);
+
+        let drafts = project_drafts(&session, 0);
+
+        assert_eq!(drafts.file_index, 0);
+        assert_eq!(drafts.file_draft_count, 2);
+        assert_eq!(drafts.anchored.len(), 1);
+        assert_eq!(drafts.anchored[0].row, 6);
+        assert_eq!(drafts.anchored[0].body, "needs a test");
+        assert!(!drafts.anchored[0].is_proposed);
+        assert_eq!(drafts.stale.len(), 1);
+        assert_eq!(drafts.stale[0].path, "src/review.rs");
+        assert!(matches!(drafts.stale[0].side, DiffSideDto::Right));
+        assert_eq!(drafts.stale[0].line, 9_999);
+        assert_eq!(drafts.stale[0].body, "written last week");
+        assert_eq!(drafts.stale[0].location, "was RIGHT line 9999");
+        assert!(drafts.write_failure.is_none());
+    }
+
+    #[test]
+    fn project_file_carries_the_empty_reason_for_a_binary_file() {
+        let session = ReviewSession::new(
+            SessionSource::Demo,
+            vec![DiffFile {
+                path: "image.bin".into(),
+                old_path: None,
+                status: FileStatus::Modified,
+                is_binary: true,
+                hunks: Arc::from([]),
+                counts: domain::ChangeCounts::default(),
+                lines: Arc::from([]),
+            }]
+            .into(),
+        )
+        .unwrap();
+
+        let detail = project_file(&session, 0).expect("index zero is in range");
+
+        assert!(detail.rows.is_empty());
+        let reason = detail.empty_reason.expect("a binary file explains itself");
+        assert_eq!(reason.label, "Binary file");
+        assert_eq!(reason.detail, "ZReview does not render binary content yet.");
+    }
+
+    #[test]
+    fn project_file_carries_no_empty_reason_when_there_are_rows() {
+        let session = demo_session();
+        let detail = project_file(&session, 0).expect("index zero is in range");
+        assert!(detail.empty_reason.is_none());
+    }
+
+    #[test]
+    fn snapshot_carries_the_sessions_warnings() {
+        let mut session = demo_session();
+        session.push_warning(SessionFailure::new("drafts are not being saved"));
+
+        let snapshot = project_snapshot(&session);
+
+        assert_eq!(snapshot.warnings.len(), 1);
+        assert_eq!(snapshot.warnings[0].summary, "drafts are not being saved");
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,15 +1,25 @@
 //! The Tauri shell: wires the framework-free `app` crate to a window.
 
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, atomic::AtomicBool};
 
 use app::SessionModel;
-use session::SessionRequest;
+use session::{ReviewStorage, SessionRequest};
 
 mod commands;
 mod dto;
 
 /// The one review sitting this window shows, shared with every command.
-pub(crate) struct ManagedSession(pub(crate) Arc<Mutex<SessionModel>>);
+pub(crate) struct ManagedSession {
+    pub(crate) model: Arc<Mutex<SessionModel>>,
+    /// What was asked to be opened, kept so a deferred load knows what to load.
+    pub(crate) request: SessionRequest,
+    /// Where that request's drafts are persisted.
+    pub(crate) storage: ReviewStorage,
+    /// Swapped `true` by whichever `open_session` call loads first, so a second
+    /// concurrent call (React `StrictMode`'s double mount effect, for one)
+    /// waits for that load instead of starting a redundant one of its own.
+    pub(crate) load_started: Arc<AtomicBool>,
+}
 
 /// Builds the window and runs the application until it closes.
 ///
@@ -17,15 +27,19 @@ pub(crate) struct ManagedSession(pub(crate) Arc<Mutex<SessionModel>>);
 ///
 /// Panics if the Tauri application fails to start, or if bindings export fails
 /// in a debug build.
-pub fn run() {
-    let model = Arc::new(Mutex::new(SessionModel::loading(
-        SessionRequest::Demo.description(),
-    )));
+pub fn run(request: SessionRequest, storage: ReviewStorage) {
+    let model = Arc::new(Mutex::new(SessionModel::loading(request.description())));
+    let managed = ManagedSession {
+        model,
+        request,
+        storage,
+        load_started: Arc::new(AtomicBool::new(false)),
+    };
     let specta_builder = commands::specta_builder();
 
     tauri::Builder::default()
         .plugin(tauri_plugin_clipboard_manager::init())
-        .manage(ManagedSession(model))
+        .manage(managed)
         .invoke_handler(specta_builder.invoke_handler())
         .setup(move |_app| {
             #[cfg(debug_assertions)]

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1,3 +1,107 @@
-fn main() {
-    desktop_lib::run();
+use std::{env, path::Path, process::ExitCode};
+
+use session::{ReviewStorage, SessionRequest};
+
+const USAGE: &str = "usage:
+  desktop
+  desktop <repository> <base> [<head>]";
+
+fn main() -> ExitCode {
+    // Only argument parsing happens before the window opens. Everything that can
+    // be slow or fail, such as Git, is reported inside the app.
+    let (request, storage) = match parse_arguments(&env::args().skip(1).collect::<Vec<_>>()) {
+        Ok(parsed) => parsed,
+        Err(message) => {
+            eprintln!("desktop: {message}");
+            eprintln!("{USAGE}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    desktop_lib::run(request, storage);
+
+    ExitCode::SUCCESS
+}
+
+fn parse_arguments(arguments: &[String]) -> Result<(SessionRequest, ReviewStorage), String> {
+    match arguments {
+        [] => Ok((SessionRequest::Demo, ReviewStorage::Disabled)),
+        [first, ..] if first == "pr" => {
+            Err("pull requests are not supported by this build".to_owned())
+        }
+        [repository, base] => Ok((
+            SessionRequest::LocalComparison {
+                repository: Path::new(repository).to_path_buf(),
+                base: base.clone(),
+                head: "HEAD".to_owned(),
+            },
+            ReviewStorage::Default,
+        )),
+        [repository, base, head] => Ok((
+            SessionRequest::LocalComparison {
+                repository: Path::new(repository).to_path_buf(),
+                base: base.clone(),
+                head: head.clone(),
+            },
+            ReviewStorage::Default,
+        )),
+        _ => Err("expected a repository, base revision, and optional head revision".to_owned()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn arguments(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_owned()).collect()
+    }
+
+    #[test]
+    fn no_arguments_opens_the_generated_fixture_with_storage_disabled() {
+        assert_eq!(
+            parse_arguments(&[]).unwrap(),
+            (SessionRequest::Demo, ReviewStorage::Disabled),
+        );
+    }
+
+    #[test]
+    fn a_local_comparison_defaults_its_head_to_head_and_uses_default_storage() {
+        assert_eq!(
+            parse_arguments(&arguments(&["/tmp/repository", "main"])).unwrap(),
+            (
+                SessionRequest::LocalComparison {
+                    repository: Path::new("/tmp/repository").to_path_buf(),
+                    base: "main".to_owned(),
+                    head: "HEAD".to_owned(),
+                },
+                ReviewStorage::Default,
+            ),
+        );
+        assert_eq!(
+            parse_arguments(&arguments(&["/tmp/repository", "main", "feature"])).unwrap(),
+            (
+                SessionRequest::LocalComparison {
+                    repository: Path::new("/tmp/repository").to_path_buf(),
+                    base: "main".to_owned(),
+                    head: "feature".to_owned(),
+                },
+                ReviewStorage::Default,
+            ),
+        );
+    }
+
+    #[test]
+    fn unusable_argument_counts_are_rejected() {
+        assert!(parse_arguments(&arguments(&["only-a-repository"])).is_err());
+        assert!(parse_arguments(&arguments(&["a", "b", "c", "d"])).is_err());
+    }
+
+    /// Pull requests are out of scope for this CLI, so `pr` is intercepted
+    /// before arity matching rather than parsed as a repository name.
+    #[test]
+    fn a_pr_argument_is_rejected() {
+        assert!(parse_arguments(&arguments(&["pr"])).is_err());
+        assert!(parse_arguments(&arguments(&["pr", "123"])).is_err());
+    }
 }

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -5,15 +5,23 @@ import type { Channel } from "@tauri-apps/api/core";
 import App from "./App";
 import { makeFile, makeFileSummary, makeRow, makeSidebar, makeSnapshot } from "./test/fixtures";
 
+const describeSession = vi.fn();
 const openSession = vi.fn();
 const selectFile = vi.fn();
 const toggleViewed = vi.fn();
+const editDraft = vi.fn();
+const discardDraft = vi.fn();
+const reanchorDraft = vi.fn();
 
 vi.mock("./bindings", () => ({
   commands: {
+    describeSession: () => describeSession(),
     openSession: (channel: unknown) => openSession(channel),
     selectFile: (index: unknown) => selectFile(index),
     toggleViewed: () => toggleViewed(),
+    editDraft: (...args: unknown[]) => editDraft(...args),
+    discardDraft: (...args: unknown[]) => discardDraft(...args),
+    reanchorDraft: (...args: unknown[]) => reanchorDraft(...args),
   },
 }));
 
@@ -23,9 +31,14 @@ vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
 }));
 
 beforeEach(() => {
+  describeSession.mockReset();
+  describeSession.mockResolvedValue("the generated fixture");
   openSession.mockReset();
   selectFile.mockReset();
   toggleViewed.mockReset();
+  editDraft.mockReset();
+  discardDraft.mockReset();
+  reanchorDraft.mockReset();
   writeText.mockReset();
 });
 
@@ -38,7 +51,8 @@ describe("App", () => {
     });
 
     render(<App />);
-    expect(screen.getByText(/Opening the generated fixture/)).toBeTruthy();
+
+    await waitFor(() => expect(screen.getByText(/Opening the generated fixture/)).toBeTruthy());
 
     channel?.onmessage("Fetching Git objects");
 
@@ -84,6 +98,15 @@ describe("App", () => {
     render(<App />);
 
     await waitFor(() => expect(screen.getByText("network unreachable")).toBeTruthy());
+  });
+
+  it("shows the failure screen when describeSession itself rejects", async () => {
+    describeSession.mockReset();
+    describeSession.mockRejectedValue(new Error("IPC is unavailable"));
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText("Error: IPC is unavailable")).toBeTruthy());
   });
 
   describe("once ready", () => {
@@ -183,6 +206,49 @@ describe("App", () => {
       await user.keyboard("{Meta>}c{/Meta}");
 
       expect(writeText).toHaveBeenCalledWith("first\nsecond");
+    });
+
+    it("yields the row cursor to a keydown targeting the open composer", async () => {
+      const user = userEvent.setup();
+      render(<App />);
+      await waitFor(() => expect(screen.getByText("first")).toBeTruthy());
+
+      await user.keyboard("c");
+      const editorContent = await waitFor(() => {
+        const element = document.querySelector("[data-composer] .cm-content");
+        if (!element) {
+          throw new Error("composer editor not mounted yet");
+        }
+        return element;
+      });
+
+      editorContent.dispatchEvent(new KeyboardEvent("keydown", { key: "j", bubbles: true }));
+
+      expect(screen.getByText("first").closest(".diff-row")?.className).toContain(
+        "diff-row--selected",
+      );
+      expect(screen.getByText("second").closest(".diff-row")?.className).not.toContain(
+        "diff-row--selected",
+      );
+    });
+
+    it("does not let the global c toggle swallow a keydown inside the composer", async () => {
+      const user = userEvent.setup();
+      render(<App />);
+      await waitFor(() => expect(screen.getByText("first")).toBeTruthy());
+
+      await user.keyboard("c");
+      const editorContent = await waitFor(() => {
+        const element = document.querySelector("[data-composer] .cm-content");
+        if (!element) {
+          throw new Error("composer editor not mounted yet");
+        }
+        return element;
+      });
+
+      editorContent.dispatchEvent(new KeyboardEvent("keydown", { key: "c", bubbles: true }));
+
+      expect(document.querySelector("[data-composer]")).not.toBeNull();
     });
   });
 });

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -4,7 +4,16 @@ import { SessionShell } from "./components/SessionShell";
 import { useSession } from "./hooks/useSession";
 
 export default function App() {
-  const { state, selectFile, clickRow } = useSession();
+  const {
+    state,
+    selectFile,
+    clickRow,
+    openComposer,
+    closeComposer,
+    composerChange,
+    composerDiscard,
+    reanchorDraft,
+  } = useSession();
 
   switch (state.status) {
     case "loading":
@@ -12,6 +21,17 @@ export default function App() {
     case "failed":
       return <FailureScreen failure={state.failure} />;
     case "ready":
-      return <SessionShell state={state} onSelectFile={selectFile} onRowClick={clickRow} />;
+      return (
+        <SessionShell
+          state={state}
+          onSelectFile={selectFile}
+          onRowClick={clickRow}
+          onOpenComposer={openComposer}
+          onComposerChange={composerChange}
+          onComposerClose={closeComposer}
+          onComposerDiscard={composerDiscard}
+          onReanchorDraft={reanchorDraft}
+        />
+      );
   }
 }

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -5,7 +5,8 @@ import { invoke as __TAURI_INVOKE, Channel } from "@tauri-apps/api/core";
 /** Commands */
 export const commands = {
 	/**
-	 *  Loads the demo review session, reporting each stage on `on_stage` as it goes.
+	 *  Loads the review session the window was opened with, reporting each stage on
+	 *  `on_stage` as it goes.
 	 * 
 	 *  # Errors
 	 * 
@@ -28,15 +29,87 @@ export const commands = {
 	 *  Returns a failure when the session is not ready.
 	 */
 	toggleViewed: () => typedError<SidebarDto, SessionFailureDto>(__TAURI_INVOKE("toggle_viewed")),
+	/**
+	 *  The request's own description, shown by the loading screen before anything
+	 *  about the target session is known.
+	 */
+	describeSession: () => __TAURI_INVOKE<string>("describe_session"),
+	/**
+	 *  Edits the draft over rows `start..=end` of `file_index`. Persists the new
+	 *  text on every call. That is what makes a keystroke survive a crash.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns a failure when the session is not ready. An unanchorable span is not
+	 *  an error. It comes back as `accepted: false` on the outcome, and neither is a
+	 *  `file_index` that has since been navigated away from; the outcome reflects
+	 *  the file that is actually selected.
+	 */
+	editDraft: (fileIndex: number, start: number, end: number, body: string) => typedError<DraftEditOutcomeDto, SessionFailureDto>(__TAURI_INVOKE("edit_draft", { fileIndex, start, end, body })),
+	/**
+	 *  Discards the draft on `row` of `file_index`.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns a failure when the session is not ready.
+	 */
+	discardDraft: (fileIndex: number, row: number) => typedError<DraftsDto, SessionFailureDto>(__TAURI_INVOKE("discard_draft", { fileIndex, row })),
+	/**
+	 *  Moves a stale draft, named by the position it was written against, onto
+	 *  `row` of `file_index`.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns a failure when the session is not ready, no stale draft matches
+	 *  `(path, side, line)`, or `row` cannot carry a comment.
+	 */
+	reanchorDraft: (fileIndex: number, path: string, side: DiffSideDto, line: number, row: number) => typedError<DraftsDto, SessionFailureDto>(__TAURI_INVOKE("reanchor_draft", { fileIndex, path, side, line, row })),
 };
 
 /* Types */
+/**  A draft resolved to the row it is drawn on. */
+export type AnchoredDraftDto = {
+	row: number,
+	body: string,
+	is_proposed: boolean,
+};
+
 export type DiffLineKindDto = "Context" | "Addition" | "Deletion" | "NoNewlineMarker";
+
+export type DiffSideDto = "Left" | "Right";
+
+/**  The outcome of an edit, discard, or reanchor on the composer. */
+export type DraftEditOutcomeDto = {
+	accepted: boolean,
+	drafts: DraftsDto,
+};
+
+/**
+ *  Every draft that belongs to one file, projected for a per-keystroke response.
+ * 
+ *  Deliberately narrow. Refetching a whole [`FileDetailDto`] on every keystroke
+ *  would re-send up to 100,000 rows for a single character typed.
+ */
+export type DraftsDto = {
+	file_index: number,
+	anchored: AnchoredDraftDto[],
+	stale: StaleDraftDto[],
+	file_draft_count: number,
+	write_failure: string | null,
+};
+
+/**  Why a file shows no diff rows. */
+export type EmptyReasonDto = {
+	label: string,
+	detail: string,
+};
 
 export type FileDetailDto = {
 	index: number,
 	path: string,
 	rows: RowDto[],
+	drafts: DraftsDto,
+	empty_reason: EmptyReasonDto | null,
 };
 
 export type FileStatusDto = "Added" | "Deleted" | "Modified" | "Renamed" | "Copied" | "TypeChanged" | "Unmerged";
@@ -66,8 +139,6 @@ export type RowDto = {
 	 */
 	hunk_header: string | null,
 	thread_count: number,
-	has_draft: boolean,
-	draft_is_proposed: boolean,
 };
 
 export type SessionFailureDto = {
@@ -80,6 +151,7 @@ export type SessionSnapshotDto = {
 	title: string,
 	subtitle: string,
 	sidebar: SidebarDto,
+	warnings: SessionFailureDto[],
 };
 
 export type SidebarDto = {
@@ -87,6 +159,16 @@ export type SidebarDto = {
 	selected_file: number,
 	viewed_count: number,
 	thread_count: number,
+};
+
+/**  A draft whose anchor no longer resolves against the current diff. */
+export type StaleDraftDto = {
+	path: string,
+	side: DiffSideDto,
+	line: number,
+	body: string,
+	/**  Where the draft used to sit, formatted for display, e.g. "was RIGHT line 42". */
+	location: string,
 };
 
 /* Tauri Specta runtime */

--- a/apps/desktop/src/components/CommentComposer.css
+++ b/apps/desktop/src/components/CommentComposer.css
@@ -1,0 +1,48 @@
+.comment-composer {
+  margin-left: calc(var(--gutter-width) * 2 + 20px);
+  margin-right: 12px;
+  margin-top: 4px;
+  margin-bottom: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-family: var(--font-sans);
+}
+
+.comment-composer__editor .cm-editor {
+  height: 104px;
+  border-radius: 6px;
+  border: 1px solid var(--border-default);
+}
+
+.comment-composer__editor .cm-scroller {
+  overflow: auto;
+}
+
+.comment-composer__actions {
+  display: flex;
+  gap: 8px;
+}
+
+.comment-composer__done,
+.comment-composer__discard {
+  height: 32px;
+  padding: 0 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border-strong);
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-sans);
+  font-size: var(--size-body);
+  cursor: pointer;
+}
+
+.comment-composer__discard {
+  border-color: var(--severity-error-dim);
+  color: var(--severity-error-text);
+}
+
+.comment-composer__notice {
+  font-size: var(--size-label);
+  color: var(--severity-warning-text);
+}

--- a/apps/desktop/src/components/CommentComposer.tsx
+++ b/apps/desktop/src/components/CommentComposer.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useRef } from "react";
+import { createMarkdownEditor } from "../editor/markdownEditor";
+import "./CommentComposer.css";
+
+/** The comment editor over a frozen row span, pre-filled silently on mount and rebuilt only when `rows` changes identity. */
+export function CommentComposer({
+  rows,
+  prefill,
+  notice,
+  onChange,
+  onClose,
+  onDiscard,
+}: {
+  rows: [number, number];
+  prefill: string;
+  notice: string | null;
+  onChange: (body: string) => void;
+  onClose: () => void;
+  onDiscard: () => void;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    const handle = createMarkdownEditor({
+      parent: container,
+      initialText: prefill,
+      onChange: (body) => onChangeRef.current(body),
+      onClose: () => onCloseRef.current(),
+    });
+    handle.focus();
+    return () => handle.destroy();
+    // Deliberately keyed on the span alone. Prefill only seeds the first mount.
+  }, [rows[0], rows[1]]);
+
+  return (
+    <div className="comment-composer" data-composer>
+      <div className="comment-composer__editor" ref={containerRef} />
+      <div className="comment-composer__actions">
+        <button type="button" className="comment-composer__done" onClick={onClose}>
+          Done
+        </button>
+        <button type="button" className="comment-composer__discard" onClick={onDiscard}>
+          Discard
+        </button>
+      </div>
+      {notice !== null && <div className="comment-composer__notice">{notice}</div>}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/DiffList.test.tsx
+++ b/apps/desktop/src/components/DiffList.test.tsx
@@ -1,7 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import type { RowDto } from "../bindings";
-import { makeRow } from "../test/fixtures";
+import type { ComposerState } from "../hooks/sessionReducer";
+import { makeAnchoredDraft, makeDrafts, makeRow } from "../test/fixtures";
 import { DiffList } from "./DiffList";
 
 const ROW_COUNT = 200;
@@ -15,17 +16,25 @@ function rows(): RowDto[] {
   );
 }
 
+/** Every prop DiffList needs beyond the ones a test wants to vary. */
+function baseProps() {
+  return {
+    fileIndex: 0,
+    drafts: makeDrafts(),
+    composer: null as ComposerState,
+    composerPrefill: "",
+    onRowClick: () => {},
+    onOpenComposer: () => {},
+    onComposerChange: () => {},
+    onComposerClose: () => {},
+    onComposerDiscard: () => {},
+  };
+}
+
 describe("DiffList", () => {
   it("renders a window around the cursor, not all 200 rows", () => {
     render(
-      <DiffList
-        rows={rows()}
-        fileIndex={0}
-        cursor={25}
-        selectionStart={25}
-        selectionEnd={25}
-        onRowClick={() => {}}
-      />,
+      <DiffList {...baseProps()} rows={rows()} cursor={25} selectionStart={25} selectionEnd={25} />,
     );
 
     const rendered = screen.getAllByText(/^line \d+$/);
@@ -34,39 +43,115 @@ describe("DiffList", () => {
     expect(screen.getByText("line 25")).toBeTruthy();
   });
 
-  it("renders the first row's hunk header at 40px", () => {
-    render(
-      <DiffList
-        rows={rows()}
-        fileIndex={0}
-        cursor={0}
-        selectionStart={0}
-        selectionEnd={0}
-        onRowClick={() => {}}
-      />,
-    );
+  it("renders the first row's hunk header above its row, in the same item", () => {
+    render(<DiffList {...baseProps()} rows={rows()} cursor={0} selectionStart={0} selectionEnd={0} />);
 
     const header = screen.getByText("@@ -1,200 +1,200 @@");
     const item = header.closest(".diff-list__item");
     expect(item).not.toBeNull();
-    expect((item as HTMLElement).style.height).toBe("40px");
+    // Semantic, not pixel. The item now sizes to its content (see test/setup.ts).
+    expect(item?.querySelector(".diff-row")).not.toBeNull();
+    expect(screen.getByText("line 0")).toBeTruthy();
   });
 
   it("styles the row at the cursor as selected", () => {
-    render(
-      <DiffList
-        rows={rows()}
-        fileIndex={0}
-        cursor={5}
-        selectionStart={5}
-        selectionEnd={5}
-        onRowClick={() => {}}
-      />,
-    );
+    render(<DiffList {...baseProps()} rows={rows()} cursor={5} selectionStart={5} selectionEnd={5} />);
 
     const cursorRow = screen.getByText("line 5").closest(".diff-row");
     const otherRow = screen.getByText("line 6").closest(".diff-row");
     expect(cursorRow?.className).toContain("diff-row--selected");
     expect(otherRow?.className).not.toContain("diff-row--selected");
+  });
+
+  it("shows a Comment pill at the cursor, and Edit when that row already has a draft", () => {
+    const { rerender } = render(
+      <DiffList {...baseProps()} rows={rows()} cursor={5} selectionStart={5} selectionEnd={5} />,
+    );
+    expect(screen.getByText("Comment")).toBeTruthy();
+
+    rerender(
+      <DiffList
+        {...baseProps()}
+        rows={rows()}
+        cursor={5}
+        selectionStart={5}
+        selectionEnd={5}
+        drafts={makeDrafts({ anchored: [makeAnchoredDraft({ row: 5, body: "existing" })] })}
+      />,
+    );
+    expect(screen.getByText("Edit")).toBeTruthy();
+  });
+
+  it("does not show the pill on a row that is not the cursor", () => {
+    render(<DiffList {...baseProps()} rows={rows()} cursor={5} selectionStart={5} selectionEnd={5} />);
+
+    const other = screen.getByText("line 6").closest(".diff-list__item");
+    expect(other?.querySelector(".diff-row__pill")).toBeNull();
+  });
+
+  it("clicking the pill opens the composer at that row", () => {
+    const onOpenComposer = vi.fn();
+    render(
+      <DiffList
+        {...baseProps()}
+        rows={rows()}
+        cursor={5}
+        selectionStart={5}
+        selectionEnd={5}
+        onOpenComposer={onOpenComposer}
+      />,
+    );
+
+    screen.getByText("Comment").click();
+
+    expect(onOpenComposer).toHaveBeenCalledWith(5);
+  });
+
+  it("renders a resting draft card under its row, with the body visible", () => {
+    render(
+      <DiffList
+        {...baseProps()}
+        rows={rows()}
+        cursor={0}
+        selectionStart={0}
+        selectionEnd={0}
+        drafts={makeDrafts({ anchored: [makeAnchoredDraft({ row: 5, body: "worth a look" })] })}
+      />,
+    );
+
+    expect(screen.getByText("Your draft")).toBeTruthy();
+    expect(screen.getByText("worth a look")).toBeTruthy();
+  });
+
+  it("shows the composer instead of the draft card on the row it is open over", () => {
+    render(
+      <DiffList
+        {...baseProps()}
+        rows={rows()}
+        cursor={5}
+        selectionStart={5}
+        selectionEnd={5}
+        drafts={makeDrafts({ anchored: [makeAnchoredDraft({ row: 5, body: "editing this" })] })}
+        composer={{ rows: [5, 5], notice: null }}
+      />,
+    );
+
+    expect(screen.queryByText("Your draft")).toBeNull();
+    expect(document.querySelector("[data-composer]")).not.toBeNull();
+  });
+
+  it("shows the rejected-span notice under the open composer", () => {
+    render(
+      <DiffList
+        {...baseProps()}
+        rows={rows()}
+        cursor={5}
+        selectionStart={5}
+        selectionEnd={5}
+        composer={{ rows: [5, 5], notice: "This selection cannot hold a comment" }}
+      />,
+    );
+
+    expect(screen.getByText("This selection cannot hold a comment")).toBeTruthy();
   });
 });

--- a/apps/desktop/src/components/DiffList.tsx
+++ b/apps/desktop/src/components/DiffList.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import type { RowDto } from "../bindings";
+import type { DraftsDto, RowDto } from "../bindings";
+import type { ComposerState } from "../hooks/sessionReducer";
+import { draftAtRow } from "../hooks/sessionReducer";
+import { CommentComposer } from "./CommentComposer";
 import { DiffRow } from "./DiffRow";
+import { DraftCard } from "./DraftCard";
 import { HunkHeader } from "./HunkHeader";
 import "./DiffList.css";
 
@@ -11,14 +15,28 @@ export function DiffList({
   cursor,
   selectionStart,
   selectionEnd,
+  drafts,
+  composer,
+  composerPrefill,
   onRowClick,
+  onOpenComposer,
+  onComposerChange,
+  onComposerClose,
+  onComposerDiscard,
 }: {
   rows: RowDto[];
   fileIndex: number;
   cursor: number;
   selectionStart: number;
   selectionEnd: number;
+  drafts: DraftsDto;
+  composer: ComposerState;
+  composerPrefill: string;
   onRowClick: (index: number) => void;
+  onOpenComposer: (index: number) => void;
+  onComposerChange: (body: string) => void;
+  onComposerClose: () => void;
+  onComposerDiscard: () => void;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -54,19 +72,37 @@ export function DiffList({
           if (!row) {
             return null;
           }
+          const draft = draftAtRow(drafts, item.index);
+          const composerOpenHere = composer !== null && composer.rows[1] === item.index;
           return (
             <div
               key={item.key}
+              data-index={item.index}
+              ref={virtualizer.measureElement}
               className="diff-list__item"
-              style={{ height: item.size, transform: `translateY(${item.start}px)` }}
+              style={{ transform: `translateY(${item.start}px)` }}
             >
               {row.hunk_header !== null && <HunkHeader header={row.hunk_header} />}
               <DiffRow
                 row={row}
                 selected={item.index === cursor}
                 inSelection={item.index >= selectionStart && item.index <= selectionEnd}
+                draft={draft}
+                showPill={item.index === cursor && !composerOpenHere}
                 onClick={() => onRowClick(item.index)}
+                onOpenComposer={() => onOpenComposer(item.index)}
               />
+              {draft && !composerOpenHere && <DraftCard body={draft.body} />}
+              {composerOpenHere && composer && (
+                <CommentComposer
+                  rows={composer.rows}
+                  prefill={composerPrefill}
+                  notice={composer.notice}
+                  onChange={onComposerChange}
+                  onClose={onComposerClose}
+                  onDiscard={onComposerDiscard}
+                />
+              )}
             </div>
           );
         })}

--- a/apps/desktop/src/components/DiffRow.css
+++ b/apps/desktop/src/components/DiffRow.css
@@ -99,3 +99,28 @@
   overflow: hidden;
   white-space: nowrap;
 }
+
+.diff-row__draft-chip {
+  flex-shrink: 0;
+  margin-right: 8px;
+  padding: 0 6px;
+  border-radius: 3px;
+  background: var(--accent-dim);
+  color: var(--accent-text);
+  font-family: var(--font-sans);
+  font-size: var(--size-label);
+  text-transform: uppercase;
+}
+
+.diff-row__pill {
+  flex-shrink: 0;
+  margin-right: 8px;
+  padding: 4px 10px;
+  border: none;
+  border-radius: 4px;
+  background: var(--accent-base);
+  color: var(--text-on-accent);
+  font-family: var(--font-sans);
+  font-size: var(--size-label);
+  cursor: pointer;
+}

--- a/apps/desktop/src/components/DiffRow.tsx
+++ b/apps/desktop/src/components/DiffRow.tsx
@@ -1,4 +1,4 @@
-import type { DiffLineKindDto, RowDto } from "../bindings";
+import type { AnchoredDraftDto, DiffLineKindDto, RowDto } from "../bindings";
 import "./DiffRow.css";
 
 const KIND_CLASS: Record<DiffLineKindDto, string> = {
@@ -19,14 +19,21 @@ export function DiffRow({
   row,
   selected,
   inSelection,
+  draft,
+  showPill,
   onClick,
+  onOpenComposer,
 }: {
   row: RowDto;
   selected: boolean;
   inSelection: boolean;
+  draft?: AnchoredDraftDto;
+  /** Shown only at the cursor's own row, while the composer is not open there. */
+  showPill?: boolean;
   onClick: () => void;
+  onOpenComposer?: () => void;
 }) {
-  const rail = railClass(row, selected, inSelection);
+  const rail = railClass(row, selected, inSelection, draft);
 
   return (
     <div
@@ -40,16 +47,34 @@ export function DiffRow({
       <div className="diff-row__gutter diff-row__gutter--new">{row.new_line ?? ""}</div>
       <div className="diff-row__marker">{KIND_MARKER[row.kind]}</div>
       <div className="diff-row__text">{row.text}</div>
+      {draft && <span className="diff-row__draft-chip">draft</span>}
+      {showPill && (
+        <button
+          type="button"
+          className="diff-row__pill"
+          onClick={(event) => {
+            event.stopPropagation();
+            onOpenComposer?.();
+          }}
+        >
+          {draft ? "Edit" : "Comment"}
+        </button>
+      )}
     </div>
   );
 }
 
-function railClass(row: RowDto, selected: boolean, inSelection: boolean): string {
+function railClass(
+  row: RowDto,
+  selected: boolean,
+  inSelection: boolean,
+  draft: AnchoredDraftDto | undefined,
+): string {
   if (selected || inSelection) {
     return "diff-row__rail--accent";
   }
-  if (row.has_draft) {
-    return row.draft_is_proposed ? "diff-row__rail--proposed" : "diff-row__rail--accent-dim";
+  if (draft) {
+    return draft.is_proposed ? "diff-row__rail--proposed" : "diff-row__rail--accent-dim";
   }
   if (row.thread_count > 0) {
     return "diff-row__rail--thread";

--- a/apps/desktop/src/components/DraftCard.css
+++ b/apps/desktop/src/components/DraftCard.css
@@ -1,0 +1,35 @@
+.draft-card {
+  margin-left: calc(var(--gutter-width) * 2 + 20px);
+  margin-right: 12px;
+  margin-top: 4px;
+  margin-bottom: 4px;
+  padding: 8px;
+  border-radius: 6px;
+  border-left: 2px solid var(--severity-warning);
+  background: var(--surface-overlay);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-family: var(--font-sans);
+}
+
+.draft-card__header {
+  display: flex;
+  gap: 8px;
+  font-size: var(--size-label);
+}
+
+.draft-card__label {
+  color: var(--severity-warning-text);
+  font-weight: 600;
+}
+
+.draft-card__stale {
+  color: var(--severity-error-text);
+}
+
+.draft-card__body {
+  font-size: var(--size-meta);
+  color: var(--text-primary);
+  white-space: pre-wrap;
+}

--- a/apps/desktop/src/components/DraftCard.tsx
+++ b/apps/desktop/src/components/DraftCard.tsx
@@ -1,0 +1,14 @@
+import "./DraftCard.css";
+
+/** A resting draft shown under its row while the composer is closed; `isStale` is kept for parity though an anchored draft is never stale. */
+export function DraftCard({ body, isStale = false }: { body: string; isStale?: boolean }) {
+  return (
+    <div className="draft-card">
+      <div className="draft-card__header">
+        <span className="draft-card__label">Your draft</span>
+        {isStale && <span className="draft-card__stale">needs re-anchoring</span>}
+      </div>
+      <div className="draft-card__body">{body}</div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/DraftsPanel.css
+++ b/apps/desktop/src/components/DraftsPanel.css
@@ -1,0 +1,51 @@
+.drafts-panel {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-top: 1px solid var(--border-default);
+  font-family: var(--font-sans);
+}
+
+.drafts-panel__count {
+  color: var(--text-secondary);
+  font-size: var(--size-meta);
+}
+
+.drafts-panel__stale-heading {
+  color: var(--severity-error-text);
+  font-size: var(--size-label);
+}
+
+.drafts-panel__card {
+  padding: 8px;
+  border-radius: 6px;
+  border-left: 2px solid var(--severity-error-text);
+  background: var(--surface-overlay);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.drafts-panel__location {
+  color: var(--text-secondary);
+  font-size: var(--size-label);
+}
+
+.drafts-panel__body {
+  color: var(--text-primary);
+  font-size: var(--size-meta);
+  white-space: pre-wrap;
+}
+
+.drafts-panel__move {
+  align-self: flex-start;
+  margin-top: 4px;
+  padding: 4px 10px;
+  border: none;
+  border-radius: 4px;
+  background: var(--accent-base);
+  color: var(--text-on-accent);
+  font-size: var(--size-label);
+  cursor: pointer;
+}

--- a/apps/desktop/src/components/DraftsPanel.tsx
+++ b/apps/desktop/src/components/DraftsPanel.tsx
@@ -1,0 +1,45 @@
+import type { DiffSideDto, StaleDraftDto } from "../bindings";
+import "./DraftsPanel.css";
+
+/** The reviewer's drafts on the selected file and the ones that need re-anchoring, as one relocatable component. */
+export function DraftsPanel({
+  fileDraftCount,
+  stale,
+  cursor,
+  onReanchor,
+}: {
+  fileDraftCount: number;
+  stale: StaleDraftDto[];
+  cursor: number;
+  onReanchor: (path: string, side: DiffSideDto, line: number, row: number) => void;
+}) {
+  if (fileDraftCount === 0) {
+    return null;
+  }
+
+  return (
+    <div className="drafts-panel">
+      <div className="drafts-panel__count">{fileDraftCount} of your drafts</div>
+      {stale.length > 0 && (
+        <>
+          <div className="drafts-panel__stale-heading">
+            {stale.length} draft{stale.length === 1 ? "" : "s"} need re-anchoring
+          </div>
+          {stale.map((draft) => (
+            <div key={`${draft.path}:${draft.side}:${draft.line}`} className="drafts-panel__card">
+              <div className="drafts-panel__location">{draft.location}</div>
+              <div className="drafts-panel__body">{draft.body}</div>
+              <button
+                type="button"
+                className="drafts-panel__move"
+                onClick={() => onReanchor(draft.path, draft.side, draft.line, cursor)}
+              >
+                Move to row {cursor + 1}
+              </button>
+            </div>
+          ))}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/EmptyDiffPane.css
+++ b/apps/desktop/src/components/EmptyDiffPane.css
@@ -1,0 +1,23 @@
+.empty-diff-pane {
+  flex: 1;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  background: var(--surface-inset);
+  font-family: var(--font-sans);
+}
+
+.empty-diff-pane__label {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.empty-diff-pane__detail {
+  max-width: 420px;
+  text-align: center;
+  color: var(--text-tertiary);
+  font-size: var(--size-meta);
+}

--- a/apps/desktop/src/components/EmptyDiffPane.tsx
+++ b/apps/desktop/src/components/EmptyDiffPane.tsx
@@ -1,0 +1,14 @@
+import "./EmptyDiffPane.css";
+
+/**
+ * Shown instead of the row list when a file has nothing to display, so an
+ * empty pane reads as an explanation rather than a bug.
+ */
+export function EmptyDiffPane({ label, detail }: { label: string; detail: string }) {
+  return (
+    <div className="empty-diff-pane">
+      <div className="empty-diff-pane__label">{label}</div>
+      <div className="empty-diff-pane__detail">{detail}</div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/FileSidebar.css
+++ b/apps/desktop/src/components/FileSidebar.css
@@ -122,3 +122,17 @@
 .file-row__check {
   color: var(--severity-success);
 }
+
+.file-sidebar__warnings {
+  padding: 8px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border-bottom: 1px solid var(--border-default);
+  background: var(--severity-warning-dim);
+}
+
+.file-sidebar__warning {
+  color: var(--severity-warning-text);
+  font-size: var(--size-label);
+}

--- a/apps/desktop/src/components/FileSidebar.test.tsx
+++ b/apps/desktop/src/components/FileSidebar.test.tsx
@@ -5,6 +5,21 @@ import type { FileStatusDto } from "../bindings";
 import { makeFileSummary, makeSidebar } from "../test/fixtures";
 import { FileSidebar } from "./FileSidebar";
 
+/** Every prop FileSidebar needs beyond the ones a test wants to vary. */
+function baseProps() {
+  return {
+    title: "t",
+    subtitle: "s",
+    warnings: [],
+    writeFailure: null,
+    fileDraftCount: 0,
+    staleDrafts: [],
+    cursor: 0,
+    onSelect: () => {},
+    onReanchorDraft: () => {},
+  };
+}
+
 describe("FileSidebar", () => {
   it("maps every status to a distinct glyph and colour class", () => {
     const expectations: { status: FileStatusDto; glyph: string; className: string }[] = [
@@ -19,9 +34,7 @@ describe("FileSidebar", () => {
 
     for (const { status, glyph, className } of expectations) {
       const files = [makeFileSummary({ status })];
-      const { unmount } = render(
-        <FileSidebar title="t" subtitle="s" sidebar={makeSidebar(files)} onSelect={() => {}} />,
-      );
+      const { unmount } = render(<FileSidebar {...baseProps()} sidebar={makeSidebar(files)} />);
 
       expect(screen.getByText(glyph).className).toContain(className);
       unmount();
@@ -30,7 +43,7 @@ describe("FileSidebar", () => {
 
   it("shows add and delete counts for a text file", () => {
     const files = [makeFileSummary({ additions: 12, deletions: 3 })];
-    render(<FileSidebar title="t" subtitle="s" sidebar={makeSidebar(files)} onSelect={() => {}} />);
+    render(<FileSidebar {...baseProps()} sidebar={makeSidebar(files)} />);
 
     expect(screen.getByText("+12")).toBeTruthy();
     expect(screen.getByText("-3")).toBeTruthy();
@@ -38,7 +51,7 @@ describe("FileSidebar", () => {
 
   it("shows 'binary' instead of counts for a binary file", () => {
     const files = [makeFileSummary({ is_binary: true, additions: 5, deletions: 5 })];
-    render(<FileSidebar title="t" subtitle="s" sidebar={makeSidebar(files)} onSelect={() => {}} />);
+    render(<FileSidebar {...baseProps()} sidebar={makeSidebar(files)} />);
 
     expect(screen.getByText("binary")).toBeTruthy();
     expect(screen.queryByText("+5")).toBeNull();
@@ -46,21 +59,21 @@ describe("FileSidebar", () => {
 
   it("marks a viewed file with a checkmark", () => {
     const files = [makeFileSummary({ viewed: true })];
-    render(<FileSidebar title="t" subtitle="s" sidebar={makeSidebar(files)} onSelect={() => {}} />);
+    render(<FileSidebar {...baseProps()} sidebar={makeSidebar(files)} />);
 
     expect(screen.getByText("✓")).toBeTruthy();
   });
 
   it("hides the thread badge when a file has no threads", () => {
     const files = [makeFileSummary({ thread_count: 0 })];
-    render(<FileSidebar title="t" subtitle="s" sidebar={makeSidebar(files)} onSelect={() => {}} />);
+    render(<FileSidebar {...baseProps()} sidebar={makeSidebar(files)} />);
 
     expect(screen.queryByText("0")).toBeNull();
   });
 
   it("shows the thread badge when a file has threads", () => {
     const files = [makeFileSummary({ thread_count: 3 })];
-    render(<FileSidebar title="t" subtitle="s" sidebar={makeSidebar(files)} onSelect={() => {}} />);
+    render(<FileSidebar {...baseProps()} sidebar={makeSidebar(files)} />);
 
     expect(screen.getByText("3")).toBeTruthy();
   });
@@ -72,12 +85,81 @@ describe("FileSidebar", () => {
       makeFileSummary({ index: 0, path: "a.rs" }),
       makeFileSummary({ index: 1, path: "b.rs" }),
     ];
-    render(
-      <FileSidebar title="t" subtitle="s" sidebar={makeSidebar(files)} onSelect={onSelect} />,
-    );
+    render(<FileSidebar {...baseProps()} sidebar={makeSidebar(files)} onSelect={onSelect} />);
 
     await user.click(screen.getByText("b.rs"));
 
     expect(onSelect).toHaveBeenCalledWith(1);
+  });
+
+  it("shows no warnings strip when there is nothing to warn about", () => {
+    render(<FileSidebar {...baseProps()} sidebar={makeSidebar()} />);
+
+    expect(document.querySelector(".file-sidebar__warnings")).toBeNull();
+  });
+
+  it("shows a warning from the session's own warnings list", () => {
+    render(
+      <FileSidebar
+        {...baseProps()}
+        sidebar={makeSidebar()}
+        warnings={[{ summary: "GitHub's rate limit is exhausted", detail: null, remediation: null }]}
+      />,
+    );
+
+    expect(screen.getByText("GitHub's rate limit is exhausted")).toBeTruthy();
+  });
+
+  it("merges the sink's write failure in alongside the session's own warnings", () => {
+    render(
+      <FileSidebar
+        {...baseProps()}
+        sidebar={makeSidebar()}
+        warnings={[{ summary: "1 saved draft no longer matches this diff", detail: null, remediation: null }]}
+        writeFailure="Drafts are not being saved"
+      />,
+    );
+
+    expect(screen.getByText("1 saved draft no longer matches this diff")).toBeTruthy();
+    expect(screen.getByText("Drafts are not being saved")).toBeTruthy();
+  });
+
+  it("hides the drafts panel when the file has no drafts", () => {
+    render(<FileSidebar {...baseProps()} sidebar={makeSidebar()} fileDraftCount={0} />);
+
+    expect(screen.queryByText(/of your drafts/)).toBeNull();
+  });
+
+  it("shows the drafts panel's count once the file has a draft", () => {
+    render(<FileSidebar {...baseProps()} sidebar={makeSidebar()} fileDraftCount={2} />);
+
+    expect(screen.getByText("2 of your drafts")).toBeTruthy();
+  });
+
+  it("invokes onReanchorDraft with the stale draft's key and the current cursor", async () => {
+    const user = userEvent.setup();
+    const onReanchorDraft = vi.fn();
+    render(
+      <FileSidebar
+        {...baseProps()}
+        sidebar={makeSidebar()}
+        fileDraftCount={1}
+        staleDrafts={[
+          {
+            path: "src/review.rs",
+            side: "Right",
+            line: 42,
+            body: "left last week",
+            location: "was RIGHT line 42",
+          },
+        ]}
+        cursor={9}
+        onReanchorDraft={onReanchorDraft}
+      />,
+    );
+
+    await user.click(screen.getByText("Move to row 10"));
+
+    expect(onReanchorDraft).toHaveBeenCalledWith("src/review.rs", "Right", 42, 9);
   });
 });

--- a/apps/desktop/src/components/FileSidebar.tsx
+++ b/apps/desktop/src/components/FileSidebar.tsx
@@ -1,4 +1,5 @@
-import type { FileStatusDto, FileSummaryDto, SidebarDto } from "../bindings";
+import type { DiffSideDto, FileStatusDto, FileSummaryDto, SessionFailureDto, SidebarDto, StaleDraftDto } from "../bindings";
+import { DraftsPanel } from "./DraftsPanel";
 import "./FileSidebar.css";
 
 const STATUS_GLYPH: Record<FileStatusDto, { label: string; className: string }> = {
@@ -15,13 +16,30 @@ export function FileSidebar({
   title,
   subtitle,
   sidebar,
+  warnings,
+  writeFailure,
+  fileDraftCount,
+  staleDrafts,
+  cursor,
   onSelect,
+  onReanchorDraft,
 }: {
   title: string;
   subtitle: string;
   sidebar: SidebarDto;
+  warnings: SessionFailureDto[];
+  writeFailure: string | null;
+  fileDraftCount: number;
+  staleDrafts: StaleDraftDto[];
+  cursor: number;
   onSelect: (index: number) => void;
+  onReanchorDraft: (path: string, side: DiffSideDto, line: number, row: number) => void;
 }) {
+  const warningMessages = warnings.map((warning) => warning.summary);
+  if (writeFailure !== null) {
+    warningMessages.push(writeFailure);
+  }
+
   return (
     <div className="file-sidebar">
       <div className="file-sidebar__header">
@@ -32,6 +50,15 @@ export function FileSidebar({
           {sidebar.thread_count} conversations
         </div>
       </div>
+      {warningMessages.length > 0 && (
+        <div className="file-sidebar__warnings">
+          {warningMessages.map((message) => (
+            <div key={message} className="file-sidebar__warning">
+              {message}
+            </div>
+          ))}
+        </div>
+      )}
       <div className="file-sidebar__list">
         {sidebar.files.map((file) => (
           <FileRow
@@ -42,6 +69,12 @@ export function FileSidebar({
           />
         ))}
       </div>
+      <DraftsPanel
+        fileDraftCount={fileDraftCount}
+        stale={staleDrafts}
+        cursor={cursor}
+        onReanchor={onReanchorDraft}
+      />
     </div>
   );
 }

--- a/apps/desktop/src/components/SessionShell.test.tsx
+++ b/apps/desktop/src/components/SessionShell.test.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ReadyState } from "../hooks/sessionReducer";
+import { makeFile, makeFileSummary, makeRow, makeSidebar, makeSnapshot } from "../test/fixtures";
+import { SessionShell } from "./SessionShell";
+
+/** Every prop SessionShell needs beyond the ones a test wants to vary. */
+function baseHandlers() {
+  return {
+    onSelectFile: () => {},
+    onRowClick: () => {},
+    onOpenComposer: () => {},
+    onComposerChange: () => {},
+    onComposerClose: () => {},
+    onComposerDiscard: () => {},
+    onReanchorDraft: () => {},
+  };
+}
+
+function readyState(overrides: Partial<ReadyState["file"]> = {}): ReadyState {
+  return {
+    status: "ready",
+    snapshot: makeSnapshot({ sidebar: makeSidebar([makeFileSummary()]) }),
+    file: makeFile({ rows: [makeRow({ text: "a line" })], ...overrides }),
+    cursor: 0,
+    anchor: 0,
+    drafts: makeFile().drafts,
+    composer: null,
+  };
+}
+
+describe("SessionShell", () => {
+  it("renders the diff list when the file has rows and no empty reason", () => {
+    render(<SessionShell state={readyState()} {...baseHandlers()} />);
+
+    expect(screen.getByText("a line")).toBeTruthy();
+  });
+
+  it("shows the empty-diff pane with the domain's reason when the file carries one", () => {
+    render(
+      <SessionShell
+        state={readyState({
+          rows: [],
+          empty_reason: { label: "Binary file", detail: "ZReview does not render binary content yet." },
+        })}
+        {...baseHandlers()}
+      />,
+    );
+
+    expect(screen.getByText("Binary file")).toBeTruthy();
+    expect(screen.getByText("ZReview does not render binary content yet.")).toBeTruthy();
+    expect(screen.queryByText("a line")).toBeNull();
+  });
+
+  it("falls back to a generic empty message when rows are empty with no stated reason", () => {
+    render(<SessionShell state={readyState({ rows: [] })} {...baseHandlers()} />);
+
+    expect(screen.getByText("No lines to show")).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/components/SessionShell.tsx
+++ b/apps/desktop/src/components/SessionShell.tsx
@@ -1,6 +1,8 @@
+import type { DiffSideDto } from "../bindings";
 import type { ReadyState } from "../hooks/sessionReducer";
-import { selectionRange } from "../hooks/sessionReducer";
+import { composerPrefill, selectionRange } from "../hooks/sessionReducer";
 import { DiffList } from "./DiffList";
+import { EmptyDiffPane } from "./EmptyDiffPane";
 import { FileSidebar } from "./FileSidebar";
 import "./SessionShell.css";
 
@@ -8,12 +10,24 @@ export function SessionShell({
   state,
   onSelectFile,
   onRowClick,
+  onOpenComposer,
+  onComposerChange,
+  onComposerClose,
+  onComposerDiscard,
+  onReanchorDraft,
 }: {
   state: ReadyState;
   onSelectFile: (index: number) => void;
   onRowClick: (index: number) => void;
+  onOpenComposer: (index: number) => void;
+  onComposerChange: (body: string) => void;
+  onComposerClose: () => void;
+  onComposerDiscard: () => void;
+  onReanchorDraft: (path: string, side: DiffSideDto, line: number, row: number) => void;
 }) {
   const [selectionStart, selectionEnd] = selectionRange(state);
+  const { empty_reason: emptyReason, rows } = state.file;
+  const isEmpty = emptyReason !== null || rows.length === 0;
 
   return (
     <div className="session-shell">
@@ -21,16 +35,36 @@ export function SessionShell({
         title={state.snapshot.title}
         subtitle={state.snapshot.subtitle}
         sidebar={state.snapshot.sidebar}
-        onSelect={onSelectFile}
-      />
-      <DiffList
-        rows={state.file.rows}
-        fileIndex={state.file.index}
+        warnings={state.snapshot.warnings}
+        writeFailure={state.drafts.write_failure}
+        fileDraftCount={state.drafts.file_draft_count}
+        staleDrafts={state.drafts.stale}
         cursor={state.cursor}
-        selectionStart={selectionStart}
-        selectionEnd={selectionEnd}
-        onRowClick={onRowClick}
+        onSelect={onSelectFile}
+        onReanchorDraft={onReanchorDraft}
       />
+      {isEmpty ? (
+        <EmptyDiffPane
+          label={emptyReason?.label ?? "No lines to show"}
+          detail={emptyReason?.detail ?? "This file has nothing to display."}
+        />
+      ) : (
+        <DiffList
+          rows={rows}
+          fileIndex={state.file.index}
+          cursor={state.cursor}
+          selectionStart={selectionStart}
+          selectionEnd={selectionEnd}
+          drafts={state.drafts}
+          composer={state.composer}
+          composerPrefill={composerPrefill(state)}
+          onRowClick={onRowClick}
+          onOpenComposer={onOpenComposer}
+          onComposerChange={onComposerChange}
+          onComposerClose={onComposerClose}
+          onComposerDiscard={onComposerDiscard}
+        />
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/editor/markdownEditor.test.ts
+++ b/apps/desktop/src/editor/markdownEditor.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMarkdownEditor, type MarkdownEditorHandle } from "./markdownEditor";
+
+let handle: MarkdownEditorHandle | undefined;
+
+afterEach(() => {
+  handle?.destroy();
+  handle = undefined;
+});
+
+describe("createMarkdownEditor", () => {
+  it("mounts with the initial text rendered", () => {
+    const parent = document.createElement("div");
+    handle = createMarkdownEditor({
+      parent,
+      initialText: "hello",
+      onChange: () => {},
+      onClose: () => {},
+    });
+
+    expect(parent.querySelector(".cm-editor")).not.toBeNull();
+    expect(parent.querySelector(".cm-content")?.textContent).toBe("hello");
+  });
+
+  it("calls onClose without discarding the document on Escape", () => {
+    const parent = document.createElement("div");
+    const onClose = vi.fn();
+    handle = createMarkdownEditor({
+      parent,
+      initialText: "keep me",
+      onChange: () => {},
+      onClose,
+    });
+
+    const content = parent.querySelector(".cm-content") as HTMLElement;
+    content.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(content.textContent).toBe("keep me");
+  });
+
+  it("calls onClose without discarding the document on Mod-Enter", () => {
+    const parent = document.createElement("div");
+    const onClose = vi.fn();
+    handle = createMarkdownEditor({
+      parent,
+      initialText: "keep me too",
+      onChange: () => {},
+      onClose,
+    });
+
+    // jsdom reports no platform, so CodeMirror resolves "Mod" to Ctrl here.
+    const content = parent.querySelector(".cm-content") as HTMLElement;
+    content.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", ctrlKey: true, bubbles: true }),
+    );
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(content.textContent).toBe("keep me too");
+  });
+
+  it("destroys cleanly, detaching from the parent", () => {
+    const parent = document.createElement("div");
+    handle = createMarkdownEditor({
+      parent,
+      initialText: "",
+      onChange: () => {},
+      onClose: () => {},
+    });
+
+    handle.destroy();
+    handle = undefined;
+
+    expect(parent.querySelector(".cm-editor")).toBeNull();
+  });
+});

--- a/apps/desktop/src/editor/markdownEditor.ts
+++ b/apps/desktop/src/editor/markdownEditor.ts
@@ -1,0 +1,87 @@
+import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import { markdown } from "@codemirror/lang-markdown";
+import { EditorState } from "@codemirror/state";
+import { EditorView, keymap } from "@codemirror/view";
+
+/** What a component gets back from the composer's editor; components never import CodeMirror directly. */
+export interface MarkdownEditorHandle {
+  focus: () => void;
+  destroy: () => void;
+}
+
+/** Builds a CodeMirror 6 Markdown editor mounted on `parent`, saving on every change and closing on Escape or Mod-Enter. */
+export function createMarkdownEditor({
+  parent,
+  initialText,
+  onChange,
+  onClose,
+}: {
+  parent: HTMLElement;
+  initialText: string;
+  onChange: (text: string) => void;
+  onClose: () => void;
+}): MarkdownEditorHandle {
+  const view = new EditorView({
+    parent,
+    state: EditorState.create({
+      doc: initialText,
+      extensions: [
+        markdown(),
+        history(),
+        keymap.of([
+          {
+            key: "Escape",
+            run: () => {
+              onClose();
+              return true;
+            },
+          },
+          {
+            key: "Mod-Enter",
+            run: () => {
+              onClose();
+              return true;
+            },
+          },
+          ...defaultKeymap,
+          ...historyKeymap,
+        ]),
+        EditorView.lineWrapping,
+        EditorView.updateListener.of((update) => {
+          if (update.docChanged) {
+            onChange(update.state.doc.toString());
+          }
+        }),
+        EditorView.theme({
+          "&": {
+            height: "100%",
+            fontFamily: "var(--font-sans)",
+            fontSize: "var(--size-body)",
+            color: "var(--text-primary)",
+            backgroundColor: "var(--surface-overlay)",
+          },
+          ".cm-scroller": {
+            fontFamily: "var(--font-sans)",
+          },
+          ".cm-content": {
+            caretColor: "var(--accent-base)",
+          },
+          "&.cm-focused .cm-cursor": {
+            borderLeftColor: "var(--accent-base)",
+          },
+          "&.cm-focused .cm-selectionBackground, .cm-selectionBackground": {
+            backgroundColor: "var(--surface-selected)",
+          },
+          ".cm-gutters": {
+            display: "none",
+          },
+        }),
+      ],
+    }),
+  });
+
+  return {
+    focus: () => view.focus(),
+    destroy: () => view.destroy(),
+  };
+}

--- a/apps/desktop/src/hooks/sessionReducer.test.ts
+++ b/apps/desktop/src/hooks/sessionReducer.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { FileDetailDto, SessionFailureDto } from "../bindings";
-import { makeFile, makeRow, makeSnapshot } from "../test/fixtures";
+import { makeAnchoredDraft, makeDrafts, makeFile, makeRow, makeSnapshot } from "../test/fixtures";
 import {
   type ReadyState,
-  type SessionState,
+  composerPrefill,
+  draftAtRow,
   initialState,
   selectionRange,
   sessionReducer,
@@ -15,17 +16,42 @@ function fileWithRows(rowCount: number): FileDetailDto {
   });
 }
 
-function readyState(rowCount: number, cursor = 0, anchor = 0): SessionState {
-  return { status: "ready", snapshot: makeSnapshot(), file: fileWithRows(rowCount), cursor, anchor };
+function readyState(rowCount: number, cursor = 0, anchor = 0): ReadyState {
+  const file = fileWithRows(rowCount);
+  return {
+    status: "ready",
+    snapshot: makeSnapshot(),
+    file,
+    cursor,
+    anchor,
+    drafts: file.drafts,
+    composer: null,
+  };
 }
 
 describe("sessionReducer", () => {
-  it("starts on the loading phase with the demo description", () => {
+  it("starts on the loading phase with no description yet", () => {
     expect(initialState).toEqual({
       status: "loading",
-      description: "the generated fixture",
+      description: "",
       stage: "Starting",
     });
+  });
+
+  it("fills in the description once the request describes itself", () => {
+    const next = sessionReducer(initialState, {
+      type: "describe",
+      description: "main…HEAD",
+    });
+    expect(next).toEqual({ ...initialState, description: "main…HEAD" });
+  });
+
+  it("ignores a late description once the session is no longer loading", () => {
+    const next = sessionReducer(readyState(1), {
+      type: "describe",
+      description: "main…HEAD",
+    });
+    expect(next).toEqual(readyState(1));
   });
 
   it("updates the stage while loading", () => {
@@ -66,10 +92,17 @@ describe("sessionReducer", () => {
     expect(shrunk).toMatchObject({ cursor: 3, anchor: 1 });
   });
 
-  it("resets the cursor and anchor when the file switches", () => {
-    const next = sessionReducer(readyState(10, 7, 2), { type: "file", file: fileWithRows(5) });
-    expect(next).toMatchObject({ cursor: 0, anchor: 0 });
-    expect((next as ReadyState).file.rows).toHaveLength(5);
+  it("resets the cursor and anchor when the file switches, closing the composer and swapping drafts", () => {
+    const state = sessionReducer(readyState(10, 7, 2), { type: "toggleComposer" }) as ReadyState;
+    expect(state.composer).not.toBeNull();
+
+    const nextFile = fileWithRows(5);
+    nextFile.drafts = makeDrafts({ file_draft_count: 3 });
+    const next = sessionReducer(state, { type: "file", file: nextFile }) as ReadyState;
+
+    expect(next).toMatchObject({ cursor: 0, anchor: 0, composer: null });
+    expect(next.file.rows).toHaveLength(5);
+    expect(next.drafts.file_draft_count).toBe(3);
   });
 
   it("collapses the selection to the clicked row", () => {
@@ -91,5 +124,108 @@ describe("sessionReducer", () => {
     const failure: SessionFailureDto = { summary: "boom", detail: "detail", remediation: "fix it" };
     const next = sessionReducer(initialState, { type: "failed", failure });
     expect(next).toEqual({ status: "failed", failure });
+  });
+
+  it("opens the composer on the selected span, frozen at that instant", () => {
+    const extended = sessionReducer(readyState(10, 3, 3), {
+      type: "move",
+      delta: 1,
+      extend: true,
+    }) as ReadyState;
+
+    const next = sessionReducer(extended, { type: "toggleComposer" }) as ReadyState;
+
+    expect(next.composer).toEqual({ rows: [3, 4], notice: null });
+  });
+
+  it("closes the composer when toggled again over the same frozen span", () => {
+    const opened = sessionReducer(readyState(10, 3, 3), { type: "toggleComposer" }) as ReadyState;
+    expect(opened.composer).not.toBeNull();
+
+    const closed = sessionReducer(opened, { type: "toggleComposer" }) as ReadyState;
+
+    expect(closed.composer).toBeNull();
+  });
+
+  it("reopens on the new span when the selection has moved since it was frozen", () => {
+    const opened = sessionReducer(readyState(10, 3, 3), { type: "toggleComposer" }) as ReadyState;
+    const moved = sessionReducer(opened, { type: "move", delta: 1, extend: false }) as ReadyState;
+
+    const reopened = sessionReducer(moved, { type: "toggleComposer" }) as ReadyState;
+
+    expect(reopened.composer).toEqual({ rows: [4, 4], notice: null });
+  });
+
+  it("opens the composer on a clicked pill, moving the cursor there", () => {
+    const next = sessionReducer(readyState(10, 0, 0), { type: "openComposer", index: 6 }) as ReadyState;
+
+    expect(next).toMatchObject({ cursor: 6, anchor: 6 });
+    expect(next.composer).toEqual({ rows: [6, 6], notice: null });
+  });
+
+  it("closes the composer explicitly", () => {
+    const opened = sessionReducer(readyState(10, 3, 3), { type: "toggleComposer" }) as ReadyState;
+
+    const next = sessionReducer(opened, { type: "closeComposer" }) as ReadyState;
+
+    expect(next.composer).toBeNull();
+  });
+
+  it("ignores a drafts response for a file that is no longer selected", () => {
+    const state = readyState(10, 3, 3);
+    const stale = makeDrafts({
+      file_index: 1,
+      anchored: [makeAnchoredDraft({ row: 3, body: "for the wrong file" })],
+    });
+
+    const next = sessionReducer(state, { type: "drafts", drafts: stale });
+
+    expect(next).toBe(state);
+  });
+
+  it("replaces the drafts projection and clears a stale notice on settle", () => {
+    const opened = sessionReducer(readyState(10, 3, 3), { type: "toggleComposer" }) as ReadyState;
+    const rejected = sessionReducer(opened, { type: "editRejected" }) as ReadyState;
+    expect(rejected.composer?.notice).not.toBeNull();
+
+    const drafts = makeDrafts({ anchored: [makeAnchoredDraft({ row: 3, body: "kept" })] });
+    const next = sessionReducer(rejected, { type: "drafts", drafts }) as ReadyState;
+
+    expect(next.drafts).toBe(drafts);
+    expect(next.composer?.notice).toBeNull();
+  });
+
+  it("shows the rejection notice under the composer only on a false outcome", () => {
+    const opened = sessionReducer(readyState(10, 3, 3), { type: "toggleComposer" }) as ReadyState;
+
+    const next = sessionReducer(opened, { type: "editRejected" }) as ReadyState;
+
+    expect(next.composer?.notice).toBe("This selection cannot hold a comment");
+  });
+
+  it("ignores editRejected when the composer is closed", () => {
+    const next = sessionReducer(readyState(10), { type: "editRejected" }) as ReadyState;
+    expect(next.composer).toBeNull();
+  });
+
+  it("finds the draft anchored to a row", () => {
+    const drafts = makeDrafts({ anchored: [makeAnchoredDraft({ row: 4, body: "hello" })] });
+
+    expect(draftAtRow(drafts, 4)?.body).toBe("hello");
+    expect(draftAtRow(drafts, 5)).toBeUndefined();
+  });
+
+  it("prefills the composer silently from the draft at its span's end row", () => {
+    const drafts = makeDrafts({ anchored: [makeAnchoredDraft({ row: 4, body: "existing" })] });
+    const withDrafts = { ...readyState(10), drafts } as ReadyState;
+    const opened = sessionReducer(withDrafts, { type: "openComposer", index: 4 }) as ReadyState;
+
+    expect(composerPrefill(opened)).toBe("existing");
+  });
+
+  it("prefills empty when the row has no draft or the composer is closed", () => {
+    expect(composerPrefill(readyState(10))).toBe("");
+    const opened = sessionReducer(readyState(10, 2, 2), { type: "toggleComposer" }) as ReadyState;
+    expect(composerPrefill(opened)).toBe("");
   });
 });

--- a/apps/desktop/src/hooks/sessionReducer.ts
+++ b/apps/desktop/src/hooks/sessionReducer.ts
@@ -1,8 +1,18 @@
-import type { FileDetailDto, SessionFailureDto, SessionSnapshotDto, SidebarDto } from "../bindings";
+import type {
+  AnchoredDraftDto,
+  DraftsDto,
+  FileDetailDto,
+  SessionFailureDto,
+  SessionSnapshotDto,
+  SidebarDto,
+} from "../bindings";
 import { clamp } from "../lib/clamp";
 
-/** What the loading screen shows before any session request has begun. */
-const DEMO_DESCRIPTION = "the generated fixture";
+/** Shown under the composer when a span was refused rather than saved. */
+const REJECTED_NOTICE = "This selection cannot hold a comment";
+
+/** The composer's frozen span and any notice it is showing, or absent when closed. */
+export type ComposerState = { rows: [number, number]; notice: string | null } | null;
 
 export type SessionState =
   | { status: "loading"; description: string; stage: string }
@@ -13,24 +23,32 @@ export type SessionState =
       file: FileDetailDto;
       cursor: number;
       anchor: number;
+      drafts: DraftsDto;
+      composer: ComposerState;
     };
 
 export type ReadyState = Extract<SessionState, { status: "ready" }>;
 
 export const initialState: SessionState = {
   status: "loading",
-  description: DEMO_DESCRIPTION,
+  description: "",
   stage: "Starting",
 };
 
 export type SessionAction =
+  | { type: "describe"; description: string }
   | { type: "stage"; stage: string }
   | { type: "failed"; failure: SessionFailureDto }
   | { type: "ready"; snapshot: SessionSnapshotDto; file: FileDetailDto }
   | { type: "file"; file: FileDetailDto }
   | { type: "sidebar"; sidebar: SidebarDto }
   | { type: "move"; delta: 1 | -1; extend: boolean }
-  | { type: "click"; index: number };
+  | { type: "click"; index: number }
+  | { type: "toggleComposer" }
+  | { type: "openComposer"; index: number }
+  | { type: "closeComposer" }
+  | { type: "drafts"; drafts: DraftsDto }
+  | { type: "editRejected" };
 
 /** Clamps a cursor into a row range, or to zero when the file has no rows. */
 function clampCursor(value: number, rowCount: number): number {
@@ -39,6 +57,12 @@ function clampCursor(value: number, rowCount: number): number {
 
 export function sessionReducer(state: SessionState, action: SessionAction): SessionState {
   switch (action.type) {
+    case "describe":
+      if (state.status !== "loading") {
+        return state;
+      }
+      return { ...state, description: action.description };
+
     case "stage":
       if (state.status !== "loading") {
         return state;
@@ -55,13 +79,22 @@ export function sessionReducer(state: SessionState, action: SessionAction): Sess
         file: action.file,
         cursor: 0,
         anchor: 0,
+        drafts: action.file.drafts,
+        composer: null,
       };
 
     case "file":
       if (state.status !== "ready") {
         return state;
       }
-      return { ...state, file: action.file, cursor: 0, anchor: 0 };
+      return {
+        ...state,
+        file: action.file,
+        cursor: 0,
+        anchor: 0,
+        drafts: action.file.drafts,
+        composer: null,
+      };
 
     case "sidebar":
       if (state.status !== "ready") {
@@ -85,10 +118,64 @@ export function sessionReducer(state: SessionState, action: SessionAction): Sess
       const cursor = clampCursor(action.index, state.file.rows.length);
       return { ...state, cursor, anchor: cursor };
     }
+
+    case "toggleComposer": {
+      if (state.status !== "ready") {
+        return state;
+      }
+      const [start, end] = selectionRange(state);
+      if (state.composer && state.composer.rows[0] === start && state.composer.rows[1] === end) {
+        return { ...state, composer: null };
+      }
+      return { ...state, composer: { rows: [start, end], notice: null } };
+    }
+
+    case "openComposer": {
+      if (state.status !== "ready") {
+        return state;
+      }
+      const cursor = clampCursor(action.index, state.file.rows.length);
+      return { ...state, cursor, anchor: cursor, composer: { rows: [cursor, cursor], notice: null } };
+    }
+
+    case "closeComposer":
+      if (state.status !== "ready") {
+        return state;
+      }
+      return { ...state, composer: null };
+
+    case "drafts":
+      if (state.status !== "ready" || action.drafts.file_index !== state.drafts.file_index) {
+        return state;
+      }
+      return {
+        ...state,
+        drafts: action.drafts,
+        composer: state.composer ? { ...state.composer, notice: null } : null,
+      };
+
+    case "editRejected":
+      if (state.status !== "ready" || !state.composer) {
+        return state;
+      }
+      return { ...state, composer: { ...state.composer, notice: REJECTED_NOTICE } };
   }
 }
 
 /** The inclusive row range the reviewer has selected, low index first. */
 export function selectionRange(state: ReadyState): [number, number] {
   return [Math.min(state.anchor, state.cursor), Math.max(state.anchor, state.cursor)];
+}
+
+/** The draft anchored to a row, if the projection has one there. */
+export function draftAtRow(drafts: DraftsDto, row: number): AnchoredDraftDto | undefined {
+  return drafts.anchored.find((draft) => draft.row === row);
+}
+
+/** The text a freshly opened composer should show, silently, before any typing. */
+export function composerPrefill(state: ReadyState): string {
+  if (!state.composer) {
+    return "";
+  }
+  return draftAtRow(state.drafts, state.composer.rows[1])?.body ?? "";
 }

--- a/apps/desktop/src/hooks/useDraftQueue.test.ts
+++ b/apps/desktop/src/hooks/useDraftQueue.test.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { makeDrafts } from "../test/fixtures";
+import { useDraftQueue } from "./useDraftQueue";
+
+const editDraft = vi.fn();
+const discardDraft = vi.fn();
+const reanchorDraft = vi.fn();
+
+vi.mock("../bindings", () => ({
+  commands: {
+    editDraft: (...args: unknown[]) => editDraft(...args),
+    discardDraft: (...args: unknown[]) => discardDraft(...args),
+    reanchorDraft: (...args: unknown[]) => reanchorDraft(...args),
+  },
+}));
+
+beforeEach(() => {
+  editDraft.mockReset();
+  discardDraft.mockReset();
+  reanchorDraft.mockReset();
+});
+
+/** A promise this test resolves by hand, standing in for a slow IPC round trip. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((givenResolve, givenReject) => {
+    resolve = givenResolve;
+    reject = givenReject;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("useDraftQueue", () => {
+  it("sends the first edit immediately and dispatches drafts once it settles", async () => {
+    const dispatch = vi.fn();
+    const first = deferred<unknown>();
+    editDraft.mockReturnValueOnce(first.promise);
+    const { result } = renderHook(() => useDraftQueue(dispatch));
+
+    act(() => result.current.editDraft(0, 0, 0, "a"));
+
+    expect(editDraft).toHaveBeenCalledExactlyOnceWith(0, 0, 0, "a");
+
+    const drafts = makeDrafts();
+    await act(async () => first.resolve({ status: "ok", data: { accepted: true, drafts } }));
+
+    expect(dispatch).toHaveBeenCalledWith({ type: "drafts", drafts });
+    expect(dispatch).not.toHaveBeenCalledWith({ type: "editRejected" });
+  });
+
+  it("coalesces edits queued while one is in flight, sending only the latest body", async () => {
+    const dispatch = vi.fn();
+    const first = deferred<unknown>();
+    editDraft.mockReturnValueOnce(first.promise);
+    const { result } = renderHook(() => useDraftQueue(dispatch));
+
+    act(() => {
+      result.current.editDraft(0, 0, 0, "a");
+      result.current.editDraft(0, 0, 0, "ab");
+      result.current.editDraft(0, 0, 0, "abc");
+    });
+
+    // The two intermediate keystrokes never reached the backend.
+    expect(editDraft).toHaveBeenCalledTimes(1);
+
+    const second = deferred<unknown>();
+    editDraft.mockReturnValueOnce(second.promise);
+    await act(async () =>
+      first.resolve({ status: "ok", data: { accepted: true, drafts: makeDrafts() } }),
+    );
+
+    expect(editDraft).toHaveBeenCalledTimes(2);
+    expect(editDraft).toHaveBeenLastCalledWith(0, 0, 0, "abc");
+
+    await act(async () =>
+      second.resolve({ status: "ok", data: { accepted: true, drafts: makeDrafts() } }),
+    );
+  });
+
+  // A discard behind a queued edit is never coalesced away: both are sent, in order.
+  it("sends a queued edit before the discard that follows it, never dropping either", async () => {
+    const dispatch = vi.fn();
+    const inFlightEdit = deferred<unknown>();
+    editDraft.mockReturnValueOnce(inFlightEdit.promise);
+    const { result } = renderHook(() => useDraftQueue(dispatch));
+
+    act(() => {
+      // The first edit runs immediately; the second queues behind it, and
+      // the discard queues behind that.
+      result.current.editDraft(0, 0, 0, "in flight already");
+      result.current.editDraft(0, 0, 0, "typed while distracted");
+      result.current.discardDraft(0, 0);
+    });
+
+    expect(editDraft).toHaveBeenCalledTimes(1);
+    expect(discardDraft).not.toHaveBeenCalled();
+
+    const queuedEditResponse = deferred<unknown>();
+    editDraft.mockReturnValueOnce(queuedEditResponse.promise);
+    await act(async () =>
+      inFlightEdit.resolve({ status: "ok", data: { accepted: true, drafts: makeDrafts() } }),
+    );
+
+    // The queued edit was sent next, not dropped.
+    expect(editDraft).toHaveBeenCalledTimes(2);
+    expect(discardDraft).not.toHaveBeenCalled();
+
+    const discardResponse = deferred<unknown>();
+    discardDraft.mockReturnValueOnce(discardResponse.promise);
+    await act(async () =>
+      queuedEditResponse.resolve({ status: "ok", data: { accepted: true, drafts: makeDrafts() } }),
+    );
+
+    // Only now does the discard go out, landing last.
+    expect(discardDraft).toHaveBeenCalledExactlyOnceWith(0, 0);
+
+    await act(async () =>
+      discardResponse.resolve({ status: "ok", data: makeDrafts({ file_draft_count: 0 }) }),
+    );
+  });
+
+  // Discard, then reopen and type again: the discard must still be sent.
+  it("still sends a discard queued behind an in-flight edit, even once a new edit follows it", async () => {
+    const dispatch = vi.fn();
+    const inFlightEdit = deferred<unknown>();
+    editDraft.mockReturnValueOnce(inFlightEdit.promise);
+    const { result } = renderHook(() => useDraftQueue(dispatch));
+
+    act(() => {
+      result.current.editDraft(0, 0, 0, "first draft");
+      result.current.discardDraft(0, 0);
+      // Reopened the composer and typed again, all before anything settled.
+      result.current.editDraft(0, 0, 0, "second thoughts");
+    });
+
+    expect(editDraft).toHaveBeenCalledTimes(1);
+
+    const discardResponse = deferred<unknown>();
+    discardDraft.mockReturnValueOnce(discardResponse.promise);
+    await act(async () =>
+      inFlightEdit.resolve({ status: "ok", data: { accepted: true, drafts: makeDrafts() } }),
+    );
+
+    // The discard is next, not the later edit.
+    expect(discardDraft).toHaveBeenCalledExactlyOnceWith(0, 0);
+    expect(editDraft).toHaveBeenCalledTimes(1);
+
+    const secondEditResponse = deferred<unknown>();
+    editDraft.mockReturnValueOnce(secondEditResponse.promise);
+    await act(async () =>
+      discardResponse.resolve({ status: "ok", data: makeDrafts({ file_draft_count: 0 }) }),
+    );
+
+    // Finally, the edit that followed the discard.
+    expect(editDraft).toHaveBeenCalledTimes(2);
+    expect(editDraft).toHaveBeenLastCalledWith(0, 0, 0, "second thoughts");
+
+    await act(async () =>
+      secondEditResponse.resolve({ status: "ok", data: { accepted: true, drafts: makeDrafts() } }),
+    );
+  });
+
+  it("dispatches editRejected only when the outcome was not accepted", async () => {
+    const dispatch = vi.fn();
+    const response = deferred<unknown>();
+    editDraft.mockReturnValueOnce(response.promise);
+    const { result } = renderHook(() => useDraftQueue(dispatch));
+
+    act(() => result.current.editDraft(0, 0, 2, "spans a hunk boundary"));
+    const drafts = makeDrafts();
+    await act(async () => response.resolve({ status: "ok", data: { accepted: false, drafts } }));
+
+    expect(dispatch).toHaveBeenCalledWith({ type: "drafts", drafts });
+    expect(dispatch).toHaveBeenCalledWith({ type: "editRejected" });
+  });
+
+  it("drops a failed draft command silently rather than dispatching a fatal failure", async () => {
+    const dispatch = vi.fn();
+    const response = deferred<unknown>();
+    discardDraft.mockReturnValueOnce(response.promise);
+    const { result } = renderHook(() => useDraftQueue(dispatch));
+
+    act(() => result.current.discardDraft(0, 0));
+    await act(async () =>
+      response.resolve({
+        status: "error",
+        error: { summary: "the session is not ready", detail: null, remediation: null },
+      }),
+    );
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  // A rejected send, not just an error response, must not wedge the queue.
+  it("un-wedges the queue when a send rejects outright", async () => {
+    const dispatch = vi.fn();
+    const failing = deferred<unknown>();
+    editDraft.mockReturnValueOnce(failing.promise);
+    const { result } = renderHook(() => useDraftQueue(dispatch));
+
+    act(() => {
+      result.current.editDraft(0, 0, 0, "a");
+      result.current.editDraft(0, 0, 0, "ab");
+    });
+
+    const next = deferred<unknown>();
+    editDraft.mockReturnValueOnce(next.promise);
+    await act(async () => failing.reject(new Error("IPC channel closed")));
+
+    // The queued edit was still sent: the rejection did not wedge the queue.
+    expect(editDraft).toHaveBeenCalledTimes(2);
+    expect(editDraft).toHaveBeenLastCalledWith(0, 0, 0, "ab");
+    expect(dispatch).not.toHaveBeenCalled();
+
+    await act(async () =>
+      next.resolve({ status: "ok", data: { accepted: true, drafts: makeDrafts() } }),
+    );
+    expect(dispatch).toHaveBeenCalledWith({ type: "drafts", drafts: makeDrafts() });
+  });
+
+  it("reanchor and discard both take the queue path, not sending until earlier work settles", async () => {
+    const dispatch = vi.fn();
+    const inFlightEdit = deferred<unknown>();
+    editDraft.mockReturnValueOnce(inFlightEdit.promise);
+    const { result } = renderHook(() => useDraftQueue(dispatch));
+
+    act(() => {
+      result.current.editDraft(0, 0, 0, "note");
+      result.current.reanchorDraft(0, "src/review.rs", "Right", 42, 3);
+    });
+
+    expect(reanchorDraft).not.toHaveBeenCalled();
+
+    const reanchorResponse = deferred<unknown>();
+    reanchorDraft.mockReturnValueOnce(reanchorResponse.promise);
+    await act(async () =>
+      inFlightEdit.resolve({ status: "ok", data: { accepted: true, drafts: makeDrafts() } }),
+    );
+
+    expect(reanchorDraft).toHaveBeenCalledExactlyOnceWith(0, "src/review.rs", "Right", 42, 3);
+
+    await act(async () => reanchorResponse.resolve({ status: "ok", data: makeDrafts() }));
+  });
+});

--- a/apps/desktop/src/hooks/useDraftQueue.ts
+++ b/apps/desktop/src/hooks/useDraftQueue.ts
@@ -1,0 +1,107 @@
+import { useCallback, useRef } from "react";
+import type { DiffSideDto, DraftsDto } from "../bindings";
+import { commands } from "../bindings";
+import type { SessionAction } from "./sessionReducer";
+
+type DraftCommand =
+  | { kind: "edit"; fileIndex: number; start: number; end: number; body: string }
+  | { kind: "discard"; fileIndex: number; row: number }
+  | { kind: "reanchor"; fileIndex: number; path: string; side: DiffSideDto; line: number; row: number };
+
+function send(command: DraftCommand) {
+  switch (command.kind) {
+    case "edit":
+      return commands.editDraft(command.fileIndex, command.start, command.end, command.body);
+    case "discard":
+      return commands.discardDraft(command.fileIndex, command.row);
+    case "reanchor":
+      return commands.reanchorDraft(
+        command.fileIndex,
+        command.path,
+        command.side,
+        command.line,
+        command.row,
+      );
+  }
+}
+
+/** Whichever `DraftsDto` a settled command hands back, and whether it was accepted. */
+function outcome(command: DraftCommand, data: DraftsDto | { accepted: boolean; drafts: DraftsDto }) {
+  return command.kind === "edit"
+    ? (data as { accepted: boolean; drafts: DraftsDto })
+    : { accepted: true, drafts: data as DraftsDto };
+}
+
+/** Serialises draft edits, discards, and reanchors, at most one in flight, consecutive edits coalescing while a discard or reanchor is always sent in order. */
+export function useDraftQueue(dispatch: (action: SessionAction) => void) {
+  const inFlight = useRef(false);
+  const pending = useRef<DraftCommand[]>([]);
+
+  const settle = useCallback(
+    (command: DraftCommand, data: DraftsDto | { accepted: boolean; drafts: DraftsDto }) => {
+      const { accepted, drafts } = outcome(command, data);
+      dispatch({ type: "drafts", drafts });
+      if (!accepted) {
+        dispatch({ type: "editRejected" });
+      }
+    },
+    [dispatch],
+  );
+
+  const run = useCallback(
+    (command: DraftCommand) => {
+      const advance = () => {
+        inFlight.current = false;
+        const next = pending.current.shift();
+        if (next) {
+          run(next);
+        }
+      };
+      inFlight.current = true;
+      send(command).then((result) => {
+        if (result.status === "ok") {
+          settle(command, result.data);
+        }
+        // A draft-command failure, or a rejected send, is just dropped, never fatal.
+        advance();
+      }, advance);
+    },
+    [settle],
+  );
+
+  const enqueue = useCallback(
+    (command: DraftCommand) => {
+      if (!inFlight.current) {
+        run(command);
+        return;
+      }
+      const queue = pending.current;
+      const last = queue[queue.length - 1];
+      if (command.kind === "edit" && last?.kind === "edit") {
+        queue[queue.length - 1] = command;
+      } else {
+        queue.push(command);
+      }
+    },
+    [run],
+  );
+
+  const editDraft = useCallback(
+    (fileIndex: number, start: number, end: number, body: string) =>
+      enqueue({ kind: "edit", fileIndex, start, end, body }),
+    [enqueue],
+  );
+
+  const discardDraft = useCallback(
+    (fileIndex: number, row: number) => enqueue({ kind: "discard", fileIndex, row }),
+    [enqueue],
+  );
+
+  const reanchorDraft = useCallback(
+    (fileIndex: number, path: string, side: DiffSideDto, line: number, row: number) =>
+      enqueue({ kind: "reanchor", fileIndex, path, side, line, row }),
+    [enqueue],
+  );
+
+  return { editDraft, discardDraft, reanchorDraft };
+}

--- a/apps/desktop/src/hooks/useSession.ts
+++ b/apps/desktop/src/hooks/useSession.ts
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useReducer, useRef } from "react";
 import { Channel } from "@tauri-apps/api/core";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
-import type { SessionFailureDto } from "../bindings";
+import type { DiffSideDto, SessionFailureDto } from "../bindings";
 import { commands } from "../bindings";
 import { clamp } from "../lib/clamp";
 import { initialState, selectionRange, sessionReducer } from "./sessionReducer";
+import { useDraftQueue } from "./useDraftQueue";
 
 /** Narrows a command rejection into a SessionFailureDto. */
 function toFailure(error: unknown): SessionFailureDto {
@@ -25,6 +26,7 @@ export function useSession() {
   const stateRef = useRef(state);
   stateRef.current = state;
   const hasOpened = useRef(false);
+  const draftQueue = useDraftQueue(dispatch);
 
   useEffect(() => {
     if (hasOpened.current) {
@@ -32,23 +34,32 @@ export function useSession() {
     }
     hasOpened.current = true;
 
-    const channel = new Channel<string>();
-    channel.onmessage = (stage) => dispatch({ type: "stage", stage });
+    commands
+      .describeSession()
+      .then((description) => {
+        dispatch({ type: "describe", description });
 
-    commands.openSession(channel).then((opened) => {
-      if (opened.status === "error") {
-        dispatch({ type: "failed", failure: toFailure(opened.error) });
-        return;
-      }
-      const snapshot = opened.data;
-      commands.selectFile(0).then((selected) => {
-        if (selected.status === "error") {
-          dispatch({ type: "failed", failure: toFailure(selected.error) });
-          return;
-        }
-        dispatch({ type: "ready", snapshot, file: selected.data });
+        const channel = new Channel<string>();
+        channel.onmessage = (stage) => dispatch({ type: "stage", stage });
+
+        commands.openSession(channel).then((opened) => {
+          if (opened.status === "error") {
+            dispatch({ type: "failed", failure: toFailure(opened.error) });
+            return;
+          }
+          const snapshot = opened.data;
+          commands.selectFile(0).then((selected) => {
+            if (selected.status === "error") {
+              dispatch({ type: "failed", failure: toFailure(selected.error) });
+              return;
+            }
+            dispatch({ type: "ready", snapshot, file: selected.data });
+          });
+        });
+      })
+      .catch((error: unknown) => {
+        dispatch({ type: "failed", failure: toFailure(error) });
       });
-    });
   }, []);
 
   const selectFile = useCallback((index: number) => {
@@ -73,12 +84,55 @@ export function useSession() {
 
   const clickRow = useCallback((index: number) => dispatch({ type: "click", index }), []);
 
+  const openComposer = useCallback((index: number) => dispatch({ type: "openComposer", index }), []);
+
+  const closeComposer = useCallback(() => dispatch({ type: "closeComposer" }), []);
+
+  /** Persists what the composer holds, over whatever span it was opened on. */
+  const composerChange = useCallback(
+    (body: string) => {
+      const current = stateRef.current;
+      if (current.status !== "ready" || !current.composer) {
+        return;
+      }
+      const [start, end] = current.composer.rows;
+      draftQueue.editDraft(current.drafts.file_index, start, end, body);
+    },
+    [draftQueue],
+  );
+
+  /** Discards the draft the composer is open on, then closes it. */
+  const composerDiscard = useCallback(() => {
+    const current = stateRef.current;
+    if (current.status !== "ready" || !current.composer) {
+      return;
+    }
+    draftQueue.discardDraft(current.drafts.file_index, current.composer.rows[1]);
+    dispatch({ type: "closeComposer" });
+  }, [draftQueue]);
+
+  const reanchorDraft = useCallback(
+    (path: string, side: DiffSideDto, line: number, row: number) => {
+      const current = stateRef.current;
+      if (current.status !== "ready") {
+        return;
+      }
+      draftQueue.reanchorDraft(current.drafts.file_index, path, side, line, row);
+    },
+    [draftQueue],
+  );
+
   useEffect(() => {
     if (state.status !== "ready") {
       return;
     }
 
     function handleKeydown(event: KeyboardEvent) {
+      // The composer is a real text editor, so global shortcuts yield to it entirely.
+      if (event.target instanceof HTMLElement && event.target.closest("[data-composer]")) {
+        return;
+      }
+
       const current = stateRef.current;
       if (current.status !== "ready") {
         return;
@@ -112,6 +166,11 @@ export function useSession() {
         void writeText(text);
         return;
       }
+      if (!event.metaKey && key === "c") {
+        event.preventDefault();
+        dispatch({ type: "toggleComposer" });
+        return;
+      }
       if (!event.metaKey && key === "j") {
         event.preventDefault();
         dispatch({ type: "move", delta: 1, extend: event.shiftKey });
@@ -127,5 +186,14 @@ export function useSession() {
     return () => window.removeEventListener("keydown", handleKeydown);
   }, [state.status, selectFile, toggleViewed]);
 
-  return { state, selectFile, clickRow };
+  return {
+    state,
+    selectFile,
+    clickRow,
+    openComposer,
+    closeComposer,
+    composerChange,
+    composerDiscard,
+    reanchorDraft,
+  };
 }

--- a/apps/desktop/src/test/fixtures.ts
+++ b/apps/desktop/src/test/fixtures.ts
@@ -1,4 +1,13 @@
-import type { FileDetailDto, FileSummaryDto, RowDto, SessionSnapshotDto, SidebarDto } from "../bindings";
+import type {
+  AnchoredDraftDto,
+  DraftsDto,
+  FileDetailDto,
+  FileSummaryDto,
+  RowDto,
+  SessionSnapshotDto,
+  SidebarDto,
+  StaleDraftDto,
+} from "../bindings";
 
 export function makeRow(overrides: Partial<RowDto> = {}): RowDto {
   return {
@@ -8,8 +17,37 @@ export function makeRow(overrides: Partial<RowDto> = {}): RowDto {
     text: "line",
     hunk_header: null,
     thread_count: 0,
-    has_draft: false,
-    draft_is_proposed: false,
+    ...overrides,
+  };
+}
+
+export function makeAnchoredDraft(overrides: Partial<AnchoredDraftDto> = {}): AnchoredDraftDto {
+  return {
+    row: 0,
+    body: "a draft",
+    is_proposed: false,
+    ...overrides,
+  };
+}
+
+export function makeStaleDraft(overrides: Partial<StaleDraftDto> = {}): StaleDraftDto {
+  return {
+    path: "src/review_fixture_00.rs",
+    side: "Right",
+    line: 9999,
+    body: "written last week",
+    location: "was RIGHT line 9999",
+    ...overrides,
+  };
+}
+
+export function makeDrafts(overrides: Partial<DraftsDto> = {}): DraftsDto {
+  return {
+    file_index: 0,
+    anchored: [],
+    stale: [],
+    file_draft_count: 0,
+    write_failure: null,
     ...overrides,
   };
 }
@@ -19,6 +57,8 @@ export function makeFile(overrides: Partial<FileDetailDto> = {}): FileDetailDto 
     index: 0,
     path: "src/review_fixture_00.rs",
     rows: [makeRow()],
+    drafts: makeDrafts(),
+    empty_reason: null,
     ...overrides,
   };
 }
@@ -52,6 +92,7 @@ export function makeSnapshot(overrides: Partial<SessionSnapshotDto> = {}): Sessi
     title: "Generated fixture",
     subtitle: "Diff virtualization demo",
     sidebar: makeSidebar(),
+    warnings: [],
     ...overrides,
   };
 }

--- a/apps/desktop/src/test/setup.ts
+++ b/apps/desktop/src/test/setup.ts
@@ -17,12 +17,58 @@ Object.defineProperty(window, "__TAURI_INTERNALS__", {
   },
 });
 
-// jsdom never lays out elements, so stub the offsets the virtualizer reads.
+// The virtualizer's measureElement ref reads offsetHeight synchronously on
+// mount, regardless of ResizeObserver, so every item needs a plausible one.
+// Test nominals, not layout truth. Kept consistent with estimateSize below.
+const ROW_ITEM_HEIGHT = 20;
+const HUNK_HEADER_ITEM_HEIGHT = 40;
+const COMPOSER_NOMINAL_HEIGHT = 120;
+const DRAFT_CARD_NOMINAL_HEIGHT = 60;
+
 Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
   configurable: true,
-  value: 400,
+  get(this: HTMLElement) {
+    // Every other element keeps the flat stub, e.g. the scroll container.
+    if (!this.classList.contains("diff-list__item")) {
+      return 400;
+    }
+    let height = this.querySelector(".hunk-header") ? HUNK_HEADER_ITEM_HEIGHT : ROW_ITEM_HEIGHT;
+    if (this.querySelector("[data-composer]")) {
+      height += COMPOSER_NOMINAL_HEIGHT;
+    }
+    if (this.querySelector(".draft-card")) {
+      height += DRAFT_CARD_NOMINAL_HEIGHT;
+    }
+    return height;
+  },
 });
 Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
   configurable: true,
   value: 800,
 });
+
+// jsdom has no layout engine, and CodeMirror measures text with these during
+// construction and on every document change.
+const stubRect: DOMRect = {
+  x: 0,
+  y: 0,
+  width: 0,
+  height: 0,
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  toJSON: () => ({}),
+};
+Range.prototype.getClientRects = () => [stubRect] as unknown as DOMRectList;
+Range.prototype.getBoundingClientRect = () => stubRect;
+Element.prototype.getClientRects = () => [stubRect] as unknown as DOMRectList;
+Element.prototype.getBoundingClientRect = () => stubRect;
+
+// jsdom has no ResizeObserver at all; CodeMirror's view and the virtualizer both construct one.
+class NoOpResizeObserver implements ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+window.ResizeObserver = NoOpResizeObserver;

--- a/crates/app/src/session.rs
+++ b/crates/app/src/session.rs
@@ -152,7 +152,9 @@ impl SessionModel {
     ///
     /// Storage is asked to save on every keystroke, which is what makes the text
     /// survive a crash; a sink is required not to block, so this stays cheap.
-    /// Reports whether the span can carry a comment at all.
+    /// Reports whether the span was actually stored, not merely constructible.
+    /// A span whose ends fall in different hunks builds an anchor but is refused
+    /// by `set_draft_over`, and that refusal must reach the caller too.
     pub fn draft_edited(&mut self, rows: RangeInclusive<usize>, body: String) -> bool {
         let Self {
             phase, review_sink, ..
@@ -167,9 +169,11 @@ impl SessionModel {
         let Some(anchor) = review.session.anchor_for_span(file, rows.clone()) else {
             return false;
         };
-        review.session.set_draft_over(file, rows, body);
-        Self::record_draft(review_sink.as_deref(), &review.session, &anchor);
-        true
+        let stored = review.session.set_draft_over(file, rows, body);
+        if stored {
+            Self::record_draft(review_sink.as_deref(), &review.session, &anchor);
+        }
+        stored
     }
 
     /// Removes the draft on a row and tells storage it is gone.
@@ -561,7 +565,8 @@ mod tests {
     use std::sync::{Mutex, atomic::Ordering};
 
     use domain::{
-        DiffFile, DiffSide, FindingProvenance, GuidanceSelection, SessionSource, SubmissionOutcome,
+        ChangeCounts, DiffFile, DiffHunk, DiffLine, DiffLineKind, DiffSide, FileStatus,
+        FindingProvenance, GuidanceSelection, SessionSource, SubmissionOutcome,
     };
 
     use super::*;
@@ -680,6 +685,71 @@ mod tests {
                 head_sha,
             },
             files.into(),
+        )
+        .unwrap()
+    }
+
+    /// A session with one file split across two hunks, so a span crossing them
+    /// can be tested.
+    fn two_hunk_session() -> ReviewSession {
+        let head_sha: Arc<str> = "a".repeat(40).into();
+        let lines = vec![
+            DiffLine {
+                kind: DiffLineKind::Context,
+                old_line: Some(10),
+                new_line: Some(10),
+                text: "a".into(),
+            },
+            DiffLine {
+                kind: DiffLineKind::Addition,
+                old_line: None,
+                new_line: Some(11),
+                text: "b".into(),
+            },
+            DiffLine {
+                kind: DiffLineKind::Context,
+                old_line: Some(80),
+                new_line: Some(80),
+                text: "c".into(),
+            },
+            DiffLine {
+                kind: DiffLineKind::Addition,
+                old_line: None,
+                new_line: Some(81),
+                text: "d".into(),
+            },
+        ];
+        let file = DiffFile {
+            path: "src/review.rs".into(),
+            old_path: None,
+            status: FileStatus::Modified,
+            is_binary: false,
+            hunks: vec![
+                DiffHunk {
+                    header: "@@ -10,1 +10,2 @@".into(),
+                    old_start: 10,
+                    new_start: 10,
+                    line_range: 0..2,
+                },
+                DiffHunk {
+                    header: "@@ -80,1 +80,2 @@".into(),
+                    old_start: 80,
+                    new_start: 80,
+                    line_range: 2..4,
+                },
+            ]
+            .into(),
+            counts: ChangeCounts::of(&lines),
+            lines: lines.into(),
+        };
+        ReviewSession::new(
+            SessionSource::LocalComparison {
+                repository_root: std::path::PathBuf::from("/tmp/repository"),
+                base_sha: Arc::clone(&head_sha),
+                diff_base_sha: Arc::clone(&head_sha),
+                head_sha,
+            },
+            vec![file].into(),
         )
         .unwrap()
     }
@@ -1160,6 +1230,20 @@ mod tests {
         assert_eq!(draft.anchor.start_line, Some(1));
         assert_eq!(draft.anchor.line, 3);
         assert_eq!(session.drafts().len(), 1);
+    }
+
+    /// A span whose ends fall in different hunks builds an anchor but is refused
+    /// by `set_draft_over`; that refusal must reach the caller, not `true`.
+    #[test]
+    fn a_span_crossing_hunks_is_refused_and_stores_nothing() {
+        let sink = RecordingSink::default();
+        let mut model = loaded_model(two_hunk_session(), Some(Box::new(sink.clone())), None);
+
+        // Row 0 is in the first hunk, row 3 in the second.
+        assert!(!model.draft_edited(0..=3, "spans two hunks".to_owned()));
+
+        assert!(review(&model).session().drafts().is_empty());
+        assert!(sink.calls().is_empty(), "nothing should have been written");
     }
 
     /// The point of the whole path: what is written becomes a draft anchored to the


### PR DESCRIPTION
The Tauri desktop app could render a diff but not comment on it. This is stage 3 of the migration recorded in ADR 0001. It wires real local git comparisons into the app and adds the comment composer, with drafts persisted across sessions through the existing store.

What changed:
- Local comparisons open from the command line with merge-base semantics, and the fixture stays the no-argument default
- A CodeMirror Markdown composer with frozen row spans, silent draft prefill, and escape keeping the draft
- Drafts save per keystroke through a serialised queue, survive restarts, and restore as stale with a warning when the head has advanced
- A stale-drafts panel with move-to-row reanchoring, a warnings strip, and panes for binary and empty files
- Draft commands name their target file and apply under a single lock, so an edit racing a file switch is dropped instead of landing on the wrong file
- A small fix in the orchestration crate so a span crossing hunks reports that it was not stored

Notes:
Start with the draft command seams and the queue, since the review effort went into their race behavior. The interactive walk-through has not happened yet; everything is pinned by tests against real temp git repos, but nobody has typed into the composer in a real window, and keystroke latency is unmeasured. A pre-existing reanchor edge case found along the way is filed as #9 and deliberately not fixed here.