### PR TITLE
Open a pull request Session from the desktop binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1726,6 +1726,7 @@ version = "0.1.0"
 dependencies = [
  "app",
  "domain",
+ "github",
  "serde",
  "serde_json",
  "session",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ tauri-build = { version = "=2.6.3", features = [] }
 [dependencies]
 app.workspace = true
 domain.workspace = true
+github.workspace = true
 session.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -405,6 +405,39 @@ mod tests {
         .unwrap()
     }
 
+    /// A pull request session, built directly rather than through `session::load`
+    /// since that would need a live `gh`.
+    fn pull_request_session() -> ReviewSession {
+        let sha: Arc<str> = "a".repeat(40).into();
+        ReviewSession::new(
+            SessionSource::GitHubPullRequest {
+                repository_root: std::path::PathBuf::from("/tmp/repository"),
+                owner: "acme".into(),
+                repository: "widgets".into(),
+                number: 42,
+                title: "Add the widget factory".into(),
+                url: "https://github.com/acme/widgets/pull/42".into(),
+                base_ref: "main".into(),
+                head_ref: "feature".into(),
+                base_sha: Arc::clone(&sha),
+                recorded_base_sha: Arc::clone(&sha),
+                diff_base_sha: Arc::clone(&sha),
+                head_sha: sha,
+            },
+            vec![DiffFile::demo(1)].into(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn snapshot_shows_the_pull_requests_identity_and_title() {
+        let session = pull_request_session();
+        let snapshot = project_snapshot(&session);
+
+        assert_eq!(snapshot.title, "acme/widgets \u{00B7} PR #42");
+        assert_eq!(snapshot.subtitle, "Add the widget factory");
+    }
+
     #[test]
     fn snapshot_projects_the_demo_sidebar() {
         let session = demo_session();

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -405,10 +405,10 @@ mod tests {
         .unwrap()
     }
 
-    /// A pull request session, built directly rather than through `session::load`
-    /// since that would need a live `gh`.
+    /// Built directly rather than through `session::load`, which needs a live `gh`.
     fn pull_request_session() -> ReviewSession {
-        let sha: Arc<str> = "a".repeat(40).into();
+        let base_sha: Arc<str> = "a".repeat(40).into();
+        let head_sha: Arc<str> = "b".repeat(40).into();
         ReviewSession::new(
             SessionSource::GitHubPullRequest {
                 repository_root: std::path::PathBuf::from("/tmp/repository"),
@@ -419,10 +419,10 @@ mod tests {
                 url: "https://github.com/acme/widgets/pull/42".into(),
                 base_ref: "main".into(),
                 head_ref: "feature".into(),
-                base_sha: Arc::clone(&sha),
-                recorded_base_sha: Arc::clone(&sha),
-                diff_base_sha: Arc::clone(&sha),
-                head_sha: sha,
+                base_sha: Arc::clone(&base_sha),
+                recorded_base_sha: base_sha.clone(),
+                diff_base_sha: base_sha,
+                head_sha,
             },
             vec![DiffFile::demo(1)].into(),
         )

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1,10 +1,12 @@
 use std::{env, path::Path, process::ExitCode};
 
+use github::PullRequestSelector;
 use session::{ReviewStorage, SessionRequest};
 
 const USAGE: &str = "usage:
   desktop
-  desktop <repository> <base> [<head>]";
+  desktop <repository> <base> [<head>]
+  desktop pr [<repository>] <number-or-url>";
 
 fn main() -> ExitCode {
     // Only argument parsing happens before the window opens. Everything that can
@@ -26,8 +28,8 @@ fn main() -> ExitCode {
 fn parse_arguments(arguments: &[String]) -> Result<(SessionRequest, ReviewStorage), String> {
     match arguments {
         [] => Ok((SessionRequest::Demo, ReviewStorage::Disabled)),
-        [first, ..] if first == "pr" => {
-            Err("pull requests are not supported by this build".to_owned())
+        [first, rest @ ..] if first == "pr" => {
+            Ok((parse_pull_request(rest)?, ReviewStorage::Default))
         }
         [repository, base] => Ok((
             SessionRequest::LocalComparison {
@@ -46,6 +48,35 @@ fn parse_arguments(arguments: &[String]) -> Result<(SessionRequest, ReviewStorag
             ReviewStorage::Default,
         )),
         _ => Err("expected a repository, base revision, and optional head revision".to_owned()),
+    }
+}
+
+fn parse_pull_request(arguments: &[String]) -> Result<SessionRequest, String> {
+    let (repository, selector) = match arguments {
+        [selector] => (
+            env::current_dir().map_err(|error| error.to_string())?,
+            selector,
+        ),
+        [repository, selector] => (Path::new(repository).to_path_buf(), selector),
+        _ => return Err("expected a pull request number or URL".to_owned()),
+    };
+
+    Ok(SessionRequest::PullRequest {
+        repository,
+        selector: parse_pull_request_selector(selector)?,
+    })
+}
+
+fn parse_pull_request_selector(value: &str) -> Result<PullRequestSelector, String> {
+    if value.starts_with("https://") {
+        Ok(PullRequestSelector::Url(value.to_owned()))
+    } else {
+        value
+            .parse::<u64>()
+            .ok()
+            .filter(|number| *number > 0)
+            .map(PullRequestSelector::Number)
+            .ok_or_else(|| format!("invalid pull request number or URL {value:?}"))
     }
 }
 
@@ -95,13 +126,46 @@ mod tests {
     fn unusable_argument_counts_are_rejected() {
         assert!(parse_arguments(&arguments(&["only-a-repository"])).is_err());
         assert!(parse_arguments(&arguments(&["a", "b", "c", "d"])).is_err());
+        assert!(parse_arguments(&arguments(&["pr"])).is_err());
+        assert!(parse_arguments(&arguments(&["pr", "a", "b", "c"])).is_err());
     }
 
-    /// Pull requests are out of scope for this CLI, so `pr` is intercepted
-    /// before arity matching rather than parsed as a repository name.
     #[test]
-    fn a_pr_argument_is_rejected() {
-        assert!(parse_arguments(&arguments(&["pr"])).is_err());
-        assert!(parse_arguments(&arguments(&["pr", "123"])).is_err());
+    fn parses_pull_request_numbers_and_urls() {
+        assert_eq!(
+            parse_pull_request_selector("42").unwrap(),
+            PullRequestSelector::Number(42),
+        );
+        assert_eq!(
+            parse_pull_request_selector("https://github.com/acme/widgets/pull/42").unwrap(),
+            PullRequestSelector::Url("https://github.com/acme/widgets/pull/42".to_owned()),
+        );
+        assert!(parse_pull_request_selector("0").is_err());
+        assert!(parse_pull_request_selector("not-a-pr").is_err());
+    }
+
+    #[test]
+    fn a_pull_request_takes_an_optional_repository_and_uses_default_storage() {
+        assert_eq!(
+            parse_arguments(&arguments(&["pr", "/tmp/repository", "42"])).unwrap(),
+            (
+                SessionRequest::PullRequest {
+                    repository: Path::new("/tmp/repository").to_path_buf(),
+                    selector: PullRequestSelector::Number(42),
+                },
+                ReviewStorage::Default,
+            ),
+        );
+        // Without a repository the current directory is used, so this only
+        // asserts that the selector and storage survived.
+        let (request, storage) = parse_arguments(&arguments(&["pr", "42"])).unwrap();
+        assert!(matches!(
+            request,
+            SessionRequest::PullRequest {
+                selector: PullRequestSelector::Number(42),
+                ..
+            },
+        ));
+        assert_eq!(storage, ReviewStorage::Default);
     }
 }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -9,8 +9,7 @@ const USAGE: &str = "usage:
   desktop pr [<repository>] <number-or-url>";
 
 fn main() -> ExitCode {
-    // Only argument parsing happens before the window opens. Everything that can
-    // be slow or fail, such as Git, is reported inside the app.
+    // Only argument parsing happens before the window opens. Everything that can be slow or fail, such as Git, gh, or the network, is reported inside the app.
     let (request, storage) = match parse_arguments(&env::args().skip(1).collect::<Vec<_>>()) {
         Ok(parsed) => parsed,
         Err(message) => {
@@ -156,8 +155,6 @@ mod tests {
                 ReviewStorage::Default,
             ),
         );
-        // Without a repository the current directory is used, so this only
-        // asserts that the selector and storage survived.
         let (request, storage) = parse_arguments(&arguments(&["pr", "42"])).unwrap();
         assert!(matches!(
             request,
@@ -167,5 +164,26 @@ mod tests {
             },
         ));
         assert_eq!(storage, ReviewStorage::Default);
+    }
+
+    #[test]
+    fn a_pull_request_repository_accepts_a_url_selector() {
+        assert_eq!(
+            parse_arguments(&arguments(&[
+                "pr",
+                "/tmp/repository",
+                "https://github.com/acme/widgets/pull/42",
+            ]))
+            .unwrap(),
+            (
+                SessionRequest::PullRequest {
+                    repository: Path::new("/tmp/repository").to_path_buf(),
+                    selector: PullRequestSelector::Url(
+                        "https://github.com/acme/widgets/pull/42".to_owned()
+                    ),
+                },
+                ReviewStorage::Default,
+            ),
+        );
     }
 }

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -79,28 +79,6 @@ describe("App", () => {
     );
   });
 
-  it("shows a pull request's own description while it opens", async () => {
-    describeSession.mockResolvedValue("pull request #42");
-    openSession.mockImplementation(() => new Promise(() => {}));
-
-    render(<App />);
-
-    await waitFor(() => expect(screen.getByText(/Opening pull request #42/)).toBeTruthy());
-  });
-
-  it("shows the pull request's identity and title in the header once ready", async () => {
-    openSession.mockResolvedValue({
-      status: "ok",
-      data: makeSnapshot({ title: "acme/widgets · PR #42", subtitle: "Add the widget factory" }),
-    });
-    selectFile.mockResolvedValue({ status: "ok", data: makeFile() });
-
-    render(<App />);
-
-    await waitFor(() => expect(screen.getByText("acme/widgets · PR #42")).toBeTruthy());
-    expect(screen.getByText("Add the widget factory")).toBeTruthy();
-  });
-
   it("shows the failure screen's fields when opening fails", async () => {
     openSession.mockResolvedValue({
       status: "error",

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -79,6 +79,28 @@ describe("App", () => {
     );
   });
 
+  it("shows a pull request's own description while it opens", async () => {
+    describeSession.mockResolvedValue("pull request #42");
+    openSession.mockImplementation(() => new Promise(() => {}));
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText(/Opening pull request #42/)).toBeTruthy());
+  });
+
+  it("shows the pull request's identity and title in the header once ready", async () => {
+    openSession.mockResolvedValue({
+      status: "ok",
+      data: makeSnapshot({ title: "acme/widgets · PR #42", subtitle: "Add the widget factory" }),
+    });
+    selectFile.mockResolvedValue({ status: "ok", data: makeFile() });
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText("acme/widgets · PR #42")).toBeTruthy());
+    expect(screen.getByText("Add the widget factory")).toBeTruthy();
+  });
+
   it("shows the failure screen's fields when opening fails", async () => {
     openSession.mockResolvedValue({
       status: "error",


### PR DESCRIPTION
Closes #14

The desktop binary rejected the pr argument outright, so it could not open a pull request Session even though the loader already supported one. Home cannot open a row without this.

What changed:
- The pr argument shapes from the GPUI binary are accepted, with a number or URL and an optional repository
- A pull request uses the default review storage so drafts persist
- A test pins the pull request header projection in the snapshot

Notes:
Parser parity with the GPUI binary is deliberate duplication until that binary is deleted. Please open a real pull request once to see the loading stages and a failure with remediation, since that could not be screenshotted from an agent session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189um4LrckqAAq5fgnixT1p
