### PR TITLE
Add the Home shell with launch routing and the Repositories footer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1726,15 +1726,18 @@ version = "0.1.0"
 dependencies = [
  "app",
  "domain",
+ "git",
  "github",
  "serde",
  "serde_json",
  "session",
+ "settings",
  "specta",
  "specta-typescript",
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
+ "tauri-plugin-dialog",
  "tauri-specta",
  "tempfile",
 ]
@@ -1820,7 +1823,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2093,7 +2096,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4823,6 +4826,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -5015,7 +5019,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5605,7 +5609,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5985,6 +5989,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6112,7 +6140,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7480,6 +7508,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61854a36651aa48381e5e209f69a01273b77f3f9f91f0c430b1b98d33bd47229"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.19",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de22eef34fd78c0da050e748710edd50bf127e651d02ea1b2bfada1523cc5c51"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.19",
+ "toml 1.1.3+spec-1.1.0",
+ "url",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7620,7 +7690,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8823,7 +8893,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9086,6 +9156,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1726,7 +1726,6 @@ version = "0.1.0"
 dependencies = [
  "app",
  "domain",
- "git",
  "github",
  "serde",
  "serde_json",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,6 +20,7 @@
     "@tanstack/react-virtual": "^3.14.10",
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.3",
+    "@tauri-apps/plugin-dialog": "^2.7.3",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"
   },

--- a/apps/desktop/pnpm-lock.yaml
+++ b/apps/desktop/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@tauri-apps/plugin-clipboard-manager':
         specifier: ^2.3.3
         version: 2.3.3
+      '@tauri-apps/plugin-dialog':
+        specifier: ^2.7.3
+        version: 2.7.3
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -396,6 +399,9 @@ packages:
 
   '@tauri-apps/plugin-clipboard-manager@2.3.3':
     resolution: {integrity: sha512-KnyoTs9gj1yEgDkSPUNjOIOHjJTr5wk8IWcYMOWxYTIJCip6QwlyPW8u2X+6bd6kHM4fAdZNpxoal0gy/TwJbg==}
+
+  '@tauri-apps/plugin-dialog@2.7.3':
+    resolution: {integrity: sha512-CRgE+7TP4tvq9MjBU6f04NLTFIqVMLKHk3hAqlhil00ngK9ACTrXPH3oHpKMProxILodd3YjBoKbMwSI4IEcfA==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -1317,6 +1323,10 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.11.4
 
   '@tauri-apps/plugin-clipboard-manager@2.3.3':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
+
+  '@tauri-apps/plugin-dialog@2.7.3':
     dependencies:
       '@tauri-apps/api': 2.11.1
 

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -18,7 +18,6 @@ tauri-build = { version = "=2.6.3", features = [] }
 [dependencies]
 app.workspace = true
 domain.workspace = true
-git.workspace = true
 github.workspace = true
 session.workspace = true
 settings.workspace = true

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -18,12 +18,15 @@ tauri-build = { version = "=2.6.3", features = [] }
 [dependencies]
 app.workspace = true
 domain.workspace = true
+git.workspace = true
 github.workspace = true
 session.workspace = true
+settings.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tauri = { version = "=2.11.5", features = [] }
 tauri-plugin-clipboard-manager = "=2.3.3"
+tauri-plugin-dialog = "=2.7.3"
 tauri-specta = { version = "=2.0.0-rc.25", features = ["derive", "typescript"] }
 specta = "=2.0.0-rc.25"
 specta-typescript = "=0.0.12"

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -2,5 +2,9 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "windows": ["main"],
-  "permissions": ["core:default", "clipboard-manager:allow-write-text"]
+  "permissions": [
+    "core:default",
+    "clipboard-manager:allow-write-text",
+    "dialog:allow-open"
+  ]
 }

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1,30 +1,82 @@
 //! Tauri commands exposed to the frontend, and the specta builder that types them.
 
-use std::sync::{
-    Mutex,
-    atomic::{AtomicBool, Ordering},
+use std::{
+    path::{Path, PathBuf},
+    sync::{
+        Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
-use app::{SessionPhase, lock};
+use app::{HomeModel, SessionPhase, SettingsWrite, lock};
 use domain::DiffSide;
 use session::{ReviewStorage, SessionRequest};
 use tauri::ipc::Channel;
 use tauri_specta::collect_commands;
 
-use crate::{ManagedSession, dto};
+use crate::{AppRoot, ManagedSession, dto, repositories};
 
 /// The specta builder, shared between the invoke handler and the bindings export.
 #[must_use]
 pub fn specta_builder() -> tauri_specta::Builder<tauri::Wry> {
     tauri_specta::Builder::<tauri::Wry>::new().commands(collect_commands![
+        describe_launch,
+        refresh_home,
+        add_repositories,
+        remove_repository,
+        toggle_repositories_footer,
+        dismiss_refusals,
         open_session,
         select_file,
         toggle_viewed,
-        describe_session,
         edit_draft,
         discard_draft,
         reanchor_draft,
     ])
+}
+
+/// Re-reads the settings file and resolves every clone it lists.
+fn refresh_home_on_model(home: &Mutex<HomeModel>, settings_path: &Path) {
+    let read = repositories::read(settings_path);
+    lock(home).refreshed(read);
+}
+
+/// Adds the folders a reviewer picked, then leaves Home showing the file.
+fn add_repositories_on_model(home: &Mutex<HomeModel>, settings_path: &Path, folders: &[PathBuf]) {
+    let picked = repositories::resolve_picked(folders);
+    let write = lock(home).add_repositories(picked);
+    write_then_refresh(home, settings_path, write);
+}
+
+/// Drops the entry listed at `path`, then leaves Home showing the file.
+fn remove_repository_on_model(home: &Mutex<HomeModel>, settings_path: &Path, path: &Path) {
+    let write = lock(home).remove_repository(path);
+    write_then_refresh(home, settings_path, write);
+}
+
+/// Writes what an action asked for and refreshes from the file it wrote.
+///
+/// The refresh runs whether or not the write worked, so what Home shows is
+/// always what the file actually holds. A write that failed is reported after
+/// it, since the refresh clears the last failure.
+fn write_then_refresh(home: &Mutex<HomeModel>, settings_path: &Path, write: Option<SettingsWrite>) {
+    let written = write.map(|write| repositories::write(settings_path, write.repositories));
+    refresh_home_on_model(home, settings_path);
+    if let Some(Err(failure)) = written {
+        lock(home).failed(failure);
+    }
+}
+
+/// Runs `action` against the settings file, then projects what Home now shows.
+///
+/// A machine with no home directory has nowhere to keep the file, which is a
+/// whole-Home failure rather than something an action can work around.
+fn on_settings_file(home: &Mutex<HomeModel>, action: impl FnOnce(&Path)) -> dto::HomeSnapshotDto {
+    match repositories::settings_path() {
+        Ok(path) => action(&path),
+        Err(failure) => lock(home).refreshed(Err(failure)),
+    }
+    dto::project_home(&lock(home))
 }
 
 /// Loads `request` into `model`, reporting each stage's label to `report`.
@@ -236,13 +288,14 @@ fn reanchor_draft_on_model(
 #[specta::specta]
 #[allow(clippy::needless_pass_by_value)]
 pub async fn open_session(
-    state: tauri::State<'_, ManagedSession>,
+    state: tauri::State<'_, AppRoot>,
     on_stage: Channel<String>,
 ) -> Result<dto::SessionSnapshotDto, dto::SessionFailureDto> {
-    let model = std::sync::Arc::clone(&state.model);
-    let load_started = std::sync::Arc::clone(&state.load_started);
-    let request = state.request.clone();
-    let storage = state.storage.clone();
+    let session = session(&state)?;
+    let model = std::sync::Arc::clone(&session.model);
+    let load_started = std::sync::Arc::clone(&session.load_started);
+    let request = session.request.clone();
+    let storage = session.storage.clone();
     tauri::async_runtime::spawn_blocking(move || {
         load_if_pending(&model, &load_started, &request, &storage, &|stage| {
             let _ = on_stage.send(stage.to_owned());
@@ -251,7 +304,7 @@ pub async fn open_session(
     .await
     .expect("the load task should not panic");
 
-    let guard = lock(&state.model);
+    let guard = lock(&session.model);
     match guard.phase() {
         SessionPhase::Ready(review) => Ok(dto::project_snapshot(review.session())),
         SessionPhase::Failed(failure) => Err(failure.into()),
@@ -261,17 +314,98 @@ pub async fn open_session(
     }
 }
 
-/// The request's own description, shown by the loading screen before anything
-/// about the target session is known.
+/// Re-reads the settings file and resolves every clone it lists.
+///
+/// Runs when Home opens, after an Add or a Remove, and on `r`. A settings file
+/// that cannot be read comes back as the snapshot's failure rather than as a
+/// command error, because the header and footer stay on screen either way.
+#[tauri::command(async)]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn refresh_home(state: tauri::State<'_, AppRoot>) -> dto::HomeSnapshotDto {
+    on_settings_file(&state.home, |path| {
+        refresh_home_on_model(&state.home, path);
+    })
+}
+
+/// Adds the folders the reviewer picked, writing the file once and refreshing.
+///
+/// A folder that is not a clone of a GitHub repository is refused with its
+/// reason while the rest proceed, and one already listed is ignored.
+#[tauri::command(async)]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn add_repositories(
+    state: tauri::State<'_, AppRoot>,
+    folders: Vec<String>,
+) -> dto::HomeSnapshotDto {
+    let folders = folders.into_iter().map(PathBuf::from).collect::<Vec<_>>();
+    on_settings_file(&state.home, |path| {
+        add_repositories_on_model(&state.home, path, &folders);
+    })
+}
+
+/// Drops one configured clone, writing the file and refreshing.
+#[tauri::command(async)]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn remove_repository(state: tauri::State<'_, AppRoot>, path: String) -> dto::HomeSnapshotDto {
+    let path = PathBuf::from(path);
+    on_settings_file(&state.home, |settings_path| {
+        remove_repository_on_model(&state.home, settings_path, &path);
+    })
+}
+
+/// Opens or closes the Repositories footer.
 #[tauri::command]
 #[specta::specta]
 #[allow(clippy::needless_pass_by_value)]
-pub fn describe_session(state: tauri::State<'_, ManagedSession>) -> String {
-    describe_session_on_request(&state.request)
+pub fn toggle_repositories_footer(state: tauri::State<'_, AppRoot>) -> dto::HomeSnapshotDto {
+    lock(&state.home).toggle_footer();
+    dto::project_home(&lock(&state.home))
 }
 
-fn describe_session_on_request(request: &SessionRequest) -> String {
-    request.description()
+/// Clears the refusals the last Add reported.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn dismiss_refusals(state: tauri::State<'_, AppRoot>) -> dto::HomeSnapshotDto {
+    lock(&state.home).dismiss_refusals();
+    dto::project_home(&lock(&state.home))
+}
+
+/// Which screen the binary was launched into, asked once before anything is
+/// rendered.
+///
+/// A Session carries its request's own description, which is all the loading
+/// screen can say before the load reaches the pull request itself.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn describe_launch(state: tauri::State<'_, AppRoot>) -> dto::LaunchDto {
+    describe_launch_on_root(&state)
+}
+
+fn describe_launch_on_root(root: &AppRoot) -> dto::LaunchDto {
+    match &root.session {
+        Some(session) => dto::LaunchDto::Session {
+            description: session.request.description(),
+        },
+        None => dto::LaunchDto::Home,
+    }
+}
+
+/// The Session behind the commands that need one.
+///
+/// Absent on a Home launch, where the frontend never calls them, so a call that
+/// arrives anyway is answered rather than assumed away.
+fn session<'a>(
+    state: &'a tauri::State<'_, AppRoot>,
+) -> Result<&'a ManagedSession, dto::SessionFailureDto> {
+    state
+        .session
+        .as_ref()
+        .ok_or_else(|| dto::command_failure("no session is open"))
 }
 
 /// Switches the displayed file and returns its rows.
@@ -283,10 +417,10 @@ fn describe_session_on_request(request: &SessionRequest) -> String {
 #[specta::specta]
 #[allow(clippy::needless_pass_by_value)]
 pub async fn select_file(
-    state: tauri::State<'_, ManagedSession>,
+    state: tauri::State<'_, AppRoot>,
     index: u32,
 ) -> Result<dto::FileDetailDto, dto::SessionFailureDto> {
-    select_file_on_model(&state.model, index as usize)
+    select_file_on_model(&session(&state)?.model, index as usize)
 }
 
 /// Marks the selected file viewed, or unmarks it, and returns the fresh sidebar.
@@ -298,9 +432,9 @@ pub async fn select_file(
 #[specta::specta]
 #[allow(clippy::needless_pass_by_value)]
 pub fn toggle_viewed(
-    state: tauri::State<'_, ManagedSession>,
+    state: tauri::State<'_, AppRoot>,
 ) -> Result<dto::SidebarDto, dto::SessionFailureDto> {
-    toggle_viewed_on_model(&state.model)
+    toggle_viewed_on_model(&session(&state)?.model)
 }
 
 /// Edits the draft over rows `start..=end` of `file_index`. Persists the new
@@ -316,14 +450,14 @@ pub fn toggle_viewed(
 #[specta::specta]
 #[allow(clippy::needless_pass_by_value)]
 pub fn edit_draft(
-    state: tauri::State<'_, ManagedSession>,
+    state: tauri::State<'_, AppRoot>,
     file_index: u32,
     start: u32,
     end: u32,
     body: String,
 ) -> Result<dto::DraftEditOutcomeDto, dto::SessionFailureDto> {
     edit_draft_on_model(
-        &state.model,
+        &session(&state)?.model,
         file_index as usize,
         start as usize,
         end as usize,
@@ -340,11 +474,11 @@ pub fn edit_draft(
 #[specta::specta]
 #[allow(clippy::needless_pass_by_value)]
 pub fn discard_draft(
-    state: tauri::State<'_, ManagedSession>,
+    state: tauri::State<'_, AppRoot>,
     file_index: u32,
     row: u32,
 ) -> Result<dto::DraftsDto, dto::SessionFailureDto> {
-    discard_draft_on_model(&state.model, file_index as usize, row as usize)
+    discard_draft_on_model(&session(&state)?.model, file_index as usize, row as usize)
 }
 
 /// Moves a stale draft, named by the position it was written against, onto
@@ -358,7 +492,7 @@ pub fn discard_draft(
 #[specta::specta]
 #[allow(clippy::needless_pass_by_value)]
 pub fn reanchor_draft(
-    state: tauri::State<'_, ManagedSession>,
+    state: tauri::State<'_, AppRoot>,
     file_index: u32,
     path: String,
     side: dto::DiffSideDto,
@@ -366,7 +500,7 @@ pub fn reanchor_draft(
     row: u32,
 ) -> Result<dto::DraftsDto, dto::SessionFailureDto> {
     reanchor_draft_on_model(
-        &state.model,
+        &session(&state)?.model,
         file_index as usize,
         &path,
         side.into(),
@@ -614,14 +748,173 @@ mod tests {
     }
 
     #[test]
-    fn describe_session_on_request_defers_to_the_requests_own_description() {
+    fn a_session_launch_is_described_by_its_own_request() {
         let request = SessionRequest::LocalComparison {
             repository: Path::new("/tmp/repository").to_path_buf(),
             base: "main".to_owned(),
             head: "feature".to_owned(),
         };
+        let root = AppRoot {
+            home: Arc::new(Mutex::new(HomeModel::new())),
+            session: Some(ManagedSession {
+                model: Arc::new(Mutex::new(app::SessionModel::loading(
+                    request.description(),
+                ))),
+                request: request.clone(),
+                storage: ReviewStorage::Disabled,
+                load_started: Arc::new(AtomicBool::new(false)),
+            }),
+        };
 
-        assert_eq!(describe_session_on_request(&request), request.description());
+        assert_eq!(
+            describe_launch_on_root(&root),
+            dto::LaunchDto::Session {
+                description: request.description(),
+            },
+        );
+    }
+
+    #[test]
+    fn a_launch_with_no_session_is_described_as_home() {
+        let root = AppRoot {
+            home: Arc::new(Mutex::new(HomeModel::new())),
+            session: None,
+        };
+
+        assert_eq!(describe_launch_on_root(&root), dto::LaunchDto::Home);
+    }
+
+    /// A clone whose `origin` points at GitHub, which is what Home configures.
+    fn clone_of(slug: &str) -> TempDir {
+        let directory = TempDir::new().unwrap();
+        git(directory.path(), ["init", "--quiet"]);
+        git(
+            directory.path(),
+            [
+                "remote",
+                "add",
+                "origin",
+                &format!("https://github.com/{slug}.git"),
+            ],
+        );
+        directory
+    }
+
+    fn home_model() -> Mutex<app::HomeModel> {
+        Mutex::new(app::HomeModel::new())
+    }
+
+    /// The repository paths the settings file now holds.
+    fn listed(settings_path: &Path) -> Vec<std::path::PathBuf> {
+        settings::load(settings_path).unwrap().repositories
+    }
+
+    #[test]
+    fn refreshing_home_reads_the_settings_file_every_time() {
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = directory.path().join("settings.toml");
+        let home = home_model();
+
+        refresh_home_on_model(&home, &settings_path);
+        assert!(lock(&home).repositories().is_empty());
+
+        std::fs::write(
+            &settings_path,
+            format!(
+                "repositories = [{:?}]\n",
+                clone.path().display().to_string()
+            ),
+        )
+        .unwrap();
+        refresh_home_on_model(&home, &settings_path);
+
+        let guard = lock(&home);
+        assert_eq!(guard.repositories().len(), 1, "a hand edit is picked up");
+        assert_eq!(guard.repositories()[0].slug(), Some("acme/widgets"));
+    }
+
+    #[test]
+    fn adding_a_clone_writes_the_file_and_lists_it() {
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = directory.path().join("settings.toml");
+        let home = home_model();
+
+        add_repositories_on_model(&home, &settings_path, &[clone.path().to_path_buf()]);
+
+        assert_eq!(listed(&settings_path).len(), 1);
+        assert_eq!(lock(&home).repositories()[0].slug(), Some("acme/widgets"));
+    }
+
+    #[test]
+    fn adding_a_folder_that_is_not_a_clone_refuses_it_and_writes_nothing() {
+        let not_a_clone = TempDir::new().unwrap();
+        let directory = TempDir::new().unwrap();
+        let settings_path = directory.path().join("settings.toml");
+        let home = home_model();
+
+        add_repositories_on_model(&home, &settings_path, &[not_a_clone.path().to_path_buf()]);
+
+        assert!(
+            !settings_path.exists(),
+            "nothing was accepted, so the file is never touched",
+        );
+        let guard = lock(&home);
+        assert_eq!(guard.refusals().len(), 1);
+        assert_eq!(guard.refusals()[0].reason, "not a Git repository");
+    }
+
+    #[test]
+    fn removing_a_repository_writes_the_file_without_it() {
+        let first = clone_of("acme/widgets");
+        let second = clone_of("acme/billing");
+        let directory = TempDir::new().unwrap();
+        let settings_path = directory.path().join("settings.toml");
+        let home = home_model();
+        add_repositories_on_model(
+            &home,
+            &settings_path,
+            &[first.path().to_path_buf(), second.path().to_path_buf()],
+        );
+        let listed_first = lock(&home).repositories()[0].path.clone();
+
+        remove_repository_on_model(&home, &settings_path, &listed_first);
+
+        assert_eq!(listed(&settings_path).len(), 1);
+        assert_eq!(lock(&home).repositories()[0].slug(), Some("acme/billing"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_settings_file_that_cannot_be_written_is_reported_with_the_list_still_standing() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = directory.path().join("settings.toml");
+        let home = home_model();
+        add_repositories_on_model(&home, &settings_path, &[clone.path().to_path_buf()]);
+        // Readable, so the refresh that follows still finds the clone, but not
+        // writable, so the second Add cannot record anything.
+        std::fs::set_permissions(&settings_path, std::fs::Permissions::from_mode(0o444)).unwrap();
+
+        let second = clone_of("acme/billing");
+        add_repositories_on_model(&home, &settings_path, &[second.path().to_path_buf()]);
+
+        let guard = lock(&home);
+        assert_eq!(
+            guard
+                .failure()
+                .expect("the write failure should be shown")
+                .summary,
+            "Home could not save your settings",
+        );
+        assert_eq!(
+            guard.repositories().len(),
+            1,
+            "the clone that is configured is still listed",
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -8,13 +8,13 @@ use std::{
     },
 };
 
-use app::{HomeModel, SessionPhase, SettingsWrite, lock};
+use app::{SessionPhase, SettingsWrite, lock};
 use domain::DiffSide;
 use session::{ReviewStorage, SessionRequest};
 use tauri::ipc::Channel;
 use tauri_specta::collect_commands;
 
-use crate::{AppRoot, ManagedSession, dto, repositories};
+use crate::{AppRoot, ManagedHome, ManagedSession, dto, repositories};
 
 /// The specta builder, shared between the invoke handler and the bindings export.
 #[must_use]
@@ -25,7 +25,6 @@ pub fn specta_builder() -> tauri_specta::Builder<tauri::Wry> {
         add_repositories,
         remove_repository,
         toggle_repositories_footer,
-        dismiss_refusals,
         open_session,
         select_file,
         toggle_viewed,
@@ -36,47 +35,72 @@ pub fn specta_builder() -> tauri_specta::Builder<tauri::Wry> {
 }
 
 /// Re-reads the settings file and resolves every clone it lists.
-fn refresh_home_on_model(home: &Mutex<HomeModel>, settings_path: &Path) {
-    let read = repositories::read(settings_path);
-    lock(home).refreshed(read);
+fn refresh_home_on_model(home: &ManagedHome, settings_path: &Path) {
+    let _ordered = lock(&home.settings_action);
+    read_into_model(home, settings_path);
 }
 
 /// Adds the folders a reviewer picked, then leaves Home showing the file.
-fn add_repositories_on_model(home: &Mutex<HomeModel>, settings_path: &Path, folders: &[PathBuf]) {
+fn add_repositories_on_model(home: &ManagedHome, settings_path: &Path, folders: &[PathBuf]) {
+    let _ordered = lock(&home.settings_action);
     let picked = repositories::resolve_picked(folders);
-    let write = lock(home).add_repositories(picked);
-    write_then_refresh(home, settings_path, write);
+    let write = lock(&home.model).add_repositories(settings_path, picked);
+    write_then_read(home, settings_path, write);
 }
 
 /// Drops the entry listed at `path`, then leaves Home showing the file.
-fn remove_repository_on_model(home: &Mutex<HomeModel>, settings_path: &Path, path: &Path) {
-    let write = lock(home).remove_repository(path);
-    write_then_refresh(home, settings_path, write);
+fn remove_repository_on_model(home: &ManagedHome, settings_path: &Path, path: &Path) {
+    let _ordered = lock(&home.settings_action);
+    let write = lock(&home.model).remove_repository(settings_path, path);
+    write_then_read(home, settings_path, write);
 }
 
-/// Writes what an action asked for and refreshes from the file it wrote.
+/// Reads the settings file into the model. The caller holds the action guard.
+fn read_into_model(home: &ManagedHome, settings_path: &Path) {
+    let read = repositories::read(settings_path);
+    lock(&home.model).refreshed(read);
+}
+
+/// Writes what an action asked for and reads back the file it wrote.
 ///
-/// The refresh runs whether or not the write worked, so what Home shows is
-/// always what the file actually holds. A write that failed is reported after
-/// it, since the refresh clears the last failure.
-fn write_then_refresh(home: &Mutex<HomeModel>, settings_path: &Path, write: Option<SettingsWrite>) {
-    let written = write.map(|write| repositories::write(settings_path, write.repositories));
-    refresh_home_on_model(home, settings_path);
-    if let Some(Err(failure)) = written {
-        lock(home).failed(failure);
+/// The read runs whether or not the write worked, so what Home shows is always
+/// what the file actually holds. A write that failed is its own line above the
+/// list rather than a screen in front of it.
+fn write_then_read(home: &ManagedHome, settings_path: &Path, write: Option<SettingsWrite>) {
+    if let Some(write) = write {
+        let written = repositories::write(settings_path, write.repositories);
+        lock(&home.model).write_finished(written);
     }
+    read_into_model(home, settings_path);
 }
 
 /// Runs `action` against the settings file, then projects what Home now shows.
 ///
 /// A machine with no home directory has nowhere to keep the file, which is a
 /// whole-Home failure rather than something an action can work around.
-fn on_settings_file(home: &Mutex<HomeModel>, action: impl FnOnce(&Path)) -> dto::HomeSnapshotDto {
+fn on_settings_file(
+    home: &ManagedHome,
+    action: impl FnOnce(&ManagedHome, &Path),
+) -> dto::HomeSnapshotDto {
     match repositories::settings_path() {
-        Ok(path) => action(&path),
-        Err(failure) => lock(home).refreshed(Err(failure)),
+        Ok(path) => action(home, &path),
+        Err(failure) => lock(&home.model).refreshed(Err(failure)),
     }
-    dto::project_home(&lock(home))
+    dto::project_home(&lock(&home.model))
+}
+
+/// Runs Home's file and Git work away from the UI thread.
+///
+/// The only failure is the task not finishing at all, which the frontend shows
+/// rather than waiting on a promise that will never settle.
+async fn off_the_ui_thread(
+    work: impl FnOnce() -> dto::HomeSnapshotDto + Send + 'static,
+) -> Result<dto::HomeSnapshotDto, dto::SessionFailureDto> {
+    tauri::async_runtime::spawn_blocking(work)
+        .await
+        .map_err(|error| {
+            dto::command_failure(format!("Home could not finish that action: {error}"))
+        })
 }
 
 /// Loads `request` into `model`, reporting each stage's label to `report`.
@@ -317,43 +341,67 @@ pub async fn open_session(
 /// Re-reads the settings file and resolves every clone it lists.
 ///
 /// Runs when Home opens, after an Add or a Remove, and on `r`. A settings file
-/// that cannot be read comes back as the snapshot's failure rather than as a
-/// command error, because the header and footer stay on screen either way.
-#[tauri::command(async)]
+/// that cannot be read comes back inside the snapshot rather than as a command
+/// error, because the header and footer stay on screen either way.
+///
+/// # Errors
+///
+/// Returns a failure when the task doing the reading does not finish.
+#[tauri::command]
 #[specta::specta]
 #[allow(clippy::needless_pass_by_value)]
-pub fn refresh_home(state: tauri::State<'_, AppRoot>) -> dto::HomeSnapshotDto {
-    on_settings_file(&state.home, |path| {
-        refresh_home_on_model(&state.home, path);
-    })
+pub async fn refresh_home(
+    state: tauri::State<'_, AppRoot>,
+) -> Result<dto::HomeSnapshotDto, dto::SessionFailureDto> {
+    let home = state.home.clone();
+    off_the_ui_thread(move || on_settings_file(&home, refresh_home_on_model)).await
 }
 
 /// Adds the folders the reviewer picked, writing the file once and refreshing.
 ///
 /// A folder that is not a clone of a GitHub repository is refused with its
 /// reason while the rest proceed, and one already listed is ignored.
-#[tauri::command(async)]
+///
+/// # Errors
+///
+/// Returns a failure when the task doing the work does not finish.
+#[tauri::command]
 #[specta::specta]
 #[allow(clippy::needless_pass_by_value)]
-pub fn add_repositories(
+pub async fn add_repositories(
     state: tauri::State<'_, AppRoot>,
     folders: Vec<String>,
-) -> dto::HomeSnapshotDto {
+) -> Result<dto::HomeSnapshotDto, dto::SessionFailureDto> {
+    let home = state.home.clone();
     let folders = folders.into_iter().map(PathBuf::from).collect::<Vec<_>>();
-    on_settings_file(&state.home, |path| {
-        add_repositories_on_model(&state.home, path, &folders);
+    off_the_ui_thread(move || {
+        on_settings_file(&home, |home, path| {
+            add_repositories_on_model(home, path, &folders);
+        })
     })
+    .await
 }
 
 /// Drops one configured clone, writing the file and refreshing.
-#[tauri::command(async)]
+///
+/// # Errors
+///
+/// Returns a failure when the task doing the work does not finish.
+#[tauri::command]
 #[specta::specta]
 #[allow(clippy::needless_pass_by_value)]
-pub fn remove_repository(state: tauri::State<'_, AppRoot>, path: String) -> dto::HomeSnapshotDto {
+pub async fn remove_repository(
+    state: tauri::State<'_, AppRoot>,
+    path: String,
+) -> Result<dto::HomeSnapshotDto, dto::SessionFailureDto> {
+    let home = state.home.clone();
     let path = PathBuf::from(path);
-    on_settings_file(&state.home, |settings_path| {
-        remove_repository_on_model(&state.home, settings_path, &path);
+    off_the_ui_thread(move || {
+        on_settings_file(&home, |home, settings_path| {
+            remove_repository_on_model(home, settings_path, &path);
+        })
     })
+    .await
 }
 
 /// Opens or closes the Repositories footer.
@@ -361,17 +409,8 @@ pub fn remove_repository(state: tauri::State<'_, AppRoot>, path: String) -> dto:
 #[specta::specta]
 #[allow(clippy::needless_pass_by_value)]
 pub fn toggle_repositories_footer(state: tauri::State<'_, AppRoot>) -> dto::HomeSnapshotDto {
-    lock(&state.home).toggle_footer();
-    dto::project_home(&lock(&state.home))
-}
-
-/// Clears the refusals the last Add reported.
-#[tauri::command]
-#[specta::specta]
-#[allow(clippy::needless_pass_by_value)]
-pub fn dismiss_refusals(state: tauri::State<'_, AppRoot>) -> dto::HomeSnapshotDto {
-    lock(&state.home).dismiss_refusals();
-    dto::project_home(&lock(&state.home))
+    lock(&state.home.model).toggle_footer();
+    dto::project_home(&lock(&state.home.model))
 }
 
 /// Which screen the binary was launched into, asked once before anything is
@@ -755,7 +794,7 @@ mod tests {
             head: "feature".to_owned(),
         };
         let root = AppRoot {
-            home: Arc::new(Mutex::new(HomeModel::new())),
+            home: ManagedHome::new(),
             session: Some(ManagedSession {
                 model: Arc::new(Mutex::new(app::SessionModel::loading(
                     request.description(),
@@ -777,7 +816,7 @@ mod tests {
     #[test]
     fn a_launch_with_no_session_is_described_as_home() {
         let root = AppRoot {
-            home: Arc::new(Mutex::new(HomeModel::new())),
+            home: ManagedHome::new(),
             session: None,
         };
 
@@ -800,8 +839,13 @@ mod tests {
         directory
     }
 
-    fn home_model() -> Mutex<app::HomeModel> {
-        Mutex::new(app::HomeModel::new())
+    fn home_model() -> ManagedHome {
+        ManagedHome::new()
+    }
+
+    /// What Home shows once an action has finished.
+    fn snapshot(home: &ManagedHome) -> dto::HomeSnapshotDto {
+        dto::project_home(&lock(&home.model))
     }
 
     /// The repository paths the settings file now holds.
@@ -817,7 +861,7 @@ mod tests {
         let home = home_model();
 
         refresh_home_on_model(&home, &settings_path);
-        assert!(lock(&home).repositories().is_empty());
+        assert!(lock(&home.model).repositories().is_empty());
 
         std::fs::write(
             &settings_path,
@@ -829,7 +873,7 @@ mod tests {
         .unwrap();
         refresh_home_on_model(&home, &settings_path);
 
-        let guard = lock(&home);
+        let guard = lock(&home.model);
         assert_eq!(guard.repositories().len(), 1, "a hand edit is picked up");
         assert_eq!(guard.repositories()[0].slug(), Some("acme/widgets"));
     }
@@ -844,7 +888,10 @@ mod tests {
         add_repositories_on_model(&home, &settings_path, &[clone.path().to_path_buf()]);
 
         assert_eq!(listed(&settings_path).len(), 1);
-        assert_eq!(lock(&home).repositories()[0].slug(), Some("acme/widgets"));
+        assert_eq!(
+            lock(&home.model).repositories()[0].slug(),
+            Some("acme/widgets")
+        );
     }
 
     #[test]
@@ -860,7 +907,7 @@ mod tests {
             !settings_path.exists(),
             "nothing was accepted, so the file is never touched",
         );
-        let guard = lock(&home);
+        let guard = lock(&home.model);
         assert_eq!(guard.refusals().len(), 1);
         assert_eq!(guard.refusals()[0].reason, "not a Git repository");
     }
@@ -877,17 +924,20 @@ mod tests {
             &settings_path,
             &[first.path().to_path_buf(), second.path().to_path_buf()],
         );
-        let listed_first = lock(&home).repositories()[0].path.clone();
+        let listed_first = lock(&home.model).repositories()[0].path.clone();
 
         remove_repository_on_model(&home, &settings_path, &listed_first);
 
         assert_eq!(listed(&settings_path).len(), 1);
-        assert_eq!(lock(&home).repositories()[0].slug(), Some("acme/billing"));
+        assert_eq!(
+            lock(&home.model).repositories()[0].slug(),
+            Some("acme/billing")
+        );
     }
 
     #[cfg(unix)]
     #[test]
-    fn a_settings_file_that_cannot_be_written_is_reported_with_the_list_still_standing() {
+    fn a_settings_file_that_cannot_be_written_is_a_line_above_a_list_that_stays() {
         use std::os::unix::fs::PermissionsExt;
 
         let clone = clone_of("acme/widgets");
@@ -902,18 +952,99 @@ mod tests {
         let second = clone_of("acme/billing");
         add_repositories_on_model(&home, &settings_path, &[second.path().to_path_buf()]);
 
-        let guard = lock(&home);
+        let shown = snapshot(&home);
         assert_eq!(
-            guard
-                .failure()
+            shown
+                .write_failure
                 .expect("the write failure should be shown")
                 .summary,
             "Home could not save your settings",
         );
+        assert!(
+            shown.failure.is_none(),
+            "a write failure never replaces the list",
+        );
         assert_eq!(
-            guard.repositories().len(),
+            shown.repositories.len(),
             1,
             "the clone that is configured is still listed",
+        );
+    }
+
+    /// A write replaces the whole file, so writing over one Home could not parse
+    /// would drop every repository it never managed to read.
+    #[test]
+    fn adding_over_a_malformed_settings_file_leaves_the_file_exactly_as_it_was() {
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = directory.path().join("settings.toml");
+        let malformed = "repositories = [this is not valid toml";
+        std::fs::write(&settings_path, malformed).unwrap();
+        let home = home_model();
+        refresh_home_on_model(&home, &settings_path);
+
+        add_repositories_on_model(&home, &settings_path, &[clone.path().to_path_buf()]);
+
+        assert_eq!(
+            std::fs::read_to_string(&settings_path).unwrap(),
+            malformed,
+            "the file a reviewer has to fix must survive the attempt",
+        );
+        let shown = snapshot(&home);
+        assert_eq!(shown.refusals.len(), 1);
+        assert_eq!(shown.refusals[0].path, settings_path.display().to_string());
+        assert_eq!(
+            shown.refusals[0].reason,
+            "fix this file before changing your repositories",
+        );
+    }
+
+    #[test]
+    fn removing_over_a_malformed_settings_file_leaves_the_file_exactly_as_it_was() {
+        let directory = TempDir::new().unwrap();
+        let settings_path = directory.path().join("settings.toml");
+        let malformed = "repositories = [this is not valid toml";
+        std::fs::write(&settings_path, malformed).unwrap();
+        let home = home_model();
+        refresh_home_on_model(&home, &settings_path);
+
+        remove_repository_on_model(&home, &settings_path, Path::new("/Developer/zreview"));
+
+        assert_eq!(std::fs::read_to_string(&settings_path).unwrap(), malformed,);
+    }
+
+    /// Two clicks landing together must not read the same list twice and write
+    /// back one that still holds the entry the other removed.
+    #[test]
+    fn two_concurrent_removes_leave_neither_entry_in_the_file() {
+        let first = clone_of("acme/widgets");
+        let second = clone_of("acme/billing");
+        let directory = TempDir::new().unwrap();
+        let settings_path = directory.path().join("settings.toml");
+        let home = home_model();
+        add_repositories_on_model(
+            &home,
+            &settings_path,
+            &[first.path().to_path_buf(), second.path().to_path_buf()],
+        );
+        let paths = lock(&home.model)
+            .repositories()
+            .iter()
+            .map(|entry| entry.path.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(paths.len(), 2);
+
+        thread::scope(|scope| {
+            for path in &paths {
+                let home = &home;
+                let settings_path = &settings_path;
+                scope.spawn(move || remove_repository_on_model(home, settings_path, path));
+            }
+        });
+
+        assert!(
+            listed(&settings_path).is_empty(),
+            "one remove read a list the other had already changed",
         );
     }
 

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -227,10 +227,10 @@ pub struct HomeRepositoryDto {
     pub failure: Option<String>,
 }
 
-/// A picked folder Home would not add, and why.
+/// Something Home would not do, and why.
 #[derive(Clone, Debug, Serialize, specta::Type)]
-pub struct AddRefusalDto {
-    pub folder: String,
+pub struct RefusalDto {
+    pub path: String,
     pub reason: String,
 }
 
@@ -243,10 +243,13 @@ pub struct HomeSnapshotDto {
     pub repositories: Vec<HomeRepositoryDto>,
     pub footer_summary: String,
     pub footer_expanded: bool,
-    pub refusals: Vec<AddRefusalDto>,
+    pub refusals: Vec<RefusalDto>,
     /// What replaces the list area when Home cannot read its repositories. The
     /// header and footer stay either way, so Add still works.
     pub failure: Option<SessionFailureDto>,
+    /// Why the last write did not reach the file, shown as a line above the
+    /// list, which stays because reading it still worked.
+    pub write_failure: Option<SessionFailureDto>,
 }
 
 /// Everything Home shows, from the model that decided it.
@@ -279,12 +282,13 @@ pub fn project_home(home: &app::HomeModel) -> HomeSnapshotDto {
         refusals: home
             .refusals()
             .iter()
-            .map(|refusal| AddRefusalDto {
-                folder: refusal.folder.display().to_string(),
+            .map(|refusal| RefusalDto {
+                path: refusal.path.display().to_string(),
                 reason: refusal.reason.clone(),
             })
             .collect(),
         failure: home.failure().map(Into::into),
+        write_failure: home.write_failure().map(Into::into),
     }
 }
 
@@ -718,7 +722,10 @@ mod tests {
             Some("the folder no longer exists")
         );
         assert_eq!(snapshot.footer_summary, "2 repositories \u{b7} 1 failed");
-        assert_eq!(snapshot.count_line.as_deref(), Some("2 repositories"));
+        assert_eq!(
+            snapshot.count_line.as_deref(),
+            Some("0 pull requests across 2 repositories"),
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -54,6 +54,13 @@ impl From<DiffLineKind> for DiffLineKindDto {
     }
 }
 
+/// Which screen the binary was launched into.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, specta::Type)]
+pub enum LaunchDto {
+    Home,
+    Session { description: String },
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, specta::Type)]
 pub enum DiffSideDto {
     Left,
@@ -199,6 +206,85 @@ impl From<&SessionFailure> for SessionFailureDto {
             detail: failure.detail.clone(),
             remediation: failure.remediation.clone(),
         }
+    }
+}
+
+/// One of Home's three groups, always rendered whether or not it has rows.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct HomeGroupDto {
+    pub title: String,
+    pub count: u32,
+    /// The one line an empty group shows in place of rows.
+    pub empty_copy: String,
+}
+
+/// One configured clone as the footer lists it.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct HomeRepositoryDto {
+    pub path: String,
+    pub slug: Option<String>,
+    /// Why this clone cannot be listed, absent when it resolved.
+    pub failure: Option<String>,
+}
+
+/// A picked folder Home would not add, and why.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct AddRefusalDto {
+    pub folder: String,
+    pub reason: String,
+}
+
+/// Everything Home renders, from its header to its footer.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct HomeSnapshotDto {
+    /// The header's count line, absent until there is something to count.
+    pub count_line: Option<String>,
+    pub groups: Vec<HomeGroupDto>,
+    pub repositories: Vec<HomeRepositoryDto>,
+    pub footer_summary: String,
+    pub footer_expanded: bool,
+    pub refusals: Vec<AddRefusalDto>,
+    /// What replaces the list area when Home cannot read its repositories. The
+    /// header and footer stay either way, so Add still works.
+    pub failure: Option<SessionFailureDto>,
+}
+
+/// Everything Home shows, from the model that decided it.
+///
+/// No pull requests have been fetched yet, so every group is empty and no
+/// repository carries a count.
+#[must_use]
+pub fn project_home(home: &app::HomeModel) -> HomeSnapshotDto {
+    HomeSnapshotDto {
+        count_line: home.count_line(),
+        groups: app::HomeGroup::ALL
+            .into_iter()
+            .map(|group| HomeGroupDto {
+                title: group.title().to_owned(),
+                count: 0,
+                empty_copy: group.empty_copy().to_owned(),
+            })
+            .collect(),
+        repositories: home
+            .repositories()
+            .iter()
+            .map(|entry| HomeRepositoryDto {
+                path: entry.path.display().to_string(),
+                slug: entry.slug().map(ToOwned::to_owned),
+                failure: entry.reason().map(ToOwned::to_owned),
+            })
+            .collect(),
+        footer_summary: home.footer_summary(),
+        footer_expanded: home.is_footer_expanded(),
+        refusals: home
+            .refusals()
+            .iter()
+            .map(|refusal| AddRefusalDto {
+                folder: refusal.folder.display().to_string(),
+                reason: refusal.reason.clone(),
+            })
+            .collect(),
+        failure: home.failure().map(Into::into),
     }
 }
 
@@ -579,6 +665,80 @@ mod tests {
         let session = demo_session();
         let detail = project_file(&session, 0).expect("index zero is in range");
         assert!(detail.empty_reason.is_none());
+    }
+
+    /// Home with two clones configured, one of which did not resolve.
+    fn home_with_one_failed_repository() -> app::HomeModel {
+        let mut home = app::HomeModel::new();
+        home.refreshed(Ok(vec![
+            app::RepositoryEntry {
+                path: std::path::PathBuf::from("/Developer/zreview"),
+                outcome: app::RepositoryOutcome::Valid {
+                    root: std::path::PathBuf::from("/Developer/zreview"),
+                    slug: "braidonw/zreview".to_owned(),
+                },
+            },
+            app::RepositoryEntry {
+                path: std::path::PathBuf::from("/Developer/moved"),
+                outcome: app::RepositoryOutcome::Failed {
+                    reason: "the folder no longer exists".to_owned(),
+                },
+            },
+        ]));
+        home
+    }
+
+    #[test]
+    fn home_projects_the_three_groups_in_order_with_their_empty_copy() {
+        let snapshot = project_home(&app::HomeModel::new());
+
+        let titles = snapshot
+            .groups
+            .iter()
+            .map(|group| group.title.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(titles, ["To review", "To address", "Waiting on others"]);
+        assert!(snapshot.groups.iter().all(|group| group.count == 0));
+        assert_eq!(snapshot.groups[1].empty_copy, "Nothing to address.");
+    }
+
+    #[test]
+    fn home_projects_each_repository_with_its_slug_or_its_reason() {
+        let snapshot = project_home(&home_with_one_failed_repository());
+
+        assert_eq!(snapshot.repositories[0].path, "/Developer/zreview");
+        assert_eq!(
+            snapshot.repositories[0].slug.as_deref(),
+            Some("braidonw/zreview")
+        );
+        assert!(snapshot.repositories[0].failure.is_none());
+        assert!(snapshot.repositories[1].slug.is_none());
+        assert_eq!(
+            snapshot.repositories[1].failure.as_deref(),
+            Some("the folder no longer exists")
+        );
+        assert_eq!(snapshot.footer_summary, "2 repositories \u{b7} 1 failed");
+        assert_eq!(snapshot.count_line.as_deref(), Some("2 repositories"));
+    }
+
+    #[test]
+    fn home_projects_the_whole_home_failure_and_the_footer_that_stays_with_it() {
+        let mut home = app::HomeModel::new();
+        home.refreshed(Err(SessionFailure::new(
+            "Home could not read your settings",
+        )));
+
+        let snapshot = project_home(&home);
+
+        assert_eq!(
+            snapshot
+                .failure
+                .expect("the failure should be shown")
+                .summary,
+            "Home could not read your settings",
+        );
+        assert_eq!(snapshot.footer_summary, "No repositories");
+        assert!(snapshot.count_line.is_none());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2,11 +2,25 @@
 
 use std::sync::{Arc, Mutex, atomic::AtomicBool};
 
-use app::SessionModel;
+use app::{HomeModel, SessionModel};
 use session::{ReviewStorage, SessionRequest};
 
 mod commands;
 mod dto;
+mod repositories;
+
+/// What the binary was asked to open.
+///
+/// Home is the screen with no pull request named. Everything else opens one
+/// review sitting straight away, from the command line, and never sees Home.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Launch {
+    Home,
+    Session {
+        request: SessionRequest,
+        storage: ReviewStorage,
+    },
+}
 
 /// The one review sitting this window shows, shared with every command.
 pub(crate) struct ManagedSession {
@@ -21,25 +35,41 @@ pub(crate) struct ManagedSession {
     pub(crate) load_started: Arc<AtomicBool>,
 }
 
+/// Everything the window holds, shared with every command.
+///
+/// Home and at most one Session. For now a Session is here only when the binary
+/// was launched straight into one; Home does not open Sessions yet.
+pub(crate) struct AppRoot {
+    pub(crate) home: Arc<Mutex<HomeModel>>,
+    pub(crate) session: Option<ManagedSession>,
+}
+
 /// Builds the window and runs the application until it closes.
 ///
 /// # Panics
 ///
 /// Panics if the Tauri application fails to start, or if bindings export fails
 /// in a debug build.
-pub fn run(request: SessionRequest, storage: ReviewStorage) {
-    let model = Arc::new(Mutex::new(SessionModel::loading(request.description())));
-    let managed = ManagedSession {
-        model,
-        request,
-        storage,
-        load_started: Arc::new(AtomicBool::new(false)),
+pub fn run(launch: Launch) {
+    let session = match launch {
+        Launch::Home => None,
+        Launch::Session { request, storage } => Some(ManagedSession {
+            model: Arc::new(Mutex::new(SessionModel::loading(request.description()))),
+            request,
+            storage,
+            load_started: Arc::new(AtomicBool::new(false)),
+        }),
+    };
+    let root = AppRoot {
+        home: Arc::new(Mutex::new(HomeModel::new())),
+        session,
     };
     let specta_builder = commands::specta_builder();
 
     tauri::Builder::default()
         .plugin(tauri_plugin_clipboard_manager::init())
-        .manage(managed)
+        .plugin(tauri_plugin_dialog::init())
+        .manage(root)
         .invoke_handler(specta_builder.invoke_handler())
         .setup(move |_app| {
             #[cfg(debug_assertions)]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -35,12 +35,36 @@ pub(crate) struct ManagedSession {
     pub(crate) load_started: Arc<AtomicBool>,
 }
 
+/// Home's state and the guard that orders the actions on its settings file.
+///
+/// Cloned into whatever thread an action runs on, so both halves travel
+/// together and no caller can take one without the other.
+#[derive(Clone)]
+pub(crate) struct ManagedHome {
+    pub(crate) model: Arc<Mutex<HomeModel>>,
+    /// Held for the whole of a refresh, an Add, or a Remove.
+    ///
+    /// Each of those reads the file, decides against what it read, writes, and
+    /// reads back. Two of them interleaving would let one write a list the
+    /// other had already changed, resurrecting a repository just removed.
+    pub(crate) settings_action: Arc<Mutex<()>>,
+}
+
+impl ManagedHome {
+    pub(crate) fn new() -> Self {
+        Self {
+            model: Arc::new(Mutex::new(HomeModel::new())),
+            settings_action: Arc::new(Mutex::new(())),
+        }
+    }
+}
+
 /// Everything the window holds, shared with every command.
 ///
 /// Home and at most one Session. For now a Session is here only when the binary
 /// was launched straight into one; Home does not open Sessions yet.
 pub(crate) struct AppRoot {
-    pub(crate) home: Arc<Mutex<HomeModel>>,
+    pub(crate) home: ManagedHome,
     pub(crate) session: Option<ManagedSession>,
 }
 
@@ -61,7 +85,7 @@ pub fn run(launch: Launch) {
         }),
     };
     let root = AppRoot {
-        home: Arc::new(Mutex::new(HomeModel::new())),
+        home: ManagedHome::new(),
         session,
     };
     let specta_builder = commands::specta_builder();

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1,17 +1,19 @@
 use std::{env, path::Path, process::ExitCode};
 
+use desktop_lib::Launch;
 use github::PullRequestSelector;
 use session::{ReviewStorage, SessionRequest};
 
 const USAGE: &str = "usage:
   desktop
+  desktop demo
   desktop <repository> <base> [<head>]
   desktop pr [<repository>] <number-or-url>";
 
 fn main() -> ExitCode {
     // Only argument parsing happens before the window opens. Everything that can be slow or fail, such as Git, gh, or the network, is reported inside the app.
-    let (request, storage) = match parse_arguments(&env::args().skip(1).collect::<Vec<_>>()) {
-        Ok(parsed) => parsed,
+    let launch = match parse_arguments(&env::args().skip(1).collect::<Vec<_>>()) {
+        Ok(launch) => launch,
         Err(message) => {
             eprintln!("desktop: {message}");
             eprintln!("{USAGE}");
@@ -19,18 +21,19 @@ fn main() -> ExitCode {
         }
     };
 
-    desktop_lib::run(request, storage);
+    desktop_lib::run(launch);
 
     ExitCode::SUCCESS
 }
 
-fn parse_arguments(arguments: &[String]) -> Result<(SessionRequest, ReviewStorage), String> {
+fn parse_arguments(arguments: &[String]) -> Result<Launch, String> {
     match arguments {
-        [] => Ok((SessionRequest::Demo, ReviewStorage::Disabled)),
+        [] => Ok(Launch::Home),
+        [only] if only == "demo" => Ok(session(SessionRequest::Demo, ReviewStorage::Disabled)),
         [first, rest @ ..] if first == "pr" => {
-            Ok((parse_pull_request(rest)?, ReviewStorage::Default))
+            Ok(session(parse_pull_request(rest)?, ReviewStorage::Default))
         }
-        [repository, base] => Ok((
+        [repository, base] => Ok(session(
             SessionRequest::LocalComparison {
                 repository: Path::new(repository).to_path_buf(),
                 base: base.clone(),
@@ -38,7 +41,7 @@ fn parse_arguments(arguments: &[String]) -> Result<(SessionRequest, ReviewStorag
             },
             ReviewStorage::Default,
         )),
-        [repository, base, head] => Ok((
+        [repository, base, head] => Ok(session(
             SessionRequest::LocalComparison {
                 repository: Path::new(repository).to_path_buf(),
                 base: base.clone(),
@@ -48,6 +51,10 @@ fn parse_arguments(arguments: &[String]) -> Result<(SessionRequest, ReviewStorag
         )),
         _ => Err("expected a repository, base revision, and optional head revision".to_owned()),
     }
+}
+
+fn session(request: SessionRequest, storage: ReviewStorage) -> Launch {
+    Launch::Session { request, storage }
 }
 
 fn parse_pull_request(arguments: &[String]) -> Result<SessionRequest, String> {
@@ -87,10 +94,23 @@ mod tests {
         values.iter().map(|value| (*value).to_owned()).collect()
     }
 
+    /// The Session a launch opens, for the arguments that open one directly.
+    fn opened_session(launch: Launch) -> (SessionRequest, ReviewStorage) {
+        match launch {
+            Launch::Session { request, storage } => (request, storage),
+            Launch::Home => panic!("expected a session launch, got Home"),
+        }
+    }
+
     #[test]
-    fn no_arguments_opens_the_generated_fixture_with_storage_disabled() {
+    fn no_arguments_opens_home() {
+        assert_eq!(parse_arguments(&[]).unwrap(), Launch::Home);
+    }
+
+    #[test]
+    fn demo_opens_the_generated_fixture_with_storage_disabled() {
         assert_eq!(
-            parse_arguments(&[]).unwrap(),
+            opened_session(parse_arguments(&arguments(&["demo"])).unwrap()),
             (SessionRequest::Demo, ReviewStorage::Disabled),
         );
     }
@@ -98,7 +118,7 @@ mod tests {
     #[test]
     fn a_local_comparison_defaults_its_head_to_head_and_uses_default_storage() {
         assert_eq!(
-            parse_arguments(&arguments(&["/tmp/repository", "main"])).unwrap(),
+            opened_session(parse_arguments(&arguments(&["/tmp/repository", "main"])).unwrap()),
             (
                 SessionRequest::LocalComparison {
                     repository: Path::new("/tmp/repository").to_path_buf(),
@@ -109,7 +129,9 @@ mod tests {
             ),
         );
         assert_eq!(
-            parse_arguments(&arguments(&["/tmp/repository", "main", "feature"])).unwrap(),
+            opened_session(
+                parse_arguments(&arguments(&["/tmp/repository", "main", "feature"])).unwrap()
+            ),
             (
                 SessionRequest::LocalComparison {
                     repository: Path::new("/tmp/repository").to_path_buf(),
@@ -146,7 +168,7 @@ mod tests {
     #[test]
     fn a_pull_request_takes_an_optional_repository_and_uses_default_storage() {
         assert_eq!(
-            parse_arguments(&arguments(&["pr", "/tmp/repository", "42"])).unwrap(),
+            opened_session(parse_arguments(&arguments(&["pr", "/tmp/repository", "42"])).unwrap()),
             (
                 SessionRequest::PullRequest {
                     repository: Path::new("/tmp/repository").to_path_buf(),
@@ -155,7 +177,8 @@ mod tests {
                 ReviewStorage::Default,
             ),
         );
-        let (request, storage) = parse_arguments(&arguments(&["pr", "42"])).unwrap();
+        let (request, storage) =
+            opened_session(parse_arguments(&arguments(&["pr", "42"])).unwrap());
         assert!(matches!(
             request,
             SessionRequest::PullRequest {
@@ -169,12 +192,14 @@ mod tests {
     #[test]
     fn a_pull_request_repository_accepts_a_url_selector() {
         assert_eq!(
-            parse_arguments(&arguments(&[
-                "pr",
-                "/tmp/repository",
-                "https://github.com/acme/widgets/pull/42",
-            ]))
-            .unwrap(),
+            opened_session(
+                parse_arguments(&arguments(&[
+                    "pr",
+                    "/tmp/repository",
+                    "https://github.com/acme/widgets/pull/42",
+                ]))
+                .unwrap()
+            ),
             (
                 SessionRequest::PullRequest {
                     repository: Path::new("/tmp/repository").to_path_buf(),

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -29,32 +29,32 @@ fn main() -> ExitCode {
 fn parse_arguments(arguments: &[String]) -> Result<Launch, String> {
     match arguments {
         [] => Ok(Launch::Home),
-        [only] if only == "demo" => Ok(session(SessionRequest::Demo, ReviewStorage::Disabled)),
-        [first, rest @ ..] if first == "pr" => {
-            Ok(session(parse_pull_request(rest)?, ReviewStorage::Default))
-        }
-        [repository, base] => Ok(session(
-            SessionRequest::LocalComparison {
+        [only] if only == "demo" => Ok(Launch::Session {
+            request: SessionRequest::Demo,
+            storage: ReviewStorage::Disabled,
+        }),
+        [first, rest @ ..] if first == "pr" => Ok(Launch::Session {
+            request: parse_pull_request(rest)?,
+            storage: ReviewStorage::Default,
+        }),
+        [repository, base] => Ok(Launch::Session {
+            request: SessionRequest::LocalComparison {
                 repository: Path::new(repository).to_path_buf(),
                 base: base.clone(),
                 head: "HEAD".to_owned(),
             },
-            ReviewStorage::Default,
-        )),
-        [repository, base, head] => Ok(session(
-            SessionRequest::LocalComparison {
+            storage: ReviewStorage::Default,
+        }),
+        [repository, base, head] => Ok(Launch::Session {
+            request: SessionRequest::LocalComparison {
                 repository: Path::new(repository).to_path_buf(),
                 base: base.clone(),
                 head: head.clone(),
             },
-            ReviewStorage::Default,
-        )),
+            storage: ReviewStorage::Default,
+        }),
         _ => Err("expected a repository, base revision, and optional head revision".to_owned()),
     }
-}
-
-fn session(request: SessionRequest, storage: ReviewStorage) -> Launch {
-    Launch::Session { request, storage }
 }
 
 fn parse_pull_request(arguments: &[String]) -> Result<SessionRequest, String> {

--- a/apps/desktop/src-tauri/src/repositories.rs
+++ b/apps/desktop/src-tauri/src/repositories.rs
@@ -1,0 +1,237 @@
+//! Reading the configured repositories, and resolving each one to a clone.
+//!
+//! The file and Git live here rather than in the Home model, which takes what
+//! this finds as data.
+
+use std::path::{Path, PathBuf};
+
+use app::{RepositoryEntry, RepositoryOutcome};
+use domain::SessionFailure;
+use settings::{Settings, SettingsError};
+
+/// Reads the settings file and resolves every clone it lists.
+///
+/// Runs on every refresh, so a hand edit takes effect without a restart. One
+/// clone that cannot be resolved is an entry with a reason, not a failure. Only
+/// the file itself failing stops Home listing anything at all.
+///
+/// # Errors
+///
+/// Returns the failure to show in place of the list when the file cannot be
+/// read or parsed.
+pub fn read(settings_path: &Path) -> Result<Vec<RepositoryEntry>, SessionFailure> {
+    let settings = settings::load(settings_path).map_err(|error| settings_failure(&error))?;
+    Ok(resolve_picked(&settings.repositories))
+}
+
+/// Resolves folders, whether picked or read from the file, to their clones.
+#[must_use]
+pub fn resolve_picked(folders: &[PathBuf]) -> Vec<RepositoryEntry> {
+    folders
+        .iter()
+        .map(|folder| RepositoryEntry {
+            path: folder.clone(),
+            outcome: resolve(folder),
+        })
+        .collect()
+}
+
+/// Writes the repository list, replacing whatever the file held.
+///
+/// # Errors
+///
+/// Returns the failure to show above the list when the file cannot be written.
+pub fn write(settings_path: &Path, repositories: Vec<PathBuf>) -> Result<(), SessionFailure> {
+    settings::save(settings_path, &Settings { repositories })
+        .map_err(|error| settings_failure(&error))
+}
+
+/// Where the settings file lives.
+///
+/// # Errors
+///
+/// Returns the failure to show when there is no home directory to look in.
+pub fn settings_path() -> Result<PathBuf, SessionFailure> {
+    settings::default_settings_path().map_err(|error| settings_failure(&error))
+}
+
+fn resolve(folder: &Path) -> RepositoryOutcome {
+    match github::resolve_clone(folder) {
+        Ok(resolved) => RepositoryOutcome::Valid {
+            root: resolved.root,
+            slug: resolved.slug.full_name(),
+        },
+        Err(error) => RepositoryOutcome::Failed {
+            reason: error.to_string(),
+        },
+    }
+}
+
+/// What Home shows in place of its list when the settings file itself fails.
+///
+/// Every case names the file, because the reviewer's next move is to open it.
+fn settings_failure(error: &SettingsError) -> SessionFailure {
+    match error {
+        SettingsError::NoHomeDirectory => {
+            SessionFailure::from_error("Home has nowhere to keep your settings", error)
+                .with_remediation("Set HOME, then reopen ZReview.")
+        }
+        SettingsError::Read { path, .. } | SettingsError::Parse { path, .. } => {
+            SessionFailure::from_error("Home could not read your settings", error)
+                .with_remediation(format!("Fix {}, then press r to refresh.", path.display()))
+        }
+        SettingsError::CreateDirectory { directory, .. } => {
+            SessionFailure::from_error("Home could not save your settings", error).with_remediation(
+                format!("Check that {} can be created.", directory.display()),
+            )
+        }
+        SettingsError::Write { path, .. } => {
+            SessionFailure::from_error("Home could not save your settings", error)
+                .with_remediation(format!("Check that {} is writable.", path.display()))
+        }
+        SettingsError::NonUtf8Path { .. } => {
+            SessionFailure::from_error("Home could not save your settings", error)
+                .with_remediation("Move that clone to a path made only of text.")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{ffi::OsStr, path::Path, process::Command};
+
+    use app::RepositoryOutcome;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn git<I, S>(repository: &Path, args: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(repository)
+            .args(args)
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
+
+    /// A clone whose `origin` points at GitHub, which is what Home configures.
+    fn clone_of(slug: &str) -> TempDir {
+        let directory = TempDir::new().unwrap();
+        git(directory.path(), ["init", "--quiet"]);
+        git(
+            directory.path(),
+            [
+                "remote",
+                "add",
+                "origin",
+                &format!("https://github.com/{slug}.git"),
+            ],
+        );
+        directory
+    }
+
+    fn settings_file(directory: &TempDir, contents: &str) -> PathBuf {
+        let path = directory.path().join("settings.toml");
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
+
+    #[test]
+    fn a_settings_file_that_was_never_written_reads_as_no_repositories() {
+        let directory = TempDir::new().unwrap();
+
+        let entries = read(&directory.path().join("settings.toml")).unwrap();
+
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn every_listed_clone_comes_back_with_its_slug_and_its_root() {
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let path = settings_file(
+            &directory,
+            &format!(
+                "repositories = [{:?}]\n",
+                clone.path().display().to_string()
+            ),
+        );
+
+        let entries = read(&path).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].path, clone.path());
+        assert_eq!(entries[0].slug(), Some("acme/widgets"));
+    }
+
+    #[test]
+    fn a_listed_clone_that_is_gone_carries_its_reason_and_the_rest_still_resolve() {
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let path = settings_file(
+            &directory,
+            &format!(
+                "repositories = [{:?}, \"/nowhere/at/all\"]\n",
+                clone.path().display().to_string()
+            ),
+        );
+
+        let entries = read(&path).unwrap();
+
+        assert_eq!(entries[0].slug(), Some("acme/widgets"));
+        assert_eq!(entries[1].reason(), Some("the folder no longer exists"));
+    }
+
+    #[test]
+    fn a_malformed_settings_file_becomes_a_failure_naming_the_path_and_the_problem() {
+        let directory = TempDir::new().unwrap();
+        let path = settings_file(&directory, "repositories = [this is not valid toml");
+
+        let failure = read(&path).unwrap_err();
+
+        assert_eq!(failure.summary, "Home could not read your settings");
+        let detail = failure.detail.expect("the parser's message should survive");
+        assert!(
+            detail.contains(&path.display().to_string()),
+            "the detail should name the file: {detail}",
+        );
+        assert!(
+            failure
+                .remediation
+                .expect("a malformed file is something a reviewer can fix")
+                .contains(&path.display().to_string()),
+        );
+    }
+
+    #[test]
+    fn a_picked_folder_resolves_to_the_worktree_root_rather_than_itself() {
+        let clone = clone_of("acme/widgets");
+        let nested = clone.path().join("crates/review");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let entries = resolve_picked(std::slice::from_ref(&nested));
+
+        assert_eq!(entries[0].path, nested);
+        match &entries[0].outcome {
+            RepositoryOutcome::Valid { root, slug } => {
+                assert_eq!(*root, clone.path().canonicalize().unwrap());
+                assert_eq!(slug, "acme/widgets");
+            }
+            RepositoryOutcome::Failed { reason } => panic!("unexpectedly refused: {reason}"),
+        }
+    }
+
+    #[test]
+    fn a_picked_folder_that_is_not_a_clone_carries_its_reason() {
+        let directory = TempDir::new().unwrap();
+
+        let entries = resolve_picked(&[directory.path().to_path_buf()]);
+
+        assert_eq!(entries[0].reason(), Some("not a Git repository"));
+    }
+}

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -5,7 +5,7 @@ import type { Channel } from "@tauri-apps/api/core";
 import App from "./App";
 import { makeFile, makeFileSummary, makeRow, makeSidebar, makeSnapshot } from "./test/fixtures";
 
-const describeSession = vi.fn();
+const describeLaunch = vi.fn();
 const openSession = vi.fn();
 const selectFile = vi.fn();
 const toggleViewed = vi.fn();
@@ -15,7 +15,7 @@ const reanchorDraft = vi.fn();
 
 vi.mock("./bindings", () => ({
   commands: {
-    describeSession: () => describeSession(),
+    describeLaunch: () => describeLaunch(),
     openSession: (channel: unknown) => openSession(channel),
     selectFile: (index: unknown) => selectFile(index),
     toggleViewed: () => toggleViewed(),
@@ -31,8 +31,8 @@ vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
 }));
 
 beforeEach(() => {
-  describeSession.mockReset();
-  describeSession.mockResolvedValue("the generated fixture");
+  describeLaunch.mockReset();
+  describeLaunch.mockResolvedValue({ Session: { description: "the generated fixture" } });
   openSession.mockReset();
   selectFile.mockReset();
   toggleViewed.mockReset();
@@ -100,9 +100,8 @@ describe("App", () => {
     await waitFor(() => expect(screen.getByText("network unreachable")).toBeTruthy());
   });
 
-  it("shows the failure screen when describeSession itself rejects", async () => {
-    describeSession.mockReset();
-    describeSession.mockRejectedValue(new Error("IPC is unavailable"));
+  it("shows the failure screen when openSession itself rejects", async () => {
+    openSession.mockRejectedValue(new Error("IPC is unavailable"));
 
     render(<App />);
 

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -79,7 +79,7 @@ describe("App", () => {
     );
   });
 
-  it("shows the failure screen's fields when opening fails", async () => {
+  it("shows the failure screen's fields, remediation before detail", async () => {
     openSession.mockResolvedValue({
       status: "error",
       error: { summary: "Could not load", detail: "boom", remediation: "try again" },
@@ -88,8 +88,9 @@ describe("App", () => {
     render(<App />);
 
     await waitFor(() => expect(screen.getByText("Could not load")).toBeTruthy());
-    expect(screen.getByText("boom")).toBeTruthy();
-    expect(screen.getByText("try again")).toBeTruthy();
+    expect(document.querySelector(".failure-screen")?.textContent).toBe(
+      "Could not loadtry againboom",
+    );
   });
 
   it("renders the failure screen for a plain-string command rejection", async () => {
@@ -106,6 +107,17 @@ describe("App", () => {
     render(<App />);
 
     await waitFor(() => expect(screen.getByText("Error: IPC is unavailable")).toBeTruthy());
+  });
+
+  it("shows the failure screen when the launch call rejects", async () => {
+    describeLaunch.mockReset();
+    describeLaunch.mockRejectedValue(new Error("the launch could not be described"));
+
+    render(<App />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Error: the launch could not be described")).toBeTruthy(),
+    );
   });
 
   describe("once ready", () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,37 +1,23 @@
-import { FailureScreen } from "./components/FailureScreen";
-import { LoadingScreen } from "./components/LoadingScreen";
-import { SessionShell } from "./components/SessionShell";
-import { useSession } from "./hooks/useSession";
+import { useEffect, useState } from "react";
+import type { LaunchDto } from "./bindings";
+import { commands } from "./bindings";
+import { HomeScreen } from "./components/HomeScreen";
+import { SessionApp } from "./SessionApp";
 
 export default function App() {
-  const {
-    state,
-    selectFile,
-    clickRow,
-    openComposer,
-    closeComposer,
-    composerChange,
-    composerDiscard,
-    reanchorDraft,
-  } = useSession();
+  const [launch, setLaunch] = useState<LaunchDto | null>(null);
 
-  switch (state.status) {
-    case "loading":
-      return <LoadingScreen description={state.description} stage={state.stage} />;
-    case "failed":
-      return <FailureScreen failure={state.failure} />;
-    case "ready":
-      return (
-        <SessionShell
-          state={state}
-          onSelectFile={selectFile}
-          onRowClick={clickRow}
-          onOpenComposer={openComposer}
-          onComposerChange={composerChange}
-          onComposerClose={closeComposer}
-          onComposerDiscard={composerDiscard}
-          onReanchorDraft={reanchorDraft}
-        />
-      );
+  useEffect(() => {
+    void commands.describeLaunch().then(setLaunch);
+  }, []);
+
+  // Nothing is rendered until the answer arrives, so neither screen flashes
+  // before the other.
+  if (launch === null) {
+    return null;
   }
+  if (launch === "Home") {
+    return <HomeScreen />;
+  }
+  return <SessionApp description={launch.Session.description} />;
 }

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,18 +1,27 @@
 import { useEffect, useState } from "react";
-import type { LaunchDto } from "./bindings";
+import type { LaunchDto, SessionFailureDto } from "./bindings";
 import { commands } from "./bindings";
+import { FailureScreen } from "./components/FailureScreen";
 import { HomeScreen } from "./components/HomeScreen";
+import { toFailure } from "./lib/failure";
 import { SessionApp } from "./SessionApp";
 
 export default function App() {
   const [launch, setLaunch] = useState<LaunchDto | null>(null);
+  const [failure, setFailure] = useState<SessionFailureDto | null>(null);
 
   useEffect(() => {
-    void commands.describeLaunch().then(setLaunch);
+    commands
+      .describeLaunch()
+      .then(setLaunch)
+      .catch((error: unknown) => setFailure(toFailure(error)));
   }, []);
 
-  // Nothing is rendered until the answer arrives, so neither screen flashes
-  // before the other.
+  // A launch that never answers would otherwise leave the window blank.
+  if (failure !== null) {
+    return <FailureScreen failure={failure} />;
+  }
+  // Nothing is rendered until the answer arrives, so neither screen flashes first.
   if (launch === null) {
     return null;
   }

--- a/apps/desktop/src/Home.test.tsx
+++ b/apps/desktop/src/Home.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { HomeSnapshotDto } from "./bindings";
 import App from "./App";
 import { makeHomeRepository, makeHomeSnapshot } from "./test/fixtures";
 
@@ -9,7 +10,6 @@ const refreshHome = vi.fn();
 const addRepositories = vi.fn();
 const removeRepository = vi.fn();
 const toggleRepositoriesFooter = vi.fn();
-const dismissRefusals = vi.fn();
 
 vi.mock("./bindings", () => ({
   commands: {
@@ -18,7 +18,6 @@ vi.mock("./bindings", () => ({
     addRepositories: (folders: unknown) => addRepositories(folders),
     removeRepository: (path: unknown) => removeRepository(path),
     toggleRepositoriesFooter: () => toggleRepositoriesFooter(),
-    dismissRefusals: () => dismissRefusals(),
   },
 }));
 
@@ -27,10 +26,15 @@ vi.mock("@tauri-apps/plugin-dialog", () => ({
   open: (options: unknown) => open(options),
 }));
 
-/// Home with two clones configured, one of which did not resolve.
+// The commands that touch the settings file answer with a result, as the bindings do.
+function ok(snapshot: HomeSnapshotDto) {
+  return { status: "ok", data: snapshot };
+}
+
+// Home with two clones configured, one of which did not resolve.
 function configured() {
   return makeHomeSnapshot({
-    count_line: "2 repositories",
+    count_line: "0 pull requests across 2 repositories",
     repositories: [
       makeHomeRepository({ path: "/Developer/zreview", slug: "braidonw/zreview" }),
       makeHomeRepository({
@@ -47,22 +51,21 @@ beforeEach(() => {
   describeLaunch.mockReset();
   describeLaunch.mockResolvedValue("Home");
   refreshHome.mockReset();
-  refreshHome.mockResolvedValue(makeHomeSnapshot());
+  refreshHome.mockResolvedValue(ok(makeHomeSnapshot()));
   addRepositories.mockReset();
   removeRepository.mockReset();
   toggleRepositoriesFooter.mockReset();
-  dismissRefusals.mockReset();
   open.mockReset();
 });
 
 describe("Home", () => {
   it("renders the heading, the count line, and the three groups with their empty copy", async () => {
-    refreshHome.mockResolvedValue(configured());
+    refreshHome.mockResolvedValue(ok(configured()));
 
     render(<App />);
 
     await waitFor(() => expect(screen.getByText("Home")).toBeTruthy());
-    expect(screen.getByText("2 repositories")).toBeTruthy();
+    expect(screen.getByText("0 pull requests across 2 repositories")).toBeTruthy();
     expect(screen.getByText("To review")).toBeTruthy();
     expect(screen.getByText("To address")).toBeTruthy();
     expect(screen.getByText("Waiting on others")).toBeTruthy();
@@ -72,7 +75,7 @@ describe("Home", () => {
   });
 
   it("shows the footer collapsed to its summary line with Add beside it", async () => {
-    refreshHome.mockResolvedValue(configured());
+    refreshHome.mockResolvedValue(ok(configured()));
 
     render(<App />);
 
@@ -84,7 +87,7 @@ describe("Home", () => {
 
   it("lists each repository's slug, path, state, and Remove once the footer expands", async () => {
     const user = userEvent.setup();
-    refreshHome.mockResolvedValue(configured());
+    refreshHome.mockResolvedValue(ok(configured()));
     toggleRepositoriesFooter.mockResolvedValue({ ...configured(), footer_expanded: true });
 
     render(<App />);
@@ -109,13 +112,15 @@ describe("Home", () => {
 
   it("replaces the list with the failure block while leaving Add in the footer", async () => {
     refreshHome.mockResolvedValue(
-      makeHomeSnapshot({
-        failure: {
-          summary: "Home could not read your settings",
-          detail: "could not parse the settings file",
-          remediation: "Fix ~/.config/zreview/settings.toml, then press r to refresh.",
-        },
-      }),
+      ok(
+        makeHomeSnapshot({
+          failure: {
+            summary: "Home could not read your settings",
+            detail: "could not parse the settings file",
+            remediation: "Fix ~/.config/zreview/settings.toml, then press r to refresh.",
+          },
+        }),
+      ),
     );
 
     render(<App />);
@@ -131,16 +136,41 @@ describe("Home", () => {
     expect(screen.getByRole("button", { name: "Add..." })).toBeTruthy();
   });
 
+  it("shows a write failure as a line above a list that stays", async () => {
+    refreshHome.mockResolvedValue(
+      ok({
+        ...configured(),
+        write_failure: {
+          summary: "Home could not save your settings",
+          detail: null,
+          remediation: "Check that ~/.config/zreview/settings.toml is writable.",
+        },
+      }),
+    );
+
+    render(<App />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Home could not save your settings")).toBeTruthy(),
+    );
+    expect(
+      screen.getByText("Check that ~/.config/zreview/settings.toml is writable."),
+    ).toBeTruthy();
+    expect(screen.getByText("To review")).toBeTruthy();
+  });
+
   it("passes the picked folders to the add command and shows what it refused", async () => {
     const user = userEvent.setup();
     open.mockResolvedValue(["/Developer/notes", "/Developer/billing"]);
     addRepositories.mockResolvedValue(
-      makeHomeSnapshot({
-        count_line: "1 repository",
-        repositories: [makeHomeRepository({ path: "/Developer/billing", slug: "acme/billing" })],
-        footer_summary: "1 repository",
-        refusals: [{ folder: "/Developer/notes", reason: "not a Git repository" }],
-      }),
+      ok(
+        makeHomeSnapshot({
+          count_line: "0 pull requests across 1 repository",
+          repositories: [makeHomeRepository({ path: "/Developer/billing", slug: "acme/billing" })],
+          footer_summary: "1 repository",
+          refusals: [{ path: "/Developer/notes", reason: "not a Git repository" }],
+        }),
+      ),
     );
 
     render(<App />);
@@ -157,6 +187,7 @@ describe("Home", () => {
     await waitFor(() =>
       expect(screen.getByText("/Developer/notes: not a Git repository")).toBeTruthy(),
     );
+    expect(screen.getByText("1 repository")).toBeTruthy();
   });
 
   it("adds nothing when the picker is dismissed", async () => {
@@ -174,30 +205,56 @@ describe("Home", () => {
 
   it("removes the repository the Remove beside it names", async () => {
     const user = userEvent.setup();
-    refreshHome.mockResolvedValue({ ...configured(), footer_expanded: true });
-    removeRepository.mockResolvedValue(makeHomeSnapshot({ footer_expanded: true }));
+    refreshHome.mockResolvedValue(ok({ ...configured(), footer_expanded: true }));
+    removeRepository.mockImplementation((path: string) =>
+      Promise.resolve(
+        ok({
+          ...configured(),
+          footer_expanded: true,
+          repositories: configured().repositories.filter(
+            (repository) => repository.path !== path,
+          ),
+        }),
+      ),
+    );
 
     render(<App />);
     await waitFor(() => expect(screen.getByText("braidonw/zreview")).toBeTruthy());
 
     await user.click(screen.getAllByRole("button", { name: "Remove" })[0]);
 
-    expect(removeRepository).toHaveBeenCalledWith("/Developer/zreview");
+    await waitFor(() => expect(screen.queryByText("/Developer/zreview")).toBeNull());
+    expect(screen.getByText("/Developer/moved")).toBeTruthy();
   });
 
-  it("refreshes on r", async () => {
+  it("refreshes on r, showing what the settings file now holds", async () => {
     const user = userEvent.setup();
+
     render(<App />);
-    await waitFor(() => expect(refreshHome).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByText("No repositories yet")).toBeTruthy());
+    refreshHome.mockResolvedValue(ok(configured()));
 
     await user.keyboard("r");
 
-    await waitFor(() => expect(refreshHome).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByText("To review")).toBeTruthy());
+    expect(screen.getByText("2 repositories · 1 failed")).toBeTruthy();
+  });
+
+  it("leaves the settings file alone when r is pressed with shift held", async () => {
+    const user = userEvent.setup();
+
+    render(<App />);
+    await waitFor(() => expect(screen.getByText("No repositories yet")).toBeTruthy());
+    refreshHome.mockClear();
+
+    await user.keyboard("{Shift>}r{/Shift}");
+
+    expect(refreshHome).not.toHaveBeenCalled();
   });
 
   it("expands the footer on e", async () => {
     const user = userEvent.setup();
-    refreshHome.mockResolvedValue(configured());
+    refreshHome.mockResolvedValue(ok(configured()));
     toggleRepositoriesFooter.mockResolvedValue({ ...configured(), footer_expanded: true });
 
     render(<App />);
@@ -206,5 +263,41 @@ describe("Home", () => {
     await user.keyboard("e");
 
     await waitFor(() => expect(screen.getByText("braidonw/zreview")).toBeTruthy());
+  });
+
+  it("shows the failure screen when a Home command rejects", async () => {
+    refreshHome.mockReset();
+    refreshHome.mockRejectedValue(new Error("IPC is unavailable"));
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText("Error: IPC is unavailable")).toBeTruthy());
+  });
+
+  it("shows the failure screen when a Home command answers with an error", async () => {
+    refreshHome.mockResolvedValue({
+      status: "error",
+      error: { summary: "Home could not finish that action", detail: null, remediation: null },
+    });
+
+    render(<App />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Home could not finish that action")).toBeTruthy(),
+    );
+  });
+
+  it("shows the failure screen when the picker rejects", async () => {
+    const user = userEvent.setup();
+    open.mockRejectedValue(new Error("the picker could not open"));
+
+    render(<App />);
+    await waitFor(() => expect(screen.getByText("No repositories yet")).toBeTruthy());
+
+    await user.click(screen.getByRole("button", { name: "Add repository..." }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Error: the picker could not open")).toBeTruthy(),
+    );
   });
 });

--- a/apps/desktop/src/Home.test.tsx
+++ b/apps/desktop/src/Home.test.tsx
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import App from "./App";
+import { makeHomeRepository, makeHomeSnapshot } from "./test/fixtures";
+
+const describeLaunch = vi.fn();
+const refreshHome = vi.fn();
+const addRepositories = vi.fn();
+const removeRepository = vi.fn();
+const toggleRepositoriesFooter = vi.fn();
+const dismissRefusals = vi.fn();
+
+vi.mock("./bindings", () => ({
+  commands: {
+    describeLaunch: () => describeLaunch(),
+    refreshHome: () => refreshHome(),
+    addRepositories: (folders: unknown) => addRepositories(folders),
+    removeRepository: (path: unknown) => removeRepository(path),
+    toggleRepositoriesFooter: () => toggleRepositoriesFooter(),
+    dismissRefusals: () => dismissRefusals(),
+  },
+}));
+
+const open = vi.fn();
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: (options: unknown) => open(options),
+}));
+
+/// Home with two clones configured, one of which did not resolve.
+function configured() {
+  return makeHomeSnapshot({
+    count_line: "2 repositories",
+    repositories: [
+      makeHomeRepository({ path: "/Developer/zreview", slug: "braidonw/zreview" }),
+      makeHomeRepository({
+        path: "/Developer/moved",
+        slug: null,
+        failure: "the folder no longer exists",
+      }),
+    ],
+    footer_summary: "2 repositories · 1 failed",
+  });
+}
+
+beforeEach(() => {
+  describeLaunch.mockReset();
+  describeLaunch.mockResolvedValue("Home");
+  refreshHome.mockReset();
+  refreshHome.mockResolvedValue(makeHomeSnapshot());
+  addRepositories.mockReset();
+  removeRepository.mockReset();
+  toggleRepositoriesFooter.mockReset();
+  dismissRefusals.mockReset();
+  open.mockReset();
+});
+
+describe("Home", () => {
+  it("renders the heading, the count line, and the three groups with their empty copy", async () => {
+    refreshHome.mockResolvedValue(configured());
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText("Home")).toBeTruthy());
+    expect(screen.getByText("2 repositories")).toBeTruthy();
+    expect(screen.getByText("To review")).toBeTruthy();
+    expect(screen.getByText("To address")).toBeTruthy();
+    expect(screen.getByText("Waiting on others")).toBeTruthy();
+    expect(screen.getByText("Nothing waiting for your review.")).toBeTruthy();
+    expect(screen.getByText("Nothing to address.")).toBeTruthy();
+    expect(screen.getByText("Nothing waiting on others.")).toBeTruthy();
+  });
+
+  it("shows the footer collapsed to its summary line with Add beside it", async () => {
+    refreshHome.mockResolvedValue(configured());
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText("Repositories")).toBeTruthy());
+    expect(screen.getByText("2 repositories · 1 failed")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Add..." })).toBeTruthy();
+    expect(screen.queryByText("/Developer/zreview")).toBeNull();
+  });
+
+  it("lists each repository's slug, path, state, and Remove once the footer expands", async () => {
+    const user = userEvent.setup();
+    refreshHome.mockResolvedValue(configured());
+    toggleRepositoriesFooter.mockResolvedValue({ ...configured(), footer_expanded: true });
+
+    render(<App />);
+    await waitFor(() => expect(screen.getByText("Repositories")).toBeTruthy());
+
+    await user.click(screen.getByRole("button", { name: /Repositories/ }));
+
+    await waitFor(() => expect(screen.getByText("braidonw/zreview")).toBeTruthy());
+    expect(screen.getByText("/Developer/zreview")).toBeTruthy();
+    expect(screen.getByText("the folder no longer exists")).toBeTruthy();
+    expect(screen.getAllByRole("button", { name: "Remove" })).toHaveLength(2);
+  });
+
+  it("shows the centred empty state and the no repositories summary on first launch", async () => {
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText("No repositories yet")).toBeTruthy());
+    expect(screen.getByText("No repositories")).toBeTruthy();
+    expect(screen.queryByText("To review")).toBeNull();
+    expect(screen.getAllByRole("button", { name: /Add/ }).length).toBeGreaterThan(0);
+  });
+
+  it("replaces the list with the failure block while leaving Add in the footer", async () => {
+    refreshHome.mockResolvedValue(
+      makeHomeSnapshot({
+        failure: {
+          summary: "Home could not read your settings",
+          detail: "could not parse the settings file",
+          remediation: "Fix ~/.config/zreview/settings.toml, then press r to refresh.",
+        },
+      }),
+    );
+
+    render(<App />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Home could not read your settings")).toBeTruthy(),
+    );
+    expect(screen.getByText("could not parse the settings file")).toBeTruthy();
+    expect(
+      screen.getByText("Fix ~/.config/zreview/settings.toml, then press r to refresh."),
+    ).toBeTruthy();
+    expect(screen.queryByText("To review")).toBeNull();
+    expect(screen.getByRole("button", { name: "Add..." })).toBeTruthy();
+  });
+
+  it("passes the picked folders to the add command and shows what it refused", async () => {
+    const user = userEvent.setup();
+    open.mockResolvedValue(["/Developer/notes", "/Developer/billing"]);
+    addRepositories.mockResolvedValue(
+      makeHomeSnapshot({
+        count_line: "1 repository",
+        repositories: [makeHomeRepository({ path: "/Developer/billing", slug: "acme/billing" })],
+        footer_summary: "1 repository",
+        refusals: [{ folder: "/Developer/notes", reason: "not a Git repository" }],
+      }),
+    );
+
+    render(<App />);
+    await waitFor(() => expect(screen.getByText("No repositories yet")).toBeTruthy());
+
+    await user.click(screen.getByRole("button", { name: "Add repository..." }));
+
+    await waitFor(() =>
+      expect(addRepositories).toHaveBeenCalledWith(["/Developer/notes", "/Developer/billing"]),
+    );
+    expect(open).toHaveBeenCalledWith(
+      expect.objectContaining({ directory: true, multiple: true }),
+    );
+    await waitFor(() =>
+      expect(screen.getByText("/Developer/notes: not a Git repository")).toBeTruthy(),
+    );
+  });
+
+  it("adds nothing when the picker is dismissed", async () => {
+    const user = userEvent.setup();
+    open.mockResolvedValue(null);
+
+    render(<App />);
+    await waitFor(() => expect(screen.getByText("No repositories yet")).toBeTruthy());
+
+    await user.click(screen.getByRole("button", { name: "Add repository..." }));
+
+    await waitFor(() => expect(open).toHaveBeenCalled());
+    expect(addRepositories).not.toHaveBeenCalled();
+  });
+
+  it("removes the repository the Remove beside it names", async () => {
+    const user = userEvent.setup();
+    refreshHome.mockResolvedValue({ ...configured(), footer_expanded: true });
+    removeRepository.mockResolvedValue(makeHomeSnapshot({ footer_expanded: true }));
+
+    render(<App />);
+    await waitFor(() => expect(screen.getByText("braidonw/zreview")).toBeTruthy());
+
+    await user.click(screen.getAllByRole("button", { name: "Remove" })[0]);
+
+    expect(removeRepository).toHaveBeenCalledWith("/Developer/zreview");
+  });
+
+  it("refreshes on r", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    await waitFor(() => expect(refreshHome).toHaveBeenCalledTimes(1));
+
+    await user.keyboard("r");
+
+    await waitFor(() => expect(refreshHome).toHaveBeenCalledTimes(2));
+  });
+
+  it("expands the footer on e", async () => {
+    const user = userEvent.setup();
+    refreshHome.mockResolvedValue(configured());
+    toggleRepositoriesFooter.mockResolvedValue({ ...configured(), footer_expanded: true });
+
+    render(<App />);
+    await waitFor(() => expect(screen.getByText("Repositories")).toBeTruthy());
+
+    await user.keyboard("e");
+
+    await waitFor(() => expect(screen.getByText("braidonw/zreview")).toBeTruthy());
+  });
+});

--- a/apps/desktop/src/SessionApp.tsx
+++ b/apps/desktop/src/SessionApp.tsx
@@ -1,0 +1,37 @@
+import { FailureScreen } from "./components/FailureScreen";
+import { LoadingScreen } from "./components/LoadingScreen";
+import { SessionShell } from "./components/SessionShell";
+import { useSession } from "./hooks/useSession";
+
+export function SessionApp({ description }: { description: string }) {
+  const {
+    state,
+    selectFile,
+    clickRow,
+    openComposer,
+    closeComposer,
+    composerChange,
+    composerDiscard,
+    reanchorDraft,
+  } = useSession(description);
+
+  switch (state.status) {
+    case "loading":
+      return <LoadingScreen description={state.description} stage={state.stage} />;
+    case "failed":
+      return <FailureScreen failure={state.failure} />;
+    case "ready":
+      return (
+        <SessionShell
+          state={state}
+          onSelectFile={selectFile}
+          onRowClick={clickRow}
+          onOpenComposer={openComposer}
+          onComposerChange={composerChange}
+          onComposerClose={closeComposer}
+          onComposerDiscard={composerDiscard}
+          onReanchorDraft={reanchorDraft}
+        />
+      );
+  }
+}

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -5,6 +5,35 @@ import { invoke as __TAURI_INVOKE, Channel } from "@tauri-apps/api/core";
 /** Commands */
 export const commands = {
 	/**
+	 *  Which screen the binary was launched into, asked once before anything is
+	 *  rendered.
+	 * 
+	 *  A Session carries its request's own description, which is all the loading
+	 *  screen can say before the load reaches the pull request itself.
+	 */
+	describeLaunch: () => __TAURI_INVOKE<LaunchDto>("describe_launch"),
+	/**
+	 *  Re-reads the settings file and resolves every clone it lists.
+	 * 
+	 *  Runs when Home opens, after an Add or a Remove, and on `r`. A settings file
+	 *  that cannot be read comes back as the snapshot's failure rather than as a
+	 *  command error, because the header and footer stay on screen either way.
+	 */
+	refreshHome: () => __TAURI_INVOKE<HomeSnapshotDto>("refresh_home"),
+	/**
+	 *  Adds the folders the reviewer picked, writing the file once and refreshing.
+	 * 
+	 *  A folder that is not a clone of a GitHub repository is refused with its
+	 *  reason while the rest proceed, and one already listed is ignored.
+	 */
+	addRepositories: (folders: string[]) => __TAURI_INVOKE<HomeSnapshotDto>("add_repositories", { folders }),
+	/**  Drops one configured clone, writing the file and refreshing. */
+	removeRepository: (path: string) => __TAURI_INVOKE<HomeSnapshotDto>("remove_repository", { path }),
+	/**  Opens or closes the Repositories footer. */
+	toggleRepositoriesFooter: () => __TAURI_INVOKE<HomeSnapshotDto>("toggle_repositories_footer"),
+	/**  Clears the refusals the last Add reported. */
+	dismissRefusals: () => __TAURI_INVOKE<HomeSnapshotDto>("dismiss_refusals"),
+	/**
 	 *  Loads the review session the window was opened with, reporting each stage on
 	 *  `on_stage` as it goes.
 	 * 
@@ -29,11 +58,6 @@ export const commands = {
 	 *  Returns a failure when the session is not ready.
 	 */
 	toggleViewed: () => typedError<SidebarDto, SessionFailureDto>(__TAURI_INVOKE("toggle_viewed")),
-	/**
-	 *  The request's own description, shown by the loading screen before anything
-	 *  about the target session is known.
-	 */
-	describeSession: () => __TAURI_INVOKE<string>("describe_session"),
 	/**
 	 *  Edits the draft over rows `start..=end` of `file_index`. Persists the new
 	 *  text on every call. That is what makes a keystroke survive a crash.
@@ -67,6 +91,12 @@ export const commands = {
 };
 
 /* Types */
+/**  A picked folder Home would not add, and why. */
+export type AddRefusalDto = {
+	folder: string,
+	reason: string,
+};
+
 /**  A draft resolved to the row it is drawn on. */
 export type AnchoredDraftDto = {
 	row: number,
@@ -125,6 +155,43 @@ export type FileSummaryDto = {
 	viewed: boolean,
 	thread_count: number,
 };
+
+/**  One of Home's three groups, always rendered whether or not it has rows. */
+export type HomeGroupDto = {
+	title: string,
+	count: number,
+	/**  The one line an empty group shows in place of rows. */
+	empty_copy: string,
+};
+
+/**  One configured clone as the footer lists it. */
+export type HomeRepositoryDto = {
+	path: string,
+	slug: string | null,
+	/**  Why this clone cannot be listed, absent when it resolved. */
+	failure: string | null,
+};
+
+/**  Everything Home renders, from its header to its footer. */
+export type HomeSnapshotDto = {
+	/**  The header's count line, absent until there is something to count. */
+	count_line: string | null,
+	groups: HomeGroupDto[],
+	repositories: HomeRepositoryDto[],
+	footer_summary: string,
+	footer_expanded: boolean,
+	refusals: AddRefusalDto[],
+	/**
+	 *  What replaces the list area when Home cannot read its repositories. The
+	 *  header and footer stay either way, so Add still works.
+	 */
+	failure: SessionFailureDto | null,
+};
+
+/**  Which screen the binary was launched into. */
+export type LaunchDto = "Home" | { Session: {
+	description: string,
+} };
 
 export type RowDto = {
 	kind: DiffLineKindDto,

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -16,23 +16,35 @@ export const commands = {
 	 *  Re-reads the settings file and resolves every clone it lists.
 	 * 
 	 *  Runs when Home opens, after an Add or a Remove, and on `r`. A settings file
-	 *  that cannot be read comes back as the snapshot's failure rather than as a
-	 *  command error, because the header and footer stay on screen either way.
+	 *  that cannot be read comes back inside the snapshot rather than as a command
+	 *  error, because the header and footer stay on screen either way.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns a failure when the task doing the reading does not finish.
 	 */
-	refreshHome: () => __TAURI_INVOKE<HomeSnapshotDto>("refresh_home"),
+	refreshHome: () => typedError<HomeSnapshotDto, SessionFailureDto>(__TAURI_INVOKE("refresh_home")),
 	/**
 	 *  Adds the folders the reviewer picked, writing the file once and refreshing.
 	 * 
 	 *  A folder that is not a clone of a GitHub repository is refused with its
 	 *  reason while the rest proceed, and one already listed is ignored.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns a failure when the task doing the work does not finish.
 	 */
-	addRepositories: (folders: string[]) => __TAURI_INVOKE<HomeSnapshotDto>("add_repositories", { folders }),
-	/**  Drops one configured clone, writing the file and refreshing. */
-	removeRepository: (path: string) => __TAURI_INVOKE<HomeSnapshotDto>("remove_repository", { path }),
+	addRepositories: (folders: string[]) => typedError<HomeSnapshotDto, SessionFailureDto>(__TAURI_INVOKE("add_repositories", { folders })),
+	/**
+	 *  Drops one configured clone, writing the file and refreshing.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns a failure when the task doing the work does not finish.
+	 */
+	removeRepository: (path: string) => typedError<HomeSnapshotDto, SessionFailureDto>(__TAURI_INVOKE("remove_repository", { path })),
 	/**  Opens or closes the Repositories footer. */
 	toggleRepositoriesFooter: () => __TAURI_INVOKE<HomeSnapshotDto>("toggle_repositories_footer"),
-	/**  Clears the refusals the last Add reported. */
-	dismissRefusals: () => __TAURI_INVOKE<HomeSnapshotDto>("dismiss_refusals"),
 	/**
 	 *  Loads the review session the window was opened with, reporting each stage on
 	 *  `on_stage` as it goes.
@@ -91,12 +103,6 @@ export const commands = {
 };
 
 /* Types */
-/**  A picked folder Home would not add, and why. */
-export type AddRefusalDto = {
-	folder: string,
-	reason: string,
-};
-
 /**  A draft resolved to the row it is drawn on. */
 export type AnchoredDraftDto = {
 	row: number,
@@ -180,18 +186,29 @@ export type HomeSnapshotDto = {
 	repositories: HomeRepositoryDto[],
 	footer_summary: string,
 	footer_expanded: boolean,
-	refusals: AddRefusalDto[],
+	refusals: RefusalDto[],
 	/**
 	 *  What replaces the list area when Home cannot read its repositories. The
 	 *  header and footer stay either way, so Add still works.
 	 */
 	failure: SessionFailureDto | null,
+	/**
+	 *  Why the last write did not reach the file, shown as a line above the
+	 *  list, which stays because reading it still worked.
+	 */
+	write_failure: SessionFailureDto | null,
 };
 
 /**  Which screen the binary was launched into. */
 export type LaunchDto = "Home" | { Session: {
 	description: string,
 } };
+
+/**  Something Home would not do, and why. */
+export type RefusalDto = {
+	path: string,
+	reason: string,
+};
 
 export type RowDto = {
 	kind: DiffLineKindDto,

--- a/apps/desktop/src/components/FailureScreen.tsx
+++ b/apps/desktop/src/components/FailureScreen.tsx
@@ -5,10 +5,10 @@ export function FailureScreen({ failure }: { failure: SessionFailureDto }) {
   return (
     <div className="failure-screen">
       <div className="failure-screen__summary">{failure.summary}</div>
-      {failure.detail !== null && <div className="failure-screen__detail">{failure.detail}</div>}
       {failure.remediation !== null && (
         <div className="failure-screen__remediation">{failure.remediation}</div>
       )}
+      {failure.detail !== null && <div className="failure-screen__detail">{failure.detail}</div>}
     </div>
   );
 }

--- a/apps/desktop/src/components/HomeScreen.css
+++ b/apps/desktop/src/components/HomeScreen.css
@@ -1,0 +1,247 @@
+.home {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--surface-base);
+}
+
+.home__header {
+  flex-shrink: 0;
+  height: 52px;
+  padding: 0 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--border-default);
+  background: var(--surface-raised);
+}
+
+.home__heading {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.home__title {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: var(--size-heading);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.home__count {
+  font-family: var(--font-mono);
+  font-size: var(--size-meta);
+  color: var(--text-tertiary);
+}
+
+.home__body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.home__body--list {
+  padding: 0 20px 24px;
+}
+
+.home__body--empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 0 48px;
+  text-align: center;
+}
+
+.home__empty-heading {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: var(--size-heading);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.home__empty-copy {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: var(--size-body);
+  color: var(--text-secondary);
+}
+
+.home__group {
+  padding-top: 20px;
+  display: flex;
+  flex-direction: column;
+}
+
+.home__group-label {
+  padding-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* The uppercase section label the header, the groups, and the footer share. */
+.home__label {
+  font-family: var(--font-sans);
+  font-size: var(--size-label);
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.home__group-count {
+  font-family: var(--font-mono);
+  font-size: var(--size-label);
+  color: var(--text-faint);
+}
+
+.home__group-empty {
+  height: 36px;
+  display: flex;
+  align-items: center;
+  font-family: var(--font-sans);
+  font-size: var(--size-body);
+  color: var(--text-faint);
+}
+
+.home__footer {
+  flex-shrink: 0;
+  padding: 12px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-top: 1px solid var(--border-default);
+  background: var(--surface-raised);
+}
+
+.home__footer-line {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.home__footer-toggle {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0;
+  border: 0;
+  background: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.home__summary {
+  font-family: var(--font-mono);
+  font-size: var(--size-meta);
+  color: var(--text-tertiary);
+}
+
+.home__button {
+  padding: 4px 12px;
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  background: var(--surface-overlay);
+  font-family: var(--font-sans);
+  font-size: var(--size-meta);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.home__button:hover {
+  background: var(--surface-hover);
+}
+
+.home__button--primary {
+  border-color: var(--accent-base);
+  background: var(--accent-base);
+  color: var(--text-on-accent);
+}
+
+.home__button--primary:hover {
+  background: var(--accent-hover);
+}
+
+.home__refusals {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.home__refusal {
+  height: 24px;
+  display: flex;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: var(--size-meta);
+  color: var(--severity-warning-text);
+}
+
+.home__dismiss {
+  align-self: flex-start;
+  padding: 0;
+  border: 0;
+  background: none;
+  font-family: var(--font-sans);
+  font-size: var(--size-label);
+  color: var(--text-tertiary);
+  cursor: pointer;
+}
+
+.home__repository {
+  height: 24px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.home__slug {
+  width: 200px;
+  flex-shrink: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: var(--size-meta);
+  color: var(--text-secondary);
+}
+
+.home__path {
+  width: 220px;
+  flex-shrink: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: var(--size-meta);
+  color: var(--text-faint);
+}
+
+.home__state {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: var(--size-meta);
+  color: var(--severity-error-text);
+}
+
+.home__remove {
+  padding: 0;
+  border: 0;
+  background: none;
+  font-family: var(--font-mono);
+  font-size: var(--size-meta);
+  color: var(--text-faint);
+  cursor: pointer;
+}
+
+.home__remove:hover {
+  color: var(--text-secondary);
+}

--- a/apps/desktop/src/components/HomeScreen.css
+++ b/apps/desktop/src/components/HomeScreen.css
@@ -71,6 +71,21 @@
   color: var(--text-secondary);
 }
 
+.home__write-failure {
+  min-height: var(--file-row-height);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-family: var(--font-sans);
+  font-size: var(--size-body);
+  color: var(--severity-error-text);
+}
+
+.home__write-remediation {
+  font-size: var(--size-meta);
+  color: var(--text-secondary);
+}
+
 .home__group {
   padding-top: 20px;
   display: flex;
@@ -100,7 +115,7 @@
 }
 
 .home__group-empty {
-  height: 36px;
+  height: var(--file-row-height);
   display: flex;
   align-items: center;
   font-family: var(--font-sans);
@@ -169,12 +184,6 @@
   background: var(--accent-hover);
 }
 
-.home__refusals {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
 .home__refusal {
   height: 24px;
   display: flex;
@@ -182,17 +191,6 @@
   font-family: var(--font-mono);
   font-size: var(--size-meta);
   color: var(--severity-warning-text);
-}
-
-.home__dismiss {
-  align-self: flex-start;
-  padding: 0;
-  border: 0;
-  background: none;
-  font-family: var(--font-sans);
-  font-size: var(--size-label);
-  color: var(--text-tertiary);
-  cursor: pointer;
 }
 
 .home__repository {

--- a/apps/desktop/src/components/HomeScreen.tsx
+++ b/apps/desktop/src/components/HomeScreen.tsx
@@ -1,0 +1,104 @@
+import type { HomeSnapshotDto } from "../bindings";
+import { useHome } from "../hooks/useHome";
+import { FailureScreen } from "./FailureScreen";
+import "./HomeScreen.css";
+
+/** The screen ZReview opens on when no pull request has been named. */
+export function HomeScreen() {
+  const { snapshot, toggleFooter, dismissRefusals, addRepositories, removeRepository } = useHome();
+
+  // Nothing is drawn until the first read answers, so no empty state flashes
+  // in front of a list that is about to arrive.
+  if (snapshot === null) {
+    return null;
+  }
+
+  return (
+    <div className="home">
+      <header className="home__header">
+        <div className="home__heading">
+          <h1 className="home__title">Home</h1>
+          {snapshot.count_line !== null && (
+            <span className="home__count">{snapshot.count_line}</span>
+          )}
+        </div>
+      </header>
+      <HomeBody snapshot={snapshot} onAdd={addRepositories} />
+      <footer className="home__footer">
+        <div className="home__footer-line">
+          <button className="home__footer-toggle" type="button" onClick={toggleFooter}>
+            <span className="home__label">Repositories</span>
+            <span className="home__summary">{snapshot.footer_summary}</span>
+          </button>
+          <button className="home__button" type="button" onClick={addRepositories}>
+            Add...
+          </button>
+        </div>
+        {snapshot.refusals.length > 0 && (
+          <div className="home__refusals">
+            {snapshot.refusals.map((refusal) => (
+              <div className="home__refusal" key={refusal.folder}>
+                {refusal.folder}: {refusal.reason}
+              </div>
+            ))}
+            <button className="home__dismiss" type="button" onClick={dismissRefusals}>
+              Dismiss
+            </button>
+          </div>
+        )}
+        {snapshot.footer_expanded &&
+          snapshot.repositories.map((repository) => (
+            <div className="home__repository" key={repository.path}>
+              <span className="home__slug">{repository.slug}</span>
+              <span className="home__path">{repository.path}</span>
+              <span className="home__state">{repository.failure}</span>
+              <button
+                className="home__remove"
+                type="button"
+                onClick={() => removeRepository(repository.path)}
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+      </footer>
+    </div>
+  );
+}
+
+/** The list area, which the empty state and a whole-Home failure each replace. */
+function HomeBody({ snapshot, onAdd }: { snapshot: HomeSnapshotDto; onAdd: () => void }) {
+  if (snapshot.failure !== null) {
+    return (
+      <div className="home__body">
+        <FailureScreen failure={snapshot.failure} />
+      </div>
+    );
+  }
+  if (snapshot.repositories.length === 0) {
+    return (
+      <div className="home__body home__body--empty">
+        <h2 className="home__empty-heading">No repositories yet</h2>
+        <p className="home__empty-copy">
+          Add a local clone and Home lists the pull requests that want you.
+        </p>
+        <button className="home__button home__button--primary" type="button" onClick={onAdd}>
+          Add repository...
+        </button>
+      </div>
+    );
+  }
+  return (
+    <div className="home__body home__body--list">
+      {snapshot.groups.map((group) => (
+        <section className="home__group" key={group.title}>
+          <div className="home__group-label">
+            <span className="home__label">{group.title}</span>
+            <span className="home__group-count">{group.count}</span>
+          </div>
+          {group.count === 0 && <div className="home__group-empty">{group.empty_copy}</div>}
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/HomeScreen.tsx
+++ b/apps/desktop/src/components/HomeScreen.tsx
@@ -5,10 +5,13 @@ import "./HomeScreen.css";
 
 /** The screen ZReview opens on when no pull request has been named. */
 export function HomeScreen() {
-  const { snapshot, toggleFooter, dismissRefusals, addRepositories, removeRepository } = useHome();
+  const { snapshot, failure, toggleFooter, addRepositories, removeRepository } = useHome();
 
-  // Nothing is drawn until the first read answers, so no empty state flashes
-  // in front of a list that is about to arrive.
+  // A command that never answered leaves nothing worth trusting on screen.
+  if (failure !== null) {
+    return <FailureScreen failure={failure} />;
+  }
+  // Nothing is drawn until the first read answers, so no empty state flashes in front of a list.
   if (snapshot === null) {
     return null;
   }
@@ -34,18 +37,11 @@ export function HomeScreen() {
             Add...
           </button>
         </div>
-        {snapshot.refusals.length > 0 && (
-          <div className="home__refusals">
-            {snapshot.refusals.map((refusal) => (
-              <div className="home__refusal" key={refusal.folder}>
-                {refusal.folder}: {refusal.reason}
-              </div>
-            ))}
-            <button className="home__dismiss" type="button" onClick={dismissRefusals}>
-              Dismiss
-            </button>
+        {snapshot.refusals.map((refusal) => (
+          <div className="home__refusal" key={refusal.path}>
+            {refusal.path}: {refusal.reason}
           </div>
-        )}
+        ))}
         {snapshot.footer_expanded &&
           snapshot.repositories.map((repository) => (
             <div className="home__repository" key={repository.path}>
@@ -90,6 +86,16 @@ function HomeBody({ snapshot, onAdd }: { snapshot: HomeSnapshotDto; onAdd: () =>
   }
   return (
     <div className="home__body home__body--list">
+      {snapshot.write_failure !== null && (
+        <div className="home__write-failure">
+          <span>{snapshot.write_failure.summary}</span>
+          {snapshot.write_failure.remediation !== null && (
+            <span className="home__write-remediation">
+              {snapshot.write_failure.remediation}
+            </span>
+          )}
+        </div>
+      )}
       {snapshot.groups.map((group) => (
         <section className="home__group" key={group.title}>
           <div className="home__group-label">

--- a/apps/desktop/src/hooks/useHome.ts
+++ b/apps/desktop/src/hooks/useHome.ts
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { open } from "@tauri-apps/plugin-dialog";
+import type { HomeSnapshotDto } from "../bindings";
+import { commands } from "../bindings";
+
+/** Reads Home's repositories and exposes every action the screen can take on them. */
+export function useHome() {
+  const [snapshot, setSnapshot] = useState<HomeSnapshotDto | null>(null);
+  const hasOpened = useRef(false);
+
+  const refresh = useCallback(() => {
+    void commands.refreshHome().then(setSnapshot);
+  }, []);
+
+  useEffect(() => {
+    // Guarded so React StrictMode's double mount effect does not read the
+    // settings file twice on the way in.
+    if (hasOpened.current) {
+      return;
+    }
+    hasOpened.current = true;
+    refresh();
+  }, [refresh]);
+
+  const toggleFooter = useCallback(() => {
+    void commands.toggleRepositoriesFooter().then(setSnapshot);
+  }, []);
+
+  const dismissRefusals = useCallback(() => {
+    void commands.dismissRefusals().then(setSnapshot);
+  }, []);
+
+  const removeRepository = useCallback((path: string) => {
+    void commands.removeRepository(path).then(setSnapshot);
+  }, []);
+
+  /** Opens the native folder picker, then hands what was chosen to the add command. */
+  const addRepositories = useCallback(() => {
+    void open({
+      directory: true,
+      multiple: true,
+      title: "Add repositories",
+    }).then((picked) => {
+      if (picked === null) {
+        return;
+      }
+      const folders = Array.isArray(picked) ? picked : [picked];
+      return commands.addRepositories(folders).then(setSnapshot);
+    });
+  }, []);
+
+  // r refreshes and e opens or closes the Repositories footer, as the layout
+  // prototype bound them.
+  useEffect(() => {
+    function handleKeydown(event: KeyboardEvent) {
+      if (event.metaKey || event.ctrlKey || event.altKey) {
+        return;
+      }
+      const key = event.key.toLowerCase();
+      if (key === "r") {
+        event.preventDefault();
+        refresh();
+        return;
+      }
+      if (key === "e") {
+        event.preventDefault();
+        toggleFooter();
+      }
+    }
+
+    window.addEventListener("keydown", handleKeydown);
+    return () => window.removeEventListener("keydown", handleKeydown);
+  }, [refresh, toggleFooter]);
+
+  return { snapshot, refresh, toggleFooter, dismissRefusals, addRepositories, removeRepository };
+}

--- a/apps/desktop/src/hooks/useHome.ts
+++ b/apps/desktop/src/hooks/useHome.ts
@@ -1,20 +1,48 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
-import type { HomeSnapshotDto } from "../bindings";
+import type { HomeSnapshotDto, SessionFailureDto } from "../bindings";
 import { commands } from "../bindings";
+import { toFailure } from "../lib/failure";
+
+/** What a command that touches the settings file answers with. */
+type HomeResult =
+  | { status: "ok"; data: HomeSnapshotDto }
+  | { status: "error"; error: SessionFailureDto };
+
+/** Whether a keystroke belongs to something the reviewer is typing into. */
+function isTyping(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  return target.isContentEditable || target.closest("input, textarea") !== null;
+}
 
 /** Reads Home's repositories and exposes every action the screen can take on them. */
 export function useHome() {
   const [snapshot, setSnapshot] = useState<HomeSnapshotDto | null>(null);
+  const [failure, setFailure] = useState<SessionFailureDto | null>(null);
   const hasOpened = useRef(false);
 
-  const refresh = useCallback(() => {
-    void commands.refreshHome().then(setSnapshot);
+  /** Takes what a command answered, so a rejection is shown rather than swallowed. */
+  const apply = useCallback((call: Promise<HomeResult>) => {
+    call
+      .then((result) => {
+        if (result.status === "error") {
+          setFailure(toFailure(result.error));
+          return;
+        }
+        setFailure(null);
+        setSnapshot(result.data);
+      })
+      .catch((error: unknown) => setFailure(toFailure(error)));
   }, []);
 
+  const refresh = useCallback(() => {
+    apply(commands.refreshHome());
+  }, [apply]);
+
   useEffect(() => {
-    // Guarded so React StrictMode's double mount effect does not read the
-    // settings file twice on the way in.
+    // Guarded so StrictMode's double mount effect does not read the file twice.
     if (hasOpened.current) {
       return;
     }
@@ -23,37 +51,46 @@ export function useHome() {
   }, [refresh]);
 
   const toggleFooter = useCallback(() => {
-    void commands.toggleRepositoriesFooter().then(setSnapshot);
+    commands
+      .toggleRepositoriesFooter()
+      .then((toggled) => {
+        setFailure(null);
+        setSnapshot(toggled);
+      })
+      .catch((error: unknown) => setFailure(toFailure(error)));
   }, []);
 
-  const dismissRefusals = useCallback(() => {
-    void commands.dismissRefusals().then(setSnapshot);
-  }, []);
-
-  const removeRepository = useCallback((path: string) => {
-    void commands.removeRepository(path).then(setSnapshot);
-  }, []);
+  const removeRepository = useCallback(
+    (path: string) => {
+      apply(commands.removeRepository(path));
+    },
+    [apply],
+  );
 
   /** Opens the native folder picker, then hands what was chosen to the add command. */
   const addRepositories = useCallback(() => {
-    void open({
+    open({
       directory: true,
       multiple: true,
       title: "Add repositories",
-    }).then((picked) => {
-      if (picked === null) {
-        return;
-      }
-      const folders = Array.isArray(picked) ? picked : [picked];
-      return commands.addRepositories(folders).then(setSnapshot);
-    });
-  }, []);
+    })
+      .then((picked) => {
+        if (picked === null) {
+          return;
+        }
+        const folders = Array.isArray(picked) ? picked : [picked];
+        apply(commands.addRepositories(folders));
+      })
+      .catch((error: unknown) => setFailure(toFailure(error)));
+  }, [apply]);
 
-  // r refreshes and e opens or closes the Repositories footer, as the layout
-  // prototype bound them.
+  // r refreshes and e opens or closes the Repositories footer, as the layout prototype bound them.
   useEffect(() => {
     function handleKeydown(event: KeyboardEvent) {
-      if (event.metaKey || event.ctrlKey || event.altKey) {
+      if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
+        return;
+      }
+      if (isTyping(event.target)) {
         return;
       }
       const key = event.key.toLowerCase();
@@ -72,5 +109,5 @@ export function useHome() {
     return () => window.removeEventListener("keydown", handleKeydown);
   }, [refresh, toggleFooter]);
 
-  return { snapshot, refresh, toggleFooter, dismissRefusals, addRepositories, removeRepository };
+  return { snapshot, failure, refresh, toggleFooter, addRepositories, removeRepository };
 }

--- a/apps/desktop/src/hooks/useSession.ts
+++ b/apps/desktop/src/hooks/useSession.ts
@@ -1,24 +1,12 @@
 import { useCallback, useEffect, useReducer, useRef } from "react";
 import { Channel } from "@tauri-apps/api/core";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
-import type { DiffSideDto, SessionFailureDto } from "../bindings";
+import type { DiffSideDto } from "../bindings";
 import { commands } from "../bindings";
 import { clamp } from "../lib/clamp";
+import { toFailure } from "../lib/failure";
 import { initialState, selectionRange, sessionReducer } from "./sessionReducer";
 import { useDraftQueue } from "./useDraftQueue";
-
-/** Narrows a command rejection into a SessionFailureDto. */
-function toFailure(error: unknown): SessionFailureDto {
-  if (
-    typeof error === "object" &&
-    error !== null &&
-    "summary" in error &&
-    typeof (error as { summary: unknown }).summary === "string"
-  ) {
-    return error as SessionFailureDto;
-  }
-  return { summary: String(error), detail: null, remediation: null };
-}
 
 /** Loads the session the window was launched into and exposes every action the UI can take on it. */
 export function useSession(description: string) {

--- a/apps/desktop/src/hooks/useSession.ts
+++ b/apps/desktop/src/hooks/useSession.ts
@@ -20,8 +20,8 @@ function toFailure(error: unknown): SessionFailureDto {
   return { summary: String(error), detail: null, remediation: null };
 }
 
-/** Loads the demo session and exposes every action the UI can take on it. */
-export function useSession() {
+/** Loads the session the window was launched into and exposes every action the UI can take on it. */
+export function useSession(description: string) {
   const [state, dispatch] = useReducer(sessionReducer, initialState);
   const stateRef = useRef(state);
   stateRef.current = state;
@@ -33,34 +33,31 @@ export function useSession() {
       return;
     }
     hasOpened.current = true;
+    dispatch({ type: "describe", description });
+
+    const channel = new Channel<string>();
+    channel.onmessage = (stage) => dispatch({ type: "stage", stage });
 
     commands
-      .describeSession()
-      .then((description) => {
-        dispatch({ type: "describe", description });
-
-        const channel = new Channel<string>();
-        channel.onmessage = (stage) => dispatch({ type: "stage", stage });
-
-        commands.openSession(channel).then((opened) => {
-          if (opened.status === "error") {
-            dispatch({ type: "failed", failure: toFailure(opened.error) });
+      .openSession(channel)
+      .then((opened) => {
+        if (opened.status === "error") {
+          dispatch({ type: "failed", failure: toFailure(opened.error) });
+          return;
+        }
+        const snapshot = opened.data;
+        commands.selectFile(0).then((selected) => {
+          if (selected.status === "error") {
+            dispatch({ type: "failed", failure: toFailure(selected.error) });
             return;
           }
-          const snapshot = opened.data;
-          commands.selectFile(0).then((selected) => {
-            if (selected.status === "error") {
-              dispatch({ type: "failed", failure: toFailure(selected.error) });
-              return;
-            }
-            dispatch({ type: "ready", snapshot, file: selected.data });
-          });
+          dispatch({ type: "ready", snapshot, file: selected.data });
         });
       })
       .catch((error: unknown) => {
         dispatch({ type: "failed", failure: toFailure(error) });
       });
-  }, []);
+  }, [description]);
 
   const selectFile = useCallback((index: number) => {
     commands.selectFile(index).then((selected) => {

--- a/apps/desktop/src/lib/failure.ts
+++ b/apps/desktop/src/lib/failure.ts
@@ -1,0 +1,14 @@
+import type { SessionFailureDto } from "../bindings";
+
+/** Narrows a command rejection into a SessionFailureDto. */
+export function toFailure(error: unknown): SessionFailureDto {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "summary" in error &&
+    typeof (error as { summary: unknown }).summary === "string"
+  ) {
+    return error as SessionFailureDto;
+  }
+  return { summary: String(error), detail: null, remediation: null };
+}

--- a/apps/desktop/src/test/fixtures.ts
+++ b/apps/desktop/src/test/fixtures.ts
@@ -121,6 +121,7 @@ export function makeHomeSnapshot(overrides: Partial<HomeSnapshotDto> = {}): Home
     footer_expanded: false,
     refusals: [],
     failure: null,
+    write_failure: null,
     ...overrides,
   };
 }

--- a/apps/desktop/src/test/fixtures.ts
+++ b/apps/desktop/src/test/fixtures.ts
@@ -3,6 +3,8 @@ import type {
   DraftsDto,
   FileDetailDto,
   FileSummaryDto,
+  HomeRepositoryDto,
+  HomeSnapshotDto,
   RowDto,
   SessionSnapshotDto,
   SidebarDto,
@@ -93,6 +95,32 @@ export function makeSnapshot(overrides: Partial<SessionSnapshotDto> = {}): Sessi
     subtitle: "Diff virtualization demo",
     sidebar: makeSidebar(),
     warnings: [],
+    ...overrides,
+  };
+}
+
+export function makeHomeRepository(overrides: Partial<HomeRepositoryDto> = {}): HomeRepositoryDto {
+  return {
+    path: "/Developer/zreview",
+    slug: "braidonw/zreview",
+    failure: null,
+    ...overrides,
+  };
+}
+
+export function makeHomeSnapshot(overrides: Partial<HomeSnapshotDto> = {}): HomeSnapshotDto {
+  return {
+    count_line: null,
+    groups: [
+      { title: "To review", count: 0, empty_copy: "Nothing waiting for your review." },
+      { title: "To address", count: 0, empty_copy: "Nothing to address." },
+      { title: "Waiting on others", count: 0, empty_copy: "Nothing waiting on others." },
+    ],
+    repositories: [],
+    footer_summary: "No repositories",
+    footer_expanded: false,
+    refusals: [],
+    failure: null,
     ...overrides,
   };
 }

--- a/crates/app/src/home.rs
+++ b/crates/app/src/home.rs
@@ -277,7 +277,7 @@ impl HomeModel {
         let counted = repository_count(self.repositories.len());
         match self.failed_count() {
             0 => counted,
-            failed => format!("{counted} · {failed} failed"),
+            failed => format!("{counted} \u{00B7} {failed} failed"),
         }
     }
 }
@@ -405,7 +405,7 @@ mod tests {
             failed("/Developer/moved", "the folder no longer exists"),
         ]));
 
-        assert_eq!(home.footer_summary(), "4 repositories · 1 failed");
+        assert_eq!(home.footer_summary(), "4 repositories \u{00B7} 1 failed");
     }
 
     #[test]

--- a/crates/app/src/home.rs
+++ b/crates/app/src/home.rs
@@ -1,0 +1,645 @@
+//! What Home shows and every action that changes it, with no window in it.
+//!
+//! Home reads its repositories from a settings file and resolves each one to a
+//! GitHub repository, but neither the file nor Git is touched here. A refresh
+//! arrives already read and already validated, so this model is all decisions
+//! and no I/O, and effects on the file come back as return values.
+
+use std::path::{Path, PathBuf};
+
+use domain::SessionFailure;
+
+/// What resolving one clone found.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RepositoryOutcome {
+    /// The worktree root the clone resolved to, and the GitHub repository its
+    /// remotes name.
+    Valid { root: PathBuf, slug: String },
+    /// Why Home cannot list this clone.
+    Failed { reason: String },
+}
+
+/// One clone and what resolving it found.
+///
+/// The path is the one the settings file lists, or the one the picker returned,
+/// which is not always the worktree root.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RepositoryEntry {
+    pub path: PathBuf,
+    pub outcome: RepositoryOutcome,
+}
+
+impl RepositoryEntry {
+    /// The GitHub repository this clone points at, absent when it did not resolve.
+    #[must_use]
+    pub fn slug(&self) -> Option<&str> {
+        match &self.outcome {
+            RepositoryOutcome::Valid { slug, .. } => Some(slug),
+            RepositoryOutcome::Failed { .. } => None,
+        }
+    }
+
+    /// Why this clone cannot be listed, absent when it resolved.
+    #[must_use]
+    pub fn reason(&self) -> Option<&str> {
+        match &self.outcome {
+            RepositoryOutcome::Valid { .. } => None,
+            RepositoryOutcome::Failed { reason } => Some(reason),
+        }
+    }
+
+    /// The worktree root, when there is one, which is what identifies a clone.
+    fn root(&self) -> Option<&Path> {
+        match &self.outcome {
+            RepositoryOutcome::Valid { root, .. } => Some(root),
+            RepositoryOutcome::Failed { .. } => None,
+        }
+    }
+
+    #[must_use]
+    const fn is_failed(&self) -> bool {
+        matches!(self.outcome, RepositoryOutcome::Failed { .. })
+    }
+}
+
+/// A picked folder Home would not add, and why.
+///
+/// Shown until the next Add answers it or the reviewer dismisses it, so a
+/// selection that was partly refused says which part and what was wrong with it.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AddRefusal {
+    pub folder: PathBuf,
+    pub reason: String,
+}
+
+/// The repository list to write to the settings file, in the order it goes in.
+///
+/// Handed back rather than written here, so this model never touches the file.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SettingsWrite {
+    pub repositories: Vec<PathBuf>,
+}
+
+/// What a pull request wants from the reviewer, which is what Home groups by.
+///
+/// The groups are always rendered, and always in this order, so an empty one
+/// states that nothing is waiting rather than leaving it to be inferred.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HomeGroup {
+    ToReview,
+    ToAddress,
+    WaitingOnOthers,
+}
+
+impl HomeGroup {
+    pub const ALL: [Self; 3] = [Self::ToReview, Self::ToAddress, Self::WaitingOnOthers];
+
+    #[must_use]
+    pub const fn title(self) -> &'static str {
+        match self {
+            Self::ToReview => "To review",
+            Self::ToAddress => "To address",
+            Self::WaitingOnOthers => "Waiting on others",
+        }
+    }
+
+    /// The one line an empty group shows in place of rows.
+    #[must_use]
+    pub const fn empty_copy(self) -> &'static str {
+        match self {
+            Self::ToReview => "Nothing waiting for your review.",
+            Self::ToAddress => "Nothing to address.",
+            Self::WaitingOnOthers => "Nothing waiting on others.",
+        }
+    }
+}
+
+/// Everything Home is, and every action that changes it.
+///
+/// Held behind a lock and shared by whatever is displaying it, as the session
+/// model is.
+#[derive(Debug, Default)]
+pub struct HomeModel {
+    repositories: Vec<RepositoryEntry>,
+    failure: Option<SessionFailure>,
+    footer_expanded: bool,
+    refusals: Vec<AddRefusal>,
+}
+
+impl HomeModel {
+    /// Starts empty, before the settings file has been read.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Takes what a refresh read, or the failure that stopped it reading.
+    ///
+    /// A failed read empties the list, because everything in it came from the
+    /// file that could not be read.
+    pub fn refreshed(&mut self, result: Result<Vec<RepositoryEntry>, SessionFailure>) {
+        match result {
+            Ok(repositories) => {
+                self.repositories = repositories;
+                self.failure = None;
+            }
+            Err(failure) => {
+                self.repositories.clear();
+                self.failure = Some(failure);
+            }
+        }
+    }
+
+    /// Records a failure that leaves the repository list standing, such as a
+    /// settings file that could be read but not written.
+    pub fn failed(&mut self, failure: SessionFailure) {
+        self.failure = Some(failure);
+    }
+
+    #[must_use]
+    pub fn repositories(&self) -> &[RepositoryEntry] {
+        &self.repositories
+    }
+
+    /// What stops Home listing anything at all, if anything does.
+    #[must_use]
+    pub const fn failure(&self) -> Option<&SessionFailure> {
+        self.failure.as_ref()
+    }
+
+    /// How many configured clones could not be resolved.
+    #[must_use]
+    pub fn failed_count(&self) -> usize {
+        self.repositories
+            .iter()
+            .filter(|entry| entry.is_failed())
+            .count()
+    }
+
+    /// The header's count line, absent while there is nothing to count.
+    ///
+    /// The pull requests it will also count are not fetched yet.
+    #[must_use]
+    pub fn count_line(&self) -> Option<String> {
+        (!self.repositories.is_empty()).then(|| repository_count(self.repositories.len()))
+    }
+
+    /// Takes the folders a reviewer picked, saying what the file should now hold.
+    ///
+    /// Every folder that resolved and is not already listed is accepted, so one
+    /// bad pick in a selection costs only itself. A folder already listed is
+    /// ignored rather than refused, because re-adding a clone is harmless and
+    /// says nothing a reviewer needs to act on. Nothing is written when nothing
+    /// was accepted.
+    #[must_use]
+    pub fn add_repositories(&mut self, picked: Vec<RepositoryEntry>) -> Option<SettingsWrite> {
+        // This selection's refusals replace the last one's, which the reviewer
+        // has now answered by picking again.
+        self.refusals.clear();
+        let mut repositories = self
+            .repositories
+            .iter()
+            .map(|entry| entry.path.clone())
+            .collect::<Vec<_>>();
+        let mut accepted = 0_usize;
+        for entry in picked {
+            match entry.outcome {
+                RepositoryOutcome::Valid { root, .. } => {
+                    if !self.is_listed(&root) && !repositories.contains(&root) {
+                        repositories.push(root);
+                        accepted += 1;
+                    }
+                }
+                RepositoryOutcome::Failed { reason } => self.refusals.push(AddRefusal {
+                    folder: entry.path,
+                    reason,
+                }),
+            }
+        }
+        (accepted > 0).then_some(SettingsWrite { repositories })
+    }
+
+    /// Drops the entry listed at `path`, saying what the file should now hold.
+    ///
+    /// Named by path rather than by position, so a click on a list that has been
+    /// refreshed underneath it removes the repository it was pointing at or
+    /// none at all. Nothing is written when the path is no longer listed.
+    #[must_use]
+    pub fn remove_repository(&mut self, path: &Path) -> Option<SettingsWrite> {
+        let repositories = self
+            .repositories
+            .iter()
+            .filter(|entry| entry.path != path)
+            .map(|entry| entry.path.clone())
+            .collect::<Vec<_>>();
+        (repositories.len() < self.repositories.len()).then_some(SettingsWrite { repositories })
+    }
+
+    /// The folders the last Add would not take, with the reason for each.
+    #[must_use]
+    pub fn refusals(&self) -> &[AddRefusal] {
+        &self.refusals
+    }
+
+    pub fn dismiss_refusals(&mut self) {
+        self.refusals.clear();
+    }
+
+    /// Whether `root` is a clone Home already lists.
+    ///
+    /// Compared against both the resolved root and the listed path, so a clone
+    /// whose entry did not resolve is still recognised as itself.
+    fn is_listed(&self, root: &Path) -> bool {
+        self.repositories
+            .iter()
+            .any(|entry| entry.root() == Some(root) || entry.path == root)
+    }
+
+    /// Whether the footer is showing every repository or just its summary line.
+    ///
+    /// Not persisted. It is a decision about this sitting, and a refresh leaves
+    /// it alone so the list does not fold up under whoever is reading it.
+    #[must_use]
+    pub const fn is_footer_expanded(&self) -> bool {
+        self.footer_expanded
+    }
+
+    pub const fn toggle_footer(&mut self) {
+        self.footer_expanded = !self.footer_expanded;
+    }
+
+    /// The one line the collapsed footer shows.
+    #[must_use]
+    pub fn footer_summary(&self) -> String {
+        if self.repositories.is_empty() {
+            return "No repositories".to_owned();
+        }
+        let counted = repository_count(self.repositories.len());
+        match self.failed_count() {
+            0 => counted,
+            failed => format!("{counted} · {failed} failed"),
+        }
+    }
+}
+
+/// "1 repository" or "4 repositories", as the count requires.
+fn repository_count(count: usize) -> String {
+    if count == 1 {
+        "1 repository".to_owned()
+    } else {
+        format!("{count} repositories")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use super::*;
+
+    /// A clone that resolved, listed by the path the settings file holds.
+    fn valid(path: &str, slug: &str) -> RepositoryEntry {
+        RepositoryEntry {
+            path: PathBuf::from(path),
+            outcome: RepositoryOutcome::Valid {
+                root: PathBuf::from(path),
+                slug: slug.to_owned(),
+            },
+        }
+    }
+
+    /// A clone that could not be resolved, with the reason a reviewer sees.
+    fn failed(path: &str, reason: &str) -> RepositoryEntry {
+        RepositoryEntry {
+            path: PathBuf::from(path),
+            outcome: RepositoryOutcome::Failed {
+                reason: reason.to_owned(),
+            },
+        }
+    }
+
+    #[test]
+    fn a_refresh_lists_every_configured_repository_with_its_slug() {
+        let mut home = HomeModel::new();
+
+        home.refreshed(Ok(vec![
+            valid("/Developer/zreview", "braidonw/zreview"),
+            valid("/Developer/widgets", "acme/widgets"),
+        ]));
+
+        let listed = home.repositories();
+        assert_eq!(listed.len(), 2);
+        assert_eq!(listed[0].path, Path::new("/Developer/zreview"));
+        assert_eq!(listed[0].slug(), Some("braidonw/zreview"));
+        assert_eq!(listed[1].slug(), Some("acme/widgets"));
+        assert!(home.failure().is_none());
+    }
+
+    #[test]
+    fn a_repository_that_cannot_be_resolved_keeps_its_reason_and_has_no_slug() {
+        let mut home = HomeModel::new();
+
+        home.refreshed(Ok(vec![
+            valid("/Developer/zreview", "braidonw/zreview"),
+            failed("/Developer/moved", "the folder no longer exists"),
+        ]));
+
+        let listed = home.repositories();
+        assert_eq!(listed[1].slug(), None);
+        assert_eq!(listed[1].reason(), Some("the folder no longer exists"));
+        assert_eq!(home.failed_count(), 1);
+    }
+
+    #[test]
+    fn a_settings_file_that_cannot_be_read_becomes_the_whole_home_failure() {
+        let mut home = HomeModel::new();
+        home.refreshed(Ok(vec![valid("/Developer/zreview", "braidonw/zreview")]));
+
+        home.refreshed(Err(SessionFailure::new("Could not read your settings")
+            .with_remediation(
+                "Fix ~/.config/zreview/settings.toml, then press r.",
+            )));
+
+        let failure = home.failure().expect("the failure should be held");
+        assert_eq!(failure.summary, "Could not read your settings");
+        assert!(
+            home.repositories().is_empty(),
+            "a list read from an unreadable file cannot be trusted",
+        );
+    }
+
+    #[test]
+    fn a_later_successful_refresh_clears_the_whole_home_failure() {
+        let mut home = HomeModel::new();
+        home.refreshed(Err(SessionFailure::new("Could not read your settings")));
+
+        home.refreshed(Ok(vec![valid("/Developer/zreview", "braidonw/zreview")]));
+
+        assert!(home.failure().is_none());
+        assert_eq!(home.repositories().len(), 1);
+    }
+
+    #[test]
+    fn the_count_line_counts_the_configured_repositories() {
+        let mut home = HomeModel::new();
+        assert_eq!(home.count_line(), None, "nothing to count before a refresh");
+
+        home.refreshed(Ok(vec![valid("/Developer/zreview", "braidonw/zreview")]));
+        assert_eq!(home.count_line().as_deref(), Some("1 repository"));
+
+        home.refreshed(Ok(vec![
+            valid("/Developer/zreview", "braidonw/zreview"),
+            valid("/Developer/widgets", "acme/widgets"),
+        ]));
+        assert_eq!(home.count_line().as_deref(), Some("2 repositories"));
+    }
+
+    #[test]
+    fn the_footer_summary_names_the_failed_repositories() {
+        let mut home = HomeModel::new();
+
+        home.refreshed(Ok(vec![
+            valid("/Developer/zreview", "braidonw/zreview"),
+            valid("/Developer/widgets", "acme/widgets"),
+            valid("/Developer/billing", "acme/billing"),
+            failed("/Developer/moved", "the folder no longer exists"),
+        ]));
+
+        assert_eq!(home.footer_summary(), "4 repositories · 1 failed");
+    }
+
+    #[test]
+    fn the_footer_summary_leaves_out_failures_when_every_repository_resolved() {
+        let mut home = HomeModel::new();
+
+        home.refreshed(Ok(vec![valid("/Developer/zreview", "braidonw/zreview")]));
+
+        assert_eq!(home.footer_summary(), "1 repository");
+    }
+
+    #[test]
+    fn the_footer_summary_reads_no_repositories_before_any_are_configured() {
+        let home = HomeModel::new();
+
+        assert_eq!(home.footer_summary(), "No repositories");
+    }
+
+    #[test]
+    fn the_footer_starts_collapsed_and_the_expansion_outlives_a_refresh() {
+        let mut home = HomeModel::new();
+        assert!(!home.is_footer_expanded());
+
+        home.toggle_footer();
+        assert!(home.is_footer_expanded());
+
+        home.refreshed(Ok(vec![valid("/Developer/zreview", "braidonw/zreview")]));
+        assert!(
+            home.is_footer_expanded(),
+            "a refresh should not close the footer under the reviewer",
+        );
+
+        home.toggle_footer();
+        assert!(!home.is_footer_expanded());
+    }
+
+    #[test]
+    fn the_groups_are_in_a_fixed_order_each_with_its_own_empty_copy() {
+        let titles = HomeGroup::ALL.map(HomeGroup::title);
+        let copy = HomeGroup::ALL.map(HomeGroup::empty_copy);
+
+        assert_eq!(titles, ["To review", "To address", "Waiting on others"]);
+        assert_eq!(
+            copy,
+            [
+                "Nothing waiting for your review.",
+                "Nothing to address.",
+                "Nothing waiting on others.",
+            ],
+        );
+    }
+
+    /// A picked folder that resolved, whose root is not the folder itself.
+    fn picked(folder: &str, root: &str, slug: &str) -> RepositoryEntry {
+        RepositoryEntry {
+            path: PathBuf::from(folder),
+            outcome: RepositoryOutcome::Valid {
+                root: PathBuf::from(root),
+                slug: slug.to_owned(),
+            },
+        }
+    }
+
+    /// Home with two clones already configured.
+    fn configured() -> HomeModel {
+        let mut home = HomeModel::new();
+        home.refreshed(Ok(vec![
+            valid("/Developer/zreview", "braidonw/zreview"),
+            valid("/Developer/widgets", "acme/widgets"),
+        ]));
+        home
+    }
+
+    #[test]
+    fn adding_folders_writes_the_existing_entries_then_every_accepted_root() {
+        let mut home = configured();
+
+        let write = home
+            .add_repositories(vec![picked(
+                "/Developer/billing/crates",
+                "/Developer/billing",
+                "acme/billing",
+            )])
+            .expect("an accepted folder should be written");
+
+        assert_eq!(
+            write.repositories,
+            [
+                PathBuf::from("/Developer/zreview"),
+                PathBuf::from("/Developer/widgets"),
+                PathBuf::from("/Developer/billing"),
+            ],
+            "the worktree root is written, not the folder that was picked",
+        );
+        assert!(home.refusals().is_empty());
+    }
+
+    #[test]
+    fn a_folder_that_did_not_resolve_is_refused_while_the_rest_proceed() {
+        let mut home = configured();
+
+        let write = home
+            .add_repositories(vec![
+                failed("/Developer/notes", "not a Git repository"),
+                picked("/Developer/billing", "/Developer/billing", "acme/billing"),
+            ])
+            .expect("the folder that did resolve should still be written");
+
+        assert!(
+            write
+                .repositories
+                .contains(&PathBuf::from("/Developer/billing"))
+        );
+        let refusals = home.refusals();
+        assert_eq!(refusals.len(), 1);
+        assert_eq!(refusals[0].folder, Path::new("/Developer/notes"));
+        assert_eq!(refusals[0].reason, "not a Git repository");
+    }
+
+    #[test]
+    fn an_add_that_accepts_nothing_writes_nothing_and_still_reports_the_refusal() {
+        let mut home = configured();
+
+        let write = home.add_repositories(vec![failed("/Developer/notes", "no GitHub remote")]);
+
+        assert!(
+            write.is_none(),
+            "nothing was accepted, so nothing is written"
+        );
+        assert_eq!(home.refusals().len(), 1);
+    }
+
+    #[test]
+    fn a_folder_inside_a_clone_that_is_already_listed_is_ignored() {
+        let mut home = configured();
+
+        let write = home.add_repositories(vec![picked(
+            "/Developer/zreview/crates/app",
+            "/Developer/zreview",
+            "braidonw/zreview",
+        )]);
+
+        assert!(write.is_none(), "re-adding a listed clone changes nothing");
+        assert!(
+            home.refusals().is_empty(),
+            "a folder already listed is ignored, not refused",
+        );
+    }
+
+    #[test]
+    fn a_folder_already_listed_is_ignored_even_when_its_entry_did_not_resolve() {
+        let mut home = HomeModel::new();
+        home.refreshed(Ok(vec![failed(
+            "/Developer/zreview",
+            "the folder no longer exists",
+        )]));
+
+        let write = home.add_repositories(vec![picked(
+            "/Developer/zreview",
+            "/Developer/zreview",
+            "braidonw/zreview",
+        )]);
+
+        assert!(write.is_none());
+    }
+
+    #[test]
+    fn two_picked_folders_inside_one_clone_become_one_entry() {
+        let mut home = HomeModel::new();
+        home.refreshed(Ok(Vec::new()));
+
+        let write = home
+            .add_repositories(vec![
+                picked(
+                    "/Developer/billing/api",
+                    "/Developer/billing",
+                    "acme/billing",
+                ),
+                picked(
+                    "/Developer/billing/web",
+                    "/Developer/billing",
+                    "acme/billing",
+                ),
+            ])
+            .expect("one of the two should be written");
+
+        assert_eq!(write.repositories, [PathBuf::from("/Developer/billing")]);
+    }
+
+    #[test]
+    fn each_add_replaces_the_refusals_and_a_dismissal_clears_them() {
+        let mut home = configured();
+        let _ = home.add_repositories(vec![failed("/Developer/notes", "no GitHub remote")]);
+
+        let _ = home.add_repositories(vec![failed("/Developer/scratch", "not a Git repository")]);
+        let refusals = home.refusals();
+        assert_eq!(refusals.len(), 1, "the earlier refusal has been answered");
+        assert_eq!(refusals[0].folder, Path::new("/Developer/scratch"));
+
+        home.dismiss_refusals();
+        assert!(home.refusals().is_empty());
+    }
+
+    #[test]
+    fn removing_an_entry_writes_the_list_without_it() {
+        let mut home = configured();
+
+        let write = home
+            .remove_repository(Path::new("/Developer/zreview"))
+            .expect("a listed entry should be removable");
+
+        assert_eq!(write.repositories, [PathBuf::from("/Developer/widgets")]);
+    }
+
+    #[test]
+    fn removing_an_entry_that_is_no_longer_listed_writes_nothing() {
+        let mut home = configured();
+
+        let write = home.remove_repository(Path::new("/Developer/billing"));
+
+        assert!(write.is_none());
+    }
+
+    #[test]
+    fn a_failure_that_is_not_a_read_leaves_the_list_standing() {
+        let mut home = HomeModel::new();
+        home.refreshed(Ok(vec![valid("/Developer/zreview", "braidonw/zreview")]));
+
+        home.failed(SessionFailure::new("Could not write your settings"));
+
+        assert_eq!(
+            home.failure().unwrap().summary,
+            "Could not write your settings"
+        );
+        assert_eq!(home.repositories().len(), 1);
+    }
+}

--- a/crates/app/src/home.rs
+++ b/crates/app/src/home.rs
@@ -62,13 +62,15 @@ impl RepositoryEntry {
     }
 }
 
-/// A picked folder Home would not add, and why.
+/// Something Home would not do, and why.
 ///
-/// Shown until the next Add answers it or the reviewer dismisses it, so a
-/// selection that was partly refused says which part and what was wrong with it.
+/// Replaced by the next Add, so a selection that was partly refused says which
+/// part and what was wrong with it until the reviewer picks again.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AddRefusal {
-    pub folder: PathBuf,
+pub struct Refusal {
+    /// The folder that was picked, or the settings file when the action itself
+    /// was refused.
+    pub path: PathBuf,
     pub reason: String,
 }
 
@@ -122,8 +124,9 @@ impl HomeGroup {
 pub struct HomeModel {
     repositories: Vec<RepositoryEntry>,
     failure: Option<SessionFailure>,
+    write_failure: Option<SessionFailure>,
     footer_expanded: bool,
-    refusals: Vec<AddRefusal>,
+    refusals: Vec<Refusal>,
 }
 
 impl HomeModel {
@@ -150,10 +153,13 @@ impl HomeModel {
         }
     }
 
-    /// Records a failure that leaves the repository list standing, such as a
-    /// settings file that could be read but not written.
-    pub fn failed(&mut self, failure: SessionFailure) {
-        self.failure = Some(failure);
+    /// Takes what came of writing the settings file.
+    ///
+    /// Kept apart from [`Self::failure`] because a file that could be read but
+    /// not written leaves a list worth showing. The failure is a line above it,
+    /// not a screen in front of it, and both can be true at once.
+    pub fn write_finished(&mut self, result: Result<(), SessionFailure>) {
+        self.write_failure = result.err();
     }
 
     #[must_use]
@@ -162,9 +168,18 @@ impl HomeModel {
     }
 
     /// What stops Home listing anything at all, if anything does.
+    ///
+    /// Only a settings file that could not be read, or no home directory to look
+    /// for one in. A write that failed is [`Self::write_failure`].
     #[must_use]
     pub const fn failure(&self) -> Option<&SessionFailure> {
         self.failure.as_ref()
+    }
+
+    /// Why the last write did not reach the file, if it did not.
+    #[must_use]
+    pub const fn write_failure(&self) -> Option<&SessionFailure> {
+        self.write_failure.as_ref()
     }
 
     /// How many configured clones could not be resolved.
@@ -178,10 +193,15 @@ impl HomeModel {
 
     /// The header's count line, absent while there is nothing to count.
     ///
-    /// The pull requests it will also count are not fetched yet.
+    /// No pull requests have been fetched yet, so the count of them is zero.
     #[must_use]
     pub fn count_line(&self) -> Option<String> {
-        (!self.repositories.is_empty()).then(|| repository_count(self.repositories.len()))
+        (!self.repositories.is_empty()).then(|| {
+            format!(
+                "0 pull requests across {}",
+                repository_count(self.repositories.len())
+            )
+        })
     }
 
     /// Takes the folders a reviewer picked, saying what the file should now hold.
@@ -192,7 +212,15 @@ impl HomeModel {
     /// says nothing a reviewer needs to act on. Nothing is written when nothing
     /// was accepted.
     #[must_use]
-    pub fn add_repositories(&mut self, picked: Vec<RepositoryEntry>) -> Option<SettingsWrite> {
+    pub fn add_repositories(
+        &mut self,
+        settings_path: &Path,
+        picked: Vec<RepositoryEntry>,
+    ) -> Option<SettingsWrite> {
+        if let Some(refusal) = self.unreadable_settings_refusal(settings_path) {
+            self.refusals = vec![refusal];
+            return None;
+        }
         // This selection's refusals replace the last one's, which the reviewer
         // has now answered by picking again.
         self.refusals.clear();
@@ -210,8 +238,8 @@ impl HomeModel {
                         accepted += 1;
                     }
                 }
-                RepositoryOutcome::Failed { reason } => self.refusals.push(AddRefusal {
-                    folder: entry.path,
+                RepositoryOutcome::Failed { reason } => self.refusals.push(Refusal {
+                    path: entry.path,
                     reason,
                 }),
             }
@@ -225,7 +253,15 @@ impl HomeModel {
     /// refreshed underneath it removes the repository it was pointing at or
     /// none at all. Nothing is written when the path is no longer listed.
     #[must_use]
-    pub fn remove_repository(&mut self, path: &Path) -> Option<SettingsWrite> {
+    pub fn remove_repository(
+        &mut self,
+        settings_path: &Path,
+        path: &Path,
+    ) -> Option<SettingsWrite> {
+        if let Some(refusal) = self.unreadable_settings_refusal(settings_path) {
+            self.refusals = vec![refusal];
+            return None;
+        }
         let repositories = self
             .repositories
             .iter()
@@ -235,14 +271,21 @@ impl HomeModel {
         (repositories.len() < self.repositories.len()).then_some(SettingsWrite { repositories })
     }
 
-    /// The folders the last Add would not take, with the reason for each.
+    /// What the last action would not do, with the reason for each.
     #[must_use]
-    pub fn refusals(&self) -> &[AddRefusal] {
+    pub fn refusals(&self) -> &[Refusal] {
         &self.refusals
     }
 
-    pub fn dismiss_refusals(&mut self) {
-        self.refusals.clear();
+    /// Refuses to write over a settings file Home could not read.
+    ///
+    /// A write replaces the whole file, and what an unreadable one holds is
+    /// unknown, so writing would silently drop repositories Home never saw.
+    fn unreadable_settings_refusal(&self, settings_path: &Path) -> Option<Refusal> {
+        self.failure.is_some().then(|| Refusal {
+            path: settings_path.to_path_buf(),
+            reason: "fix this file before changing your repositories".to_owned(),
+        })
     }
 
     /// Whether `root` is a clone Home already lists.
@@ -385,13 +428,19 @@ mod tests {
         assert_eq!(home.count_line(), None, "nothing to count before a refresh");
 
         home.refreshed(Ok(vec![valid("/Developer/zreview", "braidonw/zreview")]));
-        assert_eq!(home.count_line().as_deref(), Some("1 repository"));
+        assert_eq!(
+            home.count_line().as_deref(),
+            Some("0 pull requests across 1 repository"),
+        );
 
         home.refreshed(Ok(vec![
             valid("/Developer/zreview", "braidonw/zreview"),
             valid("/Developer/widgets", "acme/widgets"),
         ]));
-        assert_eq!(home.count_line().as_deref(), Some("2 repositories"));
+        assert_eq!(
+            home.count_line().as_deref(),
+            Some("0 pull requests across 2 repositories"),
+        );
     }
 
     #[test]
@@ -469,6 +518,11 @@ mod tests {
         }
     }
 
+    /// The settings file every Add and Remove in these tests would write.
+    fn settings_path() -> PathBuf {
+        PathBuf::from("/Users/braidon/.config/zreview/settings.toml")
+    }
+
     /// Home with two clones already configured.
     fn configured() -> HomeModel {
         let mut home = HomeModel::new();
@@ -484,11 +538,14 @@ mod tests {
         let mut home = configured();
 
         let write = home
-            .add_repositories(vec![picked(
-                "/Developer/billing/crates",
-                "/Developer/billing",
-                "acme/billing",
-            )])
+            .add_repositories(
+                &settings_path(),
+                vec![picked(
+                    "/Developer/billing/crates",
+                    "/Developer/billing",
+                    "acme/billing",
+                )],
+            )
             .expect("an accepted folder should be written");
 
         assert_eq!(
@@ -508,10 +565,13 @@ mod tests {
         let mut home = configured();
 
         let write = home
-            .add_repositories(vec![
-                failed("/Developer/notes", "not a Git repository"),
-                picked("/Developer/billing", "/Developer/billing", "acme/billing"),
-            ])
+            .add_repositories(
+                &settings_path(),
+                vec![
+                    failed("/Developer/notes", "not a Git repository"),
+                    picked("/Developer/billing", "/Developer/billing", "acme/billing"),
+                ],
+            )
             .expect("the folder that did resolve should still be written");
 
         assert!(
@@ -521,7 +581,7 @@ mod tests {
         );
         let refusals = home.refusals();
         assert_eq!(refusals.len(), 1);
-        assert_eq!(refusals[0].folder, Path::new("/Developer/notes"));
+        assert_eq!(refusals[0].path, Path::new("/Developer/notes"));
         assert_eq!(refusals[0].reason, "not a Git repository");
     }
 
@@ -529,7 +589,10 @@ mod tests {
     fn an_add_that_accepts_nothing_writes_nothing_and_still_reports_the_refusal() {
         let mut home = configured();
 
-        let write = home.add_repositories(vec![failed("/Developer/notes", "no GitHub remote")]);
+        let write = home.add_repositories(
+            &settings_path(),
+            vec![failed("/Developer/notes", "no GitHub remote")],
+        );
 
         assert!(
             write.is_none(),
@@ -542,11 +605,14 @@ mod tests {
     fn a_folder_inside_a_clone_that_is_already_listed_is_ignored() {
         let mut home = configured();
 
-        let write = home.add_repositories(vec![picked(
-            "/Developer/zreview/crates/app",
-            "/Developer/zreview",
-            "braidonw/zreview",
-        )]);
+        let write = home.add_repositories(
+            &settings_path(),
+            vec![picked(
+                "/Developer/zreview/crates/app",
+                "/Developer/zreview",
+                "braidonw/zreview",
+            )],
+        );
 
         assert!(write.is_none(), "re-adding a listed clone changes nothing");
         assert!(
@@ -563,11 +629,14 @@ mod tests {
             "the folder no longer exists",
         )]));
 
-        let write = home.add_repositories(vec![picked(
-            "/Developer/zreview",
-            "/Developer/zreview",
-            "braidonw/zreview",
-        )]);
+        let write = home.add_repositories(
+            &settings_path(),
+            vec![picked(
+                "/Developer/zreview",
+                "/Developer/zreview",
+                "braidonw/zreview",
+            )],
+        );
 
         assert!(write.is_none());
     }
@@ -578,35 +647,84 @@ mod tests {
         home.refreshed(Ok(Vec::new()));
 
         let write = home
-            .add_repositories(vec![
-                picked(
-                    "/Developer/billing/api",
-                    "/Developer/billing",
-                    "acme/billing",
-                ),
-                picked(
-                    "/Developer/billing/web",
-                    "/Developer/billing",
-                    "acme/billing",
-                ),
-            ])
+            .add_repositories(
+                &settings_path(),
+                vec![
+                    picked(
+                        "/Developer/billing/api",
+                        "/Developer/billing",
+                        "acme/billing",
+                    ),
+                    picked(
+                        "/Developer/billing/web",
+                        "/Developer/billing",
+                        "acme/billing",
+                    ),
+                ],
+            )
             .expect("one of the two should be written");
 
         assert_eq!(write.repositories, [PathBuf::from("/Developer/billing")]);
     }
 
     #[test]
-    fn each_add_replaces_the_refusals_and_a_dismissal_clears_them() {
+    fn each_add_replaces_the_refusals_the_last_one_reported() {
         let mut home = configured();
-        let _ = home.add_repositories(vec![failed("/Developer/notes", "no GitHub remote")]);
+        let _ = home.add_repositories(
+            &settings_path(),
+            vec![failed("/Developer/notes", "no GitHub remote")],
+        );
 
-        let _ = home.add_repositories(vec![failed("/Developer/scratch", "not a Git repository")]);
+        let _ = home.add_repositories(
+            &settings_path(),
+            vec![failed("/Developer/scratch", "not a Git repository")],
+        );
+
         let refusals = home.refusals();
         assert_eq!(refusals.len(), 1, "the earlier refusal has been answered");
-        assert_eq!(refusals[0].folder, Path::new("/Developer/scratch"));
+        assert_eq!(refusals[0].path, Path::new("/Developer/scratch"));
+    }
 
-        home.dismiss_refusals();
-        assert!(home.refusals().is_empty());
+    /// Home cannot know what a file it could not read holds, so writing over it
+    /// would replace repositories it never saw.
+    #[test]
+    fn adding_over_a_settings_file_that_could_not_be_read_is_refused() {
+        let mut home = HomeModel::new();
+        home.refreshed(Err(SessionFailure::new(
+            "Home could not read your settings",
+        )));
+
+        let write = home.add_repositories(
+            &settings_path(),
+            vec![picked(
+                "/Developer/billing",
+                "/Developer/billing",
+                "acme/billing",
+            )],
+        );
+
+        assert!(write.is_none(), "nothing may be written over that file");
+        let refusals = home.refusals();
+        assert_eq!(refusals.len(), 1);
+        assert_eq!(refusals[0].path, settings_path());
+        assert_eq!(
+            refusals[0].reason,
+            "fix this file before changing your repositories",
+        );
+    }
+
+    #[test]
+    fn removing_over_a_settings_file_that_could_not_be_read_is_refused() {
+        let mut home = HomeModel::new();
+        home.refreshed(Ok(vec![valid("/Developer/zreview", "braidonw/zreview")]));
+        home.refreshed(Err(SessionFailure::new(
+            "Home could not read your settings",
+        )));
+
+        let write = home.remove_repository(&settings_path(), Path::new("/Developer/zreview"));
+
+        assert!(write.is_none());
+        assert_eq!(home.refusals()[0].path, settings_path());
     }
 
     #[test]
@@ -614,7 +732,7 @@ mod tests {
         let mut home = configured();
 
         let write = home
-            .remove_repository(Path::new("/Developer/zreview"))
+            .remove_repository(&settings_path(), Path::new("/Developer/zreview"))
             .expect("a listed entry should be removable");
 
         assert_eq!(write.repositories, [PathBuf::from("/Developer/widgets")]);
@@ -624,22 +742,65 @@ mod tests {
     fn removing_an_entry_that_is_no_longer_listed_writes_nothing() {
         let mut home = configured();
 
-        let write = home.remove_repository(Path::new("/Developer/billing"));
+        let write = home.remove_repository(&settings_path(), Path::new("/Developer/billing"));
 
         assert!(write.is_none());
     }
 
     #[test]
-    fn a_failure_that_is_not_a_read_leaves_the_list_standing() {
+    fn a_write_failure_is_its_own_line_and_leaves_the_list_standing() {
         let mut home = HomeModel::new();
         home.refreshed(Ok(vec![valid("/Developer/zreview", "braidonw/zreview")]));
 
-        home.failed(SessionFailure::new("Could not write your settings"));
+        home.write_finished(Err(SessionFailure::new(
+            "Home could not save your settings",
+        )));
 
         assert_eq!(
-            home.failure().unwrap().summary,
-            "Could not write your settings"
+            home.write_failure()
+                .expect("the write failure shows")
+                .summary,
+            "Home could not save your settings",
+        );
+        assert!(
+            home.failure().is_none(),
+            "a write failure never replaces the list",
         );
         assert_eq!(home.repositories().len(), 1);
+    }
+
+    #[test]
+    fn a_read_failure_and_a_write_failure_are_both_visible() {
+        let mut home = HomeModel::new();
+        home.write_finished(Err(SessionFailure::new(
+            "Home could not save your settings",
+        )));
+
+        home.refreshed(Err(SessionFailure::new(
+            "Home could not read your settings",
+        )));
+
+        assert_eq!(
+            home.failure().expect("the read failure shows").summary,
+            "Home could not read your settings",
+        );
+        assert_eq!(
+            home.write_failure()
+                .expect("the write failure shows")
+                .summary,
+            "Home could not save your settings",
+        );
+    }
+
+    #[test]
+    fn a_successful_write_clears_the_write_failure() {
+        let mut home = HomeModel::new();
+        home.write_finished(Err(SessionFailure::new(
+            "Home could not save your settings",
+        )));
+
+        home.write_finished(Ok(()));
+
+        assert!(home.write_failure().is_none());
     }
 }

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -19,13 +19,13 @@ mod review;
 mod session;
 
 pub use handoff::Handoff;
-pub use home::{
-    AddRefusal, HomeGroup, HomeModel, RepositoryEntry, RepositoryOutcome, SettingsWrite,
-};
+pub use home::{HomeGroup, HomeModel, Refusal, RepositoryEntry, RepositoryOutcome, SettingsWrite};
 pub use review::{FindingDisposition, ReviewModel, ReviewRunState};
 pub use session::{PendingSend, SessionModel, SessionPhase, SubmissionState};
 
-/// Takes a model's lock, recovering from poisoning: the guarded state stays consistent, and refusing to use it would be worse than the panic that poisoned it.
+/// Takes a model's lock, recovering from poisoning. The guarded state stays
+/// consistent, and refusing to use it would be worse than the panic that
+/// poisoned it.
 pub fn lock<T>(model: &Mutex<T>) -> MutexGuard<'_, T> {
     model.lock().unwrap_or_else(PoisonError::into_inner)
 }

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -11,9 +11,13 @@
 //! knows about a database, a forge, or a UI framework.
 
 mod handoff;
+mod home;
 mod review;
 mod session;
 
 pub use handoff::Handoff;
+pub use home::{
+    AddRefusal, HomeGroup, HomeModel, RepositoryEntry, RepositoryOutcome, SettingsWrite,
+};
 pub use review::{FindingDisposition, ReviewModel, ReviewRunState};
 pub use session::{PendingSend, SessionModel, SessionPhase, SubmissionState, lock};

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -1,14 +1,17 @@
-//! What a review session does, with no window in it.
+//! What `ZReview` does, with no window in it.
 //!
-//! Everything here is the orchestration between a reviewer's actions and the
-//! domain, from which file is open and what has been drafted to how far a review
-//! run has got and what a confirmed submission does to storage. A view calls these
-//! methods and renders what comes back; effects are return values rather than
-//! callbacks, so the same model drives any front end.
+//! Home and one review sitting. Everything here is the orchestration between a
+//! reviewer's actions and the domain, from which repositories Home lists and
+//! which file is open to how far a review run has got and what a confirmed
+//! submission does to storage. A view calls these methods and renders what comes
+//! back; effects are return values rather than callbacks, so the same models
+//! drive any front end.
 //!
 //! The only seams out of this crate are the domain's two ports,
 //! [`domain::ReviewStateSink`] and [`domain::ReviewSubmitter`]. Nothing here
 //! knows about a database, a forge, or a UI framework.
+
+use std::sync::{Mutex, MutexGuard, PoisonError};
 
 mod handoff;
 mod home;
@@ -20,4 +23,9 @@ pub use home::{
     AddRefusal, HomeGroup, HomeModel, RepositoryEntry, RepositoryOutcome, SettingsWrite,
 };
 pub use review::{FindingDisposition, ReviewModel, ReviewRunState};
-pub use session::{PendingSend, SessionModel, SessionPhase, SubmissionState, lock};
+pub use session::{PendingSend, SessionModel, SessionPhase, SubmissionState};
+
+/// Takes a model's lock, recovering from poisoning: the guarded state stays consistent, and refusing to use it would be worse than the panic that poisoned it.
+pub fn lock<T>(model: &Mutex<T>) -> MutexGuard<'_, T> {
+    model.lock().unwrap_or_else(PoisonError::into_inner)
+}

--- a/crates/app/src/session.rs
+++ b/crates/app/src/session.rs
@@ -3,7 +3,7 @@
 
 use std::{
     ops::RangeInclusive,
-    sync::{Arc, Mutex, MutexGuard, PoisonError, atomic::AtomicBool},
+    sync::{Arc, atomic::AtomicBool},
 };
 
 use domain::{
@@ -553,11 +553,6 @@ impl SessionModel {
             sink.save_summary(head_sha, session.summary());
         }
     }
-}
-
-/// Takes the model's lock, recovering from poisoning: the guarded state stays consistent, and refusing to use it would be worse than the panic that poisoned it.
-pub fn lock(model: &Mutex<SessionModel>) -> MutexGuard<'_, SessionModel> {
-    model.lock().unwrap_or_else(PoisonError::into_inner)
 }
 
 #[cfg(test)]

--- a/crates/github/src/lib.rs
+++ b/crates/github/src/lib.rs
@@ -39,6 +39,69 @@ impl RepositorySlug {
     }
 }
 
+/// A local clone resolved to its worktree root and the GitHub repository it
+/// points at.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResolvedClone {
+    pub root: PathBuf,
+    pub slug: RepositorySlug,
+}
+
+/// Why a local clone is not something Home can list pull requests for.
+#[derive(Debug, Error)]
+pub enum CloneError {
+    #[error("the folder no longer exists")]
+    Missing,
+
+    #[error("not a Git repository")]
+    NotAGitRepository,
+
+    #[error("no GitHub remote")]
+    NoGithubRemote,
+
+    #[error("could not read the repository: {source}")]
+    Unreadable {
+        #[source]
+        source: git::GitError,
+    },
+}
+
+/// Resolves a local clone to its worktree root and the GitHub repository its
+/// remotes name.
+///
+/// The root, rather than the path handed in, is what identifies a clone, so two
+/// paths inside one checkout resolve to the same entry.
+///
+/// # Errors
+///
+/// Returns [`CloneError`] when the path is gone, is not a Git repository, has no
+/// remote that parses to a GitHub slug, or cannot be read.
+pub fn resolve_clone(path: &Path) -> Result<ResolvedClone, CloneError> {
+    if !path.exists() {
+        return Err(CloneError::Missing);
+    }
+    let root = git::repository_root(path).map_err(classify_git_failure)?;
+    let remotes = git::remotes(&root).map_err(classify_git_failure)?;
+    let slug = preferred_remote_repository(&remotes).ok_or(CloneError::NoGithubRemote)?;
+    Ok(ResolvedClone { root, slug })
+}
+
+/// Separates Git refusing the path from Git failing to run at all.
+///
+/// A non-zero exit from `rev-parse` or `remote` on a path that exists means the
+/// folder is not a checkout; anything else is a fault worth reporting verbatim.
+fn classify_git_failure(error: git::GitError) -> CloneError {
+    match error {
+        git::GitError::Command { .. } => CloneError::NotAGitRepository,
+        source @ (git::GitError::Execute { .. }
+        | git::GitError::NonUtf8 { .. }
+        | git::GitError::InvalidObjectId { .. }
+        | git::GitError::UnsupportedStatus(_)
+        | git::GitError::InvalidPath(_)
+        | git::GitError::InvalidPatch { .. }) => CloneError::Unreadable { source },
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PullRequestLocator {
     pub repository: RepositorySlug,
@@ -1318,6 +1381,74 @@ JSON
             captured = captured.display(),
         );
         write_executable(path, &body);
+    }
+
+    /// A clone with `origin` pointing at GitHub, which is what Home configures.
+    fn clone_with_remote(url: Option<&str>) -> TempDir {
+        let directory = TempDir::new().unwrap();
+        git(directory.path(), ["init", "--quiet"]);
+        if let Some(url) = url {
+            git(directory.path(), ["remote", "add", "origin", url]);
+        }
+        directory
+    }
+
+    #[test]
+    fn a_clone_resolves_to_its_worktree_root_and_github_slug() {
+        let directory = clone_with_remote(Some("git@github.com:acme/widgets.git"));
+        let nested = directory.path().join("crates/review");
+        fs::create_dir_all(&nested).unwrap();
+
+        let resolved = resolve_clone(&nested).unwrap();
+
+        assert_eq!(resolved.slug, RepositorySlug::new("acme", "widgets"));
+        assert_eq!(
+            resolved.root,
+            directory.path().canonicalize().unwrap(),
+            "a path inside the clone should resolve to the clone's root",
+        );
+    }
+
+    #[test]
+    fn a_clone_with_no_github_remote_is_refused() {
+        let directory = clone_with_remote(Some("https://example.com/acme/widgets.git"));
+
+        let error = resolve_clone(directory.path()).unwrap_err();
+
+        assert!(matches!(error, CloneError::NoGithubRemote), "got {error}");
+        assert_eq!(error.to_string(), "no GitHub remote");
+    }
+
+    #[test]
+    fn a_clone_with_no_remotes_at_all_is_refused() {
+        let directory = clone_with_remote(None);
+
+        let error = resolve_clone(directory.path()).unwrap_err();
+
+        assert!(matches!(error, CloneError::NoGithubRemote), "got {error}");
+    }
+
+    #[test]
+    fn a_folder_that_is_not_a_git_repository_is_refused() {
+        let directory = TempDir::new().unwrap();
+
+        let error = resolve_clone(directory.path()).unwrap_err();
+
+        assert!(
+            matches!(error, CloneError::NotAGitRepository),
+            "got {error}",
+        );
+        assert_eq!(error.to_string(), "not a Git repository");
+    }
+
+    #[test]
+    fn a_folder_that_no_longer_exists_is_refused_as_missing() {
+        let directory = TempDir::new().unwrap();
+
+        let error = resolve_clone(&directory.path().join("moved-away")).unwrap_err();
+
+        assert!(matches!(error, CloneError::Missing), "got {error}");
+        assert_eq!(error.to_string(), "the folder no longer exists");
     }
 
     #[test]

--- a/crates/github/src/lib.rs
+++ b/crates/github/src/lib.rs
@@ -59,11 +59,8 @@ pub enum CloneError {
     #[error("no GitHub remote")]
     NoGithubRemote,
 
-    #[error("could not read the repository: {source}")]
-    Unreadable {
-        #[source]
-        source: git::GitError,
-    },
+    #[error("could not read the repository: {detail}")]
+    Unreadable { detail: String },
 }
 
 /// Resolves a local clone to its worktree root and the GitHub repository its
@@ -77,29 +74,47 @@ pub enum CloneError {
 /// Returns [`CloneError`] when the path is gone, is not a Git repository, has no
 /// remote that parses to a GitHub slug, or cannot be read.
 pub fn resolve_clone(path: &Path) -> Result<ResolvedClone, CloneError> {
-    if !path.exists() {
-        return Err(CloneError::Missing);
+    // The error kind separates a clone that has been moved away from one this
+    // process is not allowed to look at, which are different problems.
+    if let Err(error) = std::fs::metadata(path) {
+        return Err(match error.kind() {
+            std::io::ErrorKind::NotFound => CloneError::Missing,
+            _ => CloneError::Unreadable {
+                detail: error.to_string(),
+            },
+        });
     }
-    let root = git::repository_root(path).map_err(classify_git_failure)?;
-    let remotes = git::remotes(&root).map_err(classify_git_failure)?;
+    let root = git::repository_root(path).map_err(|error| classify_git_failure(&error))?;
+    let remotes = git::remotes(&root).map_err(|error| classify_git_failure(&error))?;
     let slug = preferred_remote_repository(&remotes).ok_or(CloneError::NoGithubRemote)?;
     Ok(ResolvedClone { root, slug })
 }
 
-/// Separates Git refusing the path from Git failing to run at all.
+/// Separates Git saying the folder is not a checkout from Git failing for any
+/// other reason.
 ///
-/// A non-zero exit from `rev-parse` or `remote` on a path that exists means the
-/// folder is not a checkout; anything else is a fault worth reporting verbatim.
-fn classify_git_failure(error: git::GitError) -> CloneError {
+/// Only Git's own wording earns the verdict. A folder Git could not enter, or a
+/// Git that could not run at all, is a fault reported with the text it gave.
+fn classify_git_failure(error: &git::GitError) -> CloneError {
     match error {
-        git::GitError::Command { .. } => CloneError::NotAGitRepository,
-        source @ (git::GitError::Execute { .. }
+        git::GitError::Command { stderr, .. } if is_not_a_repository(stderr) => {
+            CloneError::NotAGitRepository
+        }
+        git::GitError::Command { .. }
+        | git::GitError::Execute { .. }
         | git::GitError::NonUtf8 { .. }
         | git::GitError::InvalidObjectId { .. }
         | git::GitError::UnsupportedStatus(_)
         | git::GitError::InvalidPath(_)
-        | git::GitError::InvalidPatch { .. }) => CloneError::Unreadable { source },
+        | git::GitError::InvalidPatch { .. } => CloneError::Unreadable {
+            detail: error.to_string(),
+        },
     }
+}
+
+/// Git's own wording for a path that is not inside a checkout.
+fn is_not_a_repository(stderr: &str) -> bool {
+    stderr.to_lowercase().contains("not a git repository")
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1449,6 +1464,48 @@ JSON
 
         assert!(matches!(error, CloneError::Missing), "got {error}");
         assert_eq!(error.to_string(), "the folder no longer exists");
+    }
+
+    /// A folder the process may not look inside, so `git` cannot enter it and
+    /// the failure is a fault rather than a verdict on the folder.
+    #[cfg(unix)]
+    #[test]
+    fn a_folder_git_cannot_enter_is_refused_as_unreadable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = TempDir::new().unwrap();
+        let locked = directory.path().join("locked");
+        fs::create_dir(&locked).unwrap();
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o000)).unwrap();
+
+        let error = resolve_clone(&locked).unwrap_err();
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(
+            matches!(&error, CloneError::Unreadable { detail } if detail.contains("Permission denied")),
+            "got {error}",
+        );
+    }
+
+    /// A folder whose parent cannot be read at all, which is not the same as one
+    /// that has been moved away.
+    #[cfg(unix)]
+    #[test]
+    fn a_folder_whose_metadata_cannot_be_read_is_refused_as_unreadable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = TempDir::new().unwrap();
+        let locked = directory.path().join("locked");
+        fs::create_dir(&locked).unwrap();
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o000)).unwrap();
+
+        let error = resolve_clone(&locked.join("clone")).unwrap_err();
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(
+            matches!(error, CloneError::Unreadable { .. }),
+            "a folder that cannot be looked at is not a folder that is gone: {error}",
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #15

The desktop binary could only open a Session it was told about on the command line. This is the first slice of Home. Launching with no arguments opens it, and it manages the reviewer's repository list before any pull request is fetched.

What changed:
- No arguments opens Home, demo opens the generated fixture, and the comparison and pr shapes still open a Session directly
- A framework-free Home model in the app crate, fed with validation results as data and tested with hand-built inputs
- The Tauri managed state becomes an application root holding Home and at most one Session, with thin commands over the model
- Add opens the native folder picker, validates each folder as a clone with a GitHub remote, writes accepted ones, and reports refusals; Remove writes immediately
- The settings file is re-read on every refresh, so hand edits are picked up, and a malformed file shows the failure block while Add and Remove refuse to write over it
- The Home screen with its header, three empty groups, the collapsed and expanded Repositories footer, and the first-launch empty state

Notes:
Start with the Home model and then the commands module, which serialises add, remove, and refresh under one guard. Rows, the refreshed stamp, and opening a row are later tickets. The picker and the visual layout could not be checked from an agent session, so please launch it once with no arguments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189um4LrckqAAq5fgnixT1p
