### PR TITLE
List and group pull requests on Home

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -8,13 +8,13 @@ use std::{
     },
 };
 
-use app::{SessionPhase, SettingsWrite, lock};
+use app::{SessionPhase, SettingsWrite, lock, try_lock};
 use domain::DiffSide;
 use session::{ReviewStorage, SessionRequest};
 use tauri::ipc::Channel;
 use tauri_specta::collect_commands;
 
-use crate::{AppRoot, ManagedHome, ManagedSession, dto, repositories};
+use crate::{AppRoot, ManagedHome, ManagedSession, dto, pull_requests, repositories};
 
 /// The specta builder, shared between the invoke handler and the bindings export.
 #[must_use]
@@ -22,6 +22,7 @@ pub fn specta_builder() -> tauri_specta::Builder<tauri::Wry> {
     tauri_specta::Builder::<tauri::Wry>::new().commands(collect_commands![
         describe_launch,
         refresh_home,
+        move_home_cursor,
         add_repositories,
         remove_repository,
         toggle_repositories_footer,
@@ -34,10 +35,102 @@ pub fn specta_builder() -> tauri_specta::Builder<tauri::Wry> {
     ])
 }
 
-/// Re-reads the settings file and resolves every clone it lists.
-fn refresh_home_on_model(home: &ManagedHome, settings_path: &Path) {
-    let _ordered = lock(&home.settings_action);
+/// Re-reads the settings file, then fetches what every clone it lists has open.
+///
+/// A trigger that arrives while any settings action is running starts nothing.
+/// It is not queued, because a refresh only ever asks what is true now, and the
+/// one already running is about to answer that.
+///
+/// Takes the reporter as a plain callback so it can be tested without a Tauri
+/// channel, as `run_load` does.
+fn refresh_home_on_model(
+    home: &ManagedHome,
+    settings_path: &Path,
+    report: &dyn Fn(app::RefreshState),
+) {
+    let Some(_ordered) = try_lock(&home.settings_action) else {
+        return;
+    };
+    if !lock(&home.model).begin_refresh() {
+        return;
+    }
+    report_refresh(home, report);
+
     read_into_model(home, settings_path);
+    if lock(&home.model).failure().is_some() {
+        report_refresh(home, report);
+        return;
+    }
+    let (slugs, preflight_in) = to_fetch(&lock(&home.model));
+    if let Some(clone) = preflight_in
+        && let Err(failure) = pull_requests::preflight(&home.client, &clone)
+    {
+        lock(&home.model).preflight_failed(failure);
+        report_refresh(home, report);
+        return;
+    }
+
+    lock(&home.model).fetching(slugs.len());
+    report_refresh(home, report);
+    for batch in slugs.chunks(github::REPOSITORIES_PER_BATCH) {
+        let fetched = pull_requests::fetch_batch(&home.client, batch);
+        lock(&home.model).batch_fetched(fetched);
+        report_refresh(home, report);
+    }
+    lock(&home.model).finish_refresh(now_ms());
+    report_refresh(home, report);
+}
+
+fn report_refresh(home: &ManagedHome, report: &dyn Fn(app::RefreshState)) {
+    let state = lock(&home.model).refresh_state();
+    report(state);
+}
+
+/// The repositories a refresh will ask about, and the clone to preflight in.
+///
+/// One entry per distinct repository, so two checkouts of one project are
+/// fetched once and counted once.
+fn to_fetch(home: &app::HomeModel) -> (Vec<github::RepositorySlug>, Option<PathBuf>) {
+    let mut slugs: Vec<github::RepositorySlug> = Vec::new();
+    let mut preflight_in = None;
+    for entry in home.repositories() {
+        let Some(slug) = entry.slug() else {
+            continue;
+        };
+        preflight_in.get_or_insert_with(|| entry.path.clone());
+        if slugs.iter().any(|listed| listed.full_name() == slug) {
+            continue;
+        }
+        slugs.push(
+            github::parse_full_name(slug).expect("a slug the github crate formatted parses back"),
+        );
+    }
+    (slugs, preflight_in)
+}
+
+/// Now, as the epoch milliseconds the stamp is worked out from.
+///
+/// # Panics
+///
+/// Panics if the system clock is set before 1970, against which no relative
+/// time this screen shows would mean anything.
+fn now_ms() -> i64 {
+    let since_epoch = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("the system clock is set after 1970");
+    i64::try_from(since_epoch.as_millis()).expect("the system clock is set before the year 292M")
+}
+
+fn move_home_cursor_on_model(
+    home: &ManagedHome,
+    move_to: dto::CursorMoveDto,
+) -> dto::HomeSnapshotDto {
+    let mut guard = lock(&home.model);
+    match move_to {
+        dto::CursorMoveDto::Down => guard.move_cursor_down(),
+        dto::CursorMoveDto::Up => guard.move_cursor_up(),
+    }
+    dto::project_home(&guard)
 }
 
 /// Adds the folders a reviewer picked, then leaves Home showing the file.
@@ -338,23 +431,46 @@ pub async fn open_session(
     }
 }
 
-/// Re-reads the settings file and resolves every clone it lists.
+/// Re-reads the settings file, then fetches what every clone it lists has open.
 ///
-/// Runs when Home opens, after an Add or a Remove, and on `r`. A settings file
-/// that cannot be read comes back inside the snapshot rather than as a command
-/// error, because the header and footer stay on screen either way.
+/// Runs when Home opens and on `r`, reporting how far it has got on
+/// `on_progress` as each batch of repositories lands. A trigger that arrives
+/// mid-refresh starts nothing and answers with what is already on screen.
+///
+/// A settings file that cannot be read, or a `gh` that cannot be used, comes
+/// back inside the snapshot rather than as a command error, because the header
+/// and footer stay on screen either way.
 ///
 /// # Errors
 ///
-/// Returns a failure when the task doing the reading does not finish.
+/// Returns a failure when the task doing the fetching does not finish.
 #[tauri::command]
 #[specta::specta]
 #[allow(clippy::needless_pass_by_value)]
 pub async fn refresh_home(
     state: tauri::State<'_, AppRoot>,
+    on_progress: Channel<dto::RefreshStateDto>,
 ) -> Result<dto::HomeSnapshotDto, dto::SessionFailureDto> {
     let home = state.home.clone();
-    off_the_ui_thread(move || on_settings_file(&home, refresh_home_on_model)).await
+    off_the_ui_thread(move || {
+        on_settings_file(&home, |home, settings_path| {
+            refresh_home_on_model(home, settings_path, &|state| {
+                let _ = on_progress.send(state.into());
+            });
+        })
+    })
+    .await
+}
+
+/// Moves the cursor one row through the list, across the groups.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn move_home_cursor(
+    state: tauri::State<'_, AppRoot>,
+    move_to: dto::CursorMoveDto,
+) -> dto::HomeSnapshotDto {
+    move_home_cursor_on_model(&state.home, move_to)
 }
 
 /// Adds the folders the reviewer picked, writing the file once and refreshing.
@@ -555,6 +671,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+    use crate::fake_gh::FakeGh;
 
     /// A sink whose writes always fail, for exercising `draft_write_failure`.
     struct FailingSink;
@@ -794,7 +911,7 @@ mod tests {
             head: "feature".to_owned(),
         };
         let root = AppRoot {
-            home: ManagedHome::new(),
+            home: ManagedHome::new(github::GithubClient::default()),
             session: Some(ManagedSession {
                 model: Arc::new(Mutex::new(app::SessionModel::loading(
                     request.description(),
@@ -816,7 +933,7 @@ mod tests {
     #[test]
     fn a_launch_with_no_session_is_described_as_home() {
         let root = AppRoot {
-            home: ManagedHome::new(),
+            home: ManagedHome::new(github::GithubClient::default()),
             session: None,
         };
 
@@ -839,8 +956,9 @@ mod tests {
         directory
     }
 
+    /// Home with a `gh` that is never run, for the actions that never reach it.
     fn home_model() -> ManagedHome {
-        ManagedHome::new()
+        ManagedHome::new(github::GithubClient::new("gh-that-is-never-run"))
     }
 
     /// What Home shows once an action has finished.
@@ -853,6 +971,231 @@ mod tests {
         settings::load(settings_path).unwrap().repositories
     }
 
+    /// A refresh with nothing listening to its progress.
+    fn refresh(home: &ManagedHome, settings_path: &Path) {
+        refresh_home_on_model(home, settings_path, &|_progress| {});
+    }
+
+    /// A settings file listing `clones`.
+    fn settings_listing(directory: &TempDir, clones: &[&TempDir]) -> PathBuf {
+        let listed = clones
+            .iter()
+            .map(|clone| format!("{:?}", clone.path().display().to_string()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let path = directory.path().join("settings.toml");
+        std::fs::write(&path, format!("repositories = [{listed}]\n")).unwrap();
+        path
+    }
+
+    /// One recorded search answering for `slug`, with two rows to review.
+    fn recorded_search(slug: &str) -> String {
+        format!(
+            r#"{{"data":{{
+                "viewer":{{"login":"braidonw"}},
+                "rateLimit":{{"cost":1,"remaining":4999,"resetAt":"2026-09-01T13:00:00Z"}},
+                "toReview":{{"issueCount":2,"pageInfo":{{"hasNextPage":false,"endCursor":null}},"nodes":[
+                  {{"number":412,"title":"Retry webhook deliveries","url":"https://github.com/{slug}/pull/412",
+                   "isDraft":false,"updatedAt":"2026-09-01T12:34:56Z","headRefOid":"abc123",
+                   "repository":{{"nameWithOwner":"{slug}"}},"author":{{"login":"mlee"}},
+                   "viewerLatestReview":null,"statusCheckRollup":{{"state":"SUCCESS"}}}},
+                  {{"number":398,"title":"Split the renderer","url":"https://github.com/{slug}/pull/398",
+                   "isDraft":false,"updatedAt":"2026-08-30T09:00:00Z","headRefOid":"def456",
+                   "repository":{{"nameWithOwner":"{slug}"}},"author":{{"login":"priya"}},
+                   "viewerLatestReview":null,"statusCheckRollup":null}}
+                ]}},
+                "authored":{{"issueCount":0,"pageInfo":{{"hasNextPage":false,"endCursor":null}},"nodes":[]}}
+            }}}}"#,
+        )
+    }
+
+    /// Home reading `settings_path`, with a `gh` a test has set up.
+    fn home_with(gh: &FakeGh) -> ManagedHome {
+        ManagedHome::new(gh.client())
+    }
+
+    #[test]
+    fn a_refresh_lists_the_pull_requests_it_fetched() {
+        let gh = FakeGh::new();
+        gh.answer_graphql(&recorded_search("acme/widgets"));
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = settings_listing(&directory, &[&clone]);
+        let home = home_with(&gh);
+
+        refresh(&home, &settings_path);
+
+        let shown = snapshot(&home);
+        assert_eq!(
+            shown.count_line.as_deref(),
+            Some("2 pull requests across 1 repository"),
+        );
+        let to_review = &shown.groups[0];
+        assert_eq!(to_review.title, "To review");
+        assert_eq!(to_review.count, 2);
+        assert_eq!(to_review.rows[0].identity, "acme/widgets#412");
+        assert_eq!(to_review.rows[0].title, "Retry webhook deliveries");
+        assert_eq!(to_review.rows[0].author.as_deref(), Some("mlee"));
+        assert_eq!(
+            to_review.rows[0]
+                .check_status
+                .as_ref()
+                .expect("the head has checks")
+                .label,
+            "checks passing",
+        );
+        assert!(
+            to_review.rows[1].check_status.is_none(),
+            "a head with no checks leaves the column empty",
+        );
+        assert!(shown.failed_repositories.is_empty());
+    }
+
+    #[test]
+    fn a_refresh_counts_off_the_repositories_and_ends_with_the_time_it_settled() {
+        let gh = FakeGh::new();
+        gh.answer_graphql(&recorded_search("acme/widgets"));
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = settings_listing(&directory, &[&clone]);
+        let home = home_with(&gh);
+        let reported = Mutex::new(Vec::new());
+
+        refresh_home_on_model(&home, &settings_path, &|progress| {
+            reported.lock().unwrap().push(progress);
+        });
+
+        let reported = reported.lock().unwrap().clone();
+        assert_eq!(
+            reported.first(),
+            Some(&app::RefreshState::Refreshing { done: 0, total: 0 }),
+            "the total is unknown until the settings file has been read",
+        );
+        assert!(
+            reported.contains(&app::RefreshState::Refreshing { done: 1, total: 1 }),
+            "every repository is counted off: {reported:?}",
+        );
+        assert!(
+            matches!(reported.last(), Some(app::RefreshState::Refreshed { .. })),
+            "the last thing reported is the settled stamp: {reported:?}",
+        );
+    }
+
+    /// Two refreshes never race, and the one that lost was not queued behind
+    /// the one that won.
+    #[test]
+    fn a_refresh_that_arrives_while_the_settings_guard_is_held_starts_nothing() {
+        let gh = FakeGh::new();
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = settings_listing(&directory, &[&clone]);
+        let home = home_with(&gh);
+        let held = lock(&home.settings_action);
+
+        refresh(&home, &settings_path);
+
+        assert_eq!(
+            lock(&home.model).refresh_state(),
+            app::RefreshState::NeverRefreshed,
+            "nothing was started while the guard was held",
+        );
+        assert!(lock(&home.model).repositories().is_empty());
+        drop(held);
+    }
+
+    #[test]
+    fn a_gh_that_cannot_be_used_stops_the_refresh_and_says_what_to_fix() {
+        let gh = FakeGh::new();
+        gh.refuse_authentication();
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = settings_listing(&directory, &[&clone]);
+        let home = home_with(&gh);
+
+        refresh(&home, &settings_path);
+
+        let shown = snapshot(&home);
+        let failure = shown
+            .failure
+            .expect("the preflight failure replaces the list");
+        assert_eq!(failure.summary, "Home could not use the GitHub CLI");
+        assert!(failure.remediation.unwrap().contains("gh auth login"));
+        assert_eq!(shown.refresh, dto::RefreshStateDto::Failed);
+        assert_eq!(
+            shown.repositories.len(),
+            1,
+            "an unusable gh says nothing about the configured clones",
+        );
+    }
+
+    /// Fixing `gh` and pressing `r` is all it takes to get the list back.
+    #[test]
+    fn a_refresh_after_gh_is_fixed_restores_the_list() {
+        let gh = FakeGh::new();
+        gh.refuse_authentication();
+        gh.answer_graphql(&recorded_search("acme/widgets"));
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = settings_listing(&directory, &[&clone]);
+        let home = home_with(&gh);
+        refresh(&home, &settings_path);
+        assert!(snapshot(&home).failure.is_some());
+
+        gh.allow_authentication();
+        refresh(&home, &settings_path);
+
+        let shown = snapshot(&home);
+        assert!(shown.failure.is_none());
+        assert_eq!(shown.groups[0].count, 2);
+    }
+
+    #[test]
+    fn a_repository_that_could_not_be_fetched_shows_above_the_list_and_in_the_footer() {
+        let gh = FakeGh::new();
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = settings_listing(&directory, &[&clone]);
+        let home = home_with(&gh);
+
+        refresh(&home, &settings_path);
+
+        let shown = snapshot(&home);
+        assert_eq!(shown.failed_repositories.len(), 1);
+        assert_eq!(shown.failed_repositories[0].slug, "acme/widgets");
+        assert_eq!(
+            shown.failed_repositories[0].path,
+            clone.path().display().to_string()
+        );
+        assert!(!shown.failed_repositories[0].reason.is_empty());
+        assert!(shown.repositories[0].failure.is_some());
+        assert_eq!(
+            shown.refresh,
+            dto::RefreshStateDto::Failed,
+            "nothing loaded at all",
+        );
+    }
+
+    #[test]
+    fn the_cursor_moves_down_and_up_over_the_rows_a_refresh_listed() {
+        let gh = FakeGh::new();
+        gh.answer_graphql(&recorded_search("acme/widgets"));
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = settings_listing(&directory, &[&clone]);
+        let home = home_with(&gh);
+        refresh(&home, &settings_path);
+        assert_eq!(snapshot(&home).cursor, 0);
+
+        assert_eq!(
+            move_home_cursor_on_model(&home, dto::CursorMoveDto::Down).cursor,
+            1
+        );
+        assert_eq!(
+            move_home_cursor_on_model(&home, dto::CursorMoveDto::Up).cursor,
+            0
+        );
+    }
+
     #[test]
     fn refreshing_home_reads_the_settings_file_every_time() {
         let clone = clone_of("acme/widgets");
@@ -860,7 +1203,7 @@ mod tests {
         let settings_path = directory.path().join("settings.toml");
         let home = home_model();
 
-        refresh_home_on_model(&home, &settings_path);
+        refresh(&home, &settings_path);
         assert!(lock(&home.model).repositories().is_empty());
 
         std::fs::write(
@@ -871,7 +1214,7 @@ mod tests {
             ),
         )
         .unwrap();
-        refresh_home_on_model(&home, &settings_path);
+        refresh(&home, &settings_path);
 
         let guard = lock(&home.model);
         assert_eq!(guard.repositories().len(), 1, "a hand edit is picked up");
@@ -981,7 +1324,7 @@ mod tests {
         let malformed = "repositories = [this is not valid toml";
         std::fs::write(&settings_path, malformed).unwrap();
         let home = home_model();
-        refresh_home_on_model(&home, &settings_path);
+        refresh(&home, &settings_path);
 
         add_repositories_on_model(&home, &settings_path, &[clone.path().to_path_buf()]);
 
@@ -1006,7 +1349,7 @@ mod tests {
         let malformed = "repositories = [this is not valid toml";
         std::fs::write(&settings_path, malformed).unwrap();
         let home = home_model();
-        refresh_home_on_model(&home, &settings_path);
+        refresh(&home, &settings_path);
 
         remove_repository_on_model(&home, &settings_path, Path::new("/Developer/zreview"));
 

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -46,21 +46,22 @@ pub fn specta_builder() -> tauri_specta::Builder<tauri::Wry> {
 fn refresh_home_on_model(
     home: &ManagedHome,
     settings_path: &Path,
-    report: &dyn Fn(app::RefreshState),
+    report: &dyn Fn(dto::HomeSnapshotDto),
 ) {
     let Some(_ordered) = try_lock(&home.settings_action) else {
         return;
     };
-    if !lock(&home.model).begin_refresh() {
-        return;
-    }
-    report_refresh(home, report);
+    lock(&home.model).begin_refresh();
+    // Every way out from here says how the refresh went, except a panic, which
+    // would otherwise leave the stamp counting repositories off for ever.
+    let _abandoned = AbandonedRefresh { home };
+    report_home(home, report);
 
     read_into_model(home, settings_path);
-    // Only the settings file can have failed by here, the last refresh's
-    // preflight failure having gone with the trigger that started this one.
+    // Only the settings file can have failed by here, whatever stopped the last
+    // refresh having gone with the trigger that started this one.
     if lock(&home.model).failure().is_some() {
-        report_refresh(home, report);
+        report_home(home, report);
         return;
     }
     let (slugs, preflight_in) = to_fetch(&lock(&home.model));
@@ -68,46 +69,59 @@ fn refresh_home_on_model(
         && let Err(failure) = pull_requests::preflight(&home.client, &clone)
     {
         lock(&home.model).preflight_failed(failure);
-        report_refresh(home, report);
+        report_home(home, report);
         return;
     }
 
     lock(&home.model).fetching(slugs.len());
-    report_refresh(home, report);
-    for batch in slugs.chunks(github::REPOSITORIES_PER_BATCH) {
-        let fetched = pull_requests::fetch_batch(&home.client, batch);
-        lock(&home.model).batch_fetched(fetched);
-        report_refresh(home, report);
-    }
+    report_home(home, report);
+    pull_requests::fetch(&home.client, &slugs, &|batch| {
+        lock(&home.model).batch_fetched(batch);
+        report_home(home, report);
+    });
     lock(&home.model).finish_refresh(now_ms());
-    report_refresh(home, report);
+    report_home(home, report);
 }
 
-fn report_refresh(home: &ManagedHome, report: &dyn Fn(app::RefreshState)) {
-    let state = lock(&home.model).refresh_state();
-    report(state);
+/// Ends a refresh that stopped without finishing.
+///
+/// A panic anywhere in a refresh would otherwise leave the stamp saying it is
+/// still counting repositories off, with nothing left running to finish it.
+struct AbandonedRefresh<'a> {
+    home: &'a ManagedHome,
+}
+
+impl Drop for AbandonedRefresh<'_> {
+    fn drop(&mut self) {
+        // A refresh that reached its own end has already said how it went.
+        lock(&self.home.model).refresh_abandoned();
+    }
+}
+
+/// Hands the reporter everything Home now shows, so a list fills in as it loads.
+fn report_home(home: &ManagedHome, report: &dyn Fn(dto::HomeSnapshotDto)) {
+    let shown = dto::project_home(&lock(&home.model));
+    report(shown);
 }
 
 /// The repositories a refresh will ask about, and the clone to preflight in.
 ///
-/// One entry per distinct repository, so two checkouts of one project are
-/// fetched once and counted once.
+/// Duplicates are collapsed by the fetch itself, which is the one place that
+/// knows how GitHub compares two names, so the count here is the count it will
+/// answer for.
 fn to_fetch(home: &app::HomeModel) -> (Vec<github::RepositorySlug>, Option<PathBuf>) {
-    let mut slugs: Vec<github::RepositorySlug> = Vec::new();
+    let mut slugs = Vec::new();
     let mut preflight_in = None;
     for entry in home.repositories() {
         let Some(slug) = entry.slug() else {
             continue;
         };
         preflight_in.get_or_insert_with(|| entry.path.clone());
-        if slugs.iter().any(|listed| listed.full_name() == slug) {
-            continue;
-        }
         slugs.push(
             github::parse_full_name(slug).expect("a slug the github crate formatted parses back"),
         );
     }
-    (slugs, preflight_in)
+    (github::distinct_repositories(&slugs), preflight_in)
 }
 
 /// Now, as the epoch milliseconds the stamp is worked out from.
@@ -435,9 +449,10 @@ pub async fn open_session(
 
 /// Re-reads the settings file, then fetches what every clone it lists has open.
 ///
-/// Runs when Home opens and on `r`, reporting how far it has got on
-/// `on_progress` as each batch of repositories lands. A trigger that arrives
-/// mid-refresh starts nothing and answers with what is already on screen.
+/// Runs when Home opens, on `r`, and after an Add or a Remove. Everything Home
+/// shows goes to `on_progress` as each batch of repositories lands, so the list
+/// fills in as it loads. A trigger that arrives mid-refresh starts nothing and
+/// answers with what is already on screen.
 ///
 /// A settings file that cannot be read, or a `gh` that cannot be used, comes
 /// back inside the snapshot rather than as a command error, because the header
@@ -451,13 +466,13 @@ pub async fn open_session(
 #[allow(clippy::needless_pass_by_value)]
 pub async fn refresh_home(
     state: tauri::State<'_, AppRoot>,
-    on_progress: Channel<dto::RefreshStateDto>,
+    on_progress: Channel<dto::HomeSnapshotDto>,
 ) -> Result<dto::HomeSnapshotDto, dto::SessionFailureDto> {
     let home = state.home.clone();
     off_the_ui_thread(move || {
         on_settings_file(&home, |home, settings_path| {
-            refresh_home_on_model(home, settings_path, &|state| {
-                let _ = on_progress.send(state.into());
+            refresh_home_on_model(home, settings_path, &|shown| {
+                let _ = on_progress.send(shown);
             });
         })
     })
@@ -475,10 +490,13 @@ pub fn move_home_cursor(
     move_home_cursor_on_model(&state.home, move_to)
 }
 
-/// Adds the folders the reviewer picked, writing the file once and refreshing.
+/// Adds the folders the reviewer picked, writing the file once and reading it
+/// back.
 ///
 /// A folder that is not a clone of a GitHub repository is refused with its
-/// reason while the rest proceed, and one already listed is ignored.
+/// reason while the rest proceed, and one already listed is ignored. The pull
+/// requests of a repository just added arrive with the refresh the caller runs
+/// next, not with this.
 ///
 /// # Errors
 ///
@@ -500,7 +518,10 @@ pub async fn add_repositories(
     .await
 }
 
-/// Drops one configured clone, writing the file and refreshing.
+/// Drops one configured clone, writing the file and reading it back.
+///
+/// The list is left as it stands otherwise. It is the refresh the caller runs
+/// next that asks GitHub about what remains.
 ///
 /// # Errors
 ///
@@ -1053,6 +1074,15 @@ mod tests {
         assert!(shown.failed_repositories.is_empty());
     }
 
+    /// Everything a refresh reported, in the order it said it.
+    fn reported_by(home: &ManagedHome, settings_path: &Path) -> Vec<dto::HomeSnapshotDto> {
+        let reported = Mutex::new(Vec::new());
+        refresh_home_on_model(home, settings_path, &|shown| {
+            reported.lock().unwrap().push(shown);
+        });
+        reported.into_inner().unwrap()
+    }
+
     #[test]
     fn a_refresh_counts_off_the_repositories_and_ends_with_the_time_it_settled() {
         let gh = FakeGh::new();
@@ -1061,25 +1091,49 @@ mod tests {
         let directory = TempDir::new().unwrap();
         let settings_path = settings_listing(&directory, &[&clone]);
         let home = home_with(&gh);
-        let reported = Mutex::new(Vec::new());
 
-        refresh_home_on_model(&home, &settings_path, &|progress| {
-            reported.lock().unwrap().push(progress);
-        });
+        let reported = reported_by(&home, &settings_path);
 
-        let reported = reported.lock().unwrap().clone();
+        let states = reported
+            .iter()
+            .map(|shown| shown.refresh.clone())
+            .collect::<Vec<_>>();
         assert_eq!(
-            reported.first(),
-            Some(&app::RefreshState::Refreshing { done: 0, total: 0 }),
+            states.first(),
+            Some(&dto::RefreshStateDto::Refreshing { done: 0, total: 0 }),
             "the total is unknown until the settings file has been read",
         );
         assert!(
-            reported.contains(&app::RefreshState::Refreshing { done: 1, total: 1 }),
-            "every repository is counted off: {reported:?}",
+            states.contains(&dto::RefreshStateDto::Refreshing { done: 1, total: 1 }),
+            "every repository is counted off: {states:?}",
         );
         assert!(
-            matches!(reported.last(), Some(app::RefreshState::Refreshed { .. })),
-            "the last thing reported is the settled stamp: {reported:?}",
+            matches!(states.last(), Some(dto::RefreshStateDto::Refreshed { .. })),
+            "the last thing reported is the settled stamp: {states:?}",
+        );
+    }
+
+    /// A reviewer watching a slow organisation sees the rest of the list before
+    /// it answers, so every batch carries what Home shows by then.
+    #[test]
+    fn a_refresh_reports_the_rows_it_has_as_each_batch_lands() {
+        let gh = FakeGh::new();
+        gh.answer_graphql(&recorded_search("acme/widgets"));
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = settings_listing(&directory, &[&clone]);
+        let home = home_with(&gh);
+
+        let reported = reported_by(&home, &settings_path);
+
+        let counted = reported
+            .iter()
+            .map(|shown| shown.groups[0].rows.len())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            counted,
+            [0, 0, 2, 2],
+            "the rows arrive with the batch that fetched them",
         );
     }
 
@@ -1088,21 +1142,80 @@ mod tests {
     #[test]
     fn a_refresh_that_arrives_while_the_settings_guard_is_held_starts_nothing() {
         let gh = FakeGh::new();
+        gh.answer_graphql(&recorded_search("acme/widgets"));
         let clone = clone_of("acme/widgets");
         let directory = TempDir::new().unwrap();
         let settings_path = settings_listing(&directory, &[&clone]);
         let home = home_with(&gh);
+        refresh(&home, &settings_path);
+        let settled = snapshot(&home);
+
         let held = lock(&home.settings_action);
+        let ignored = on_settings_file(&home, |home, settings_path| {
+            refresh(home, settings_path);
+        });
+        drop(held);
+
+        assert_eq!(ignored.refresh, settled.refresh, "the stamp is left alone");
+        assert_eq!(
+            ignored.groups[0].rows.len(),
+            2,
+            "the rows on screen are still on screen",
+        );
+        assert_eq!(ignored.count_line, settled.count_line);
+    }
+
+    /// A refresh that stopped part way must not leave a stamp counting off for
+    /// ever, with nothing left running to finish it.
+    #[test]
+    fn a_refresh_that_panicked_ends_as_failed_rather_than_running_for_ever() {
+        let gh = FakeGh::new();
+        gh.answer_graphql(&recorded_search("acme/widgets"));
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = settings_listing(&directory, &[&clone]);
+        let home = home_with(&gh);
+        let reports = std::sync::atomic::AtomicUsize::new(0);
+
+        let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            refresh_home_on_model(&home, &settings_path, &|_shown| {
+                assert!(
+                    reports.fetch_add(1, Ordering::AcqRel) < 2,
+                    "the refresh gave up here"
+                );
+            });
+        }));
+
+        assert!(panicked.is_err(), "the refresh was stopped by a panic");
+        let shown = snapshot(&home);
+        assert_eq!(shown.refresh, dto::RefreshStateDto::Failed);
+        assert_eq!(
+            shown.failure.expect("an abandoned refresh says so").summary,
+            "Home could not finish the refresh",
+        );
+    }
+
+    /// The next trigger has to be able to start, whatever became of the last.
+    #[test]
+    fn a_refresh_after_one_that_panicked_still_runs() {
+        let gh = FakeGh::new();
+        gh.answer_graphql(&recorded_search("acme/widgets"));
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = settings_listing(&directory, &[&clone]);
+        let home = home_with(&gh);
+        let _panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            refresh_home_on_model(&home, &settings_path, &|_shown| panic!("gave up"));
+        }));
 
         refresh(&home, &settings_path);
 
-        assert_eq!(
-            lock(&home.model).refresh_state(),
-            app::RefreshState::NeverRefreshed,
-            "nothing was started while the guard was held",
-        );
-        assert!(lock(&home.model).repositories().is_empty());
-        drop(held);
+        let shown = snapshot(&home);
+        assert!(matches!(
+            shown.refresh,
+            dto::RefreshStateDto::Refreshed { .. }
+        ));
+        assert_eq!(shown.groups[0].rows.len(), 2);
     }
 
     #[test]
@@ -1190,7 +1303,7 @@ mod tests {
 
         assert_eq!(
             move_home_cursor_on_model(&home, dto::CursorMoveDto::Down).cursor,
-            1
+            1,
         );
         assert_eq!(
             move_home_cursor_on_model(&home, dto::CursorMoveDto::Up).cursor,
@@ -1206,7 +1319,7 @@ mod tests {
         let home = home_model();
 
         refresh(&home, &settings_path);
-        assert!(lock(&home.model).repositories().is_empty());
+        assert!(snapshot(&home).repositories.is_empty());
 
         std::fs::write(
             &settings_path,
@@ -1218,9 +1331,9 @@ mod tests {
         .unwrap();
         refresh(&home, &settings_path);
 
-        let guard = lock(&home.model);
-        assert_eq!(guard.repositories().len(), 1, "a hand edit is picked up");
-        assert_eq!(guard.repositories()[0].slug(), Some("acme/widgets"));
+        let shown = snapshot(&home);
+        assert_eq!(shown.repositories.len(), 1, "a hand edit is picked up");
+        assert_eq!(shown.repositories[0].slug.as_deref(), Some("acme/widgets"));
     }
 
     #[test]
@@ -1234,8 +1347,8 @@ mod tests {
 
         assert_eq!(listed(&settings_path).len(), 1);
         assert_eq!(
-            lock(&home.model).repositories()[0].slug(),
-            Some("acme/widgets")
+            snapshot(&home).repositories[0].slug.as_deref(),
+            Some("acme/widgets"),
         );
     }
 
@@ -1252,9 +1365,9 @@ mod tests {
             !settings_path.exists(),
             "nothing was accepted, so the file is never touched",
         );
-        let guard = lock(&home.model);
-        assert_eq!(guard.refusals().len(), 1);
-        assert_eq!(guard.refusals()[0].reason, "not a Git repository");
+        let shown = snapshot(&home);
+        assert_eq!(shown.refusals.len(), 1);
+        assert_eq!(shown.refusals[0].reason, "not a Git repository");
     }
 
     #[test]
@@ -1269,14 +1382,14 @@ mod tests {
             &settings_path,
             &[first.path().to_path_buf(), second.path().to_path_buf()],
         );
-        let listed_first = lock(&home.model).repositories()[0].path.clone();
+        let listed_first = PathBuf::from(&snapshot(&home).repositories[0].path);
 
         remove_repository_on_model(&home, &settings_path, &listed_first);
 
         assert_eq!(listed(&settings_path).len(), 1);
         assert_eq!(
-            lock(&home.model).repositories()[0].slug(),
-            Some("acme/billing")
+            snapshot(&home).repositories[0].slug.as_deref(),
+            Some("acme/billing"),
         );
     }
 
@@ -1372,10 +1485,10 @@ mod tests {
             &settings_path,
             &[first.path().to_path_buf(), second.path().to_path_buf()],
         );
-        let paths = lock(&home.model)
-            .repositories()
+        let paths = snapshot(&home)
+            .repositories
             .iter()
-            .map(|entry| entry.path.clone())
+            .map(|entry| PathBuf::from(&entry.path))
             .collect::<Vec<_>>();
         assert_eq!(paths.len(), 2);
 

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -57,6 +57,8 @@ fn refresh_home_on_model(
     report_refresh(home, report);
 
     read_into_model(home, settings_path);
+    // Only the settings file can have failed by here, the last refresh's
+    // preflight failure having gone with the trigger that started this one.
     if lock(&home.model).failure().is_some() {
         report_refresh(home, report);
         return;

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -209,6 +209,70 @@ impl From<&SessionFailure> for SessionFailureDto {
     }
 }
 
+/// Which severity a status column paints itself in.
+///
+/// Named rather than coloured, so the values themselves stay in the one style
+/// sheet that owns them.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, specta::Type)]
+pub enum StatusToneDto {
+    Success,
+    Error,
+    Warning,
+    Muted,
+}
+
+/// One status column's words and the weight they carry.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, specta::Type)]
+pub struct RowStatusDto {
+    pub label: String,
+    pub tone: StatusToneDto,
+}
+
+impl From<app::CheckStatus> for RowStatusDto {
+    fn from(status: app::CheckStatus) -> Self {
+        Self {
+            label: status.label().to_owned(),
+            tone: match status {
+                app::CheckStatus::Passing => StatusToneDto::Success,
+                app::CheckStatus::Failing => StatusToneDto::Error,
+                app::CheckStatus::Running => StatusToneDto::Warning,
+            },
+        }
+    }
+}
+
+impl From<app::ReviewStatus> for RowStatusDto {
+    fn from(status: app::ReviewStatus) -> Self {
+        Self {
+            label: status.label().to_owned(),
+            tone: match status {
+                app::ReviewStatus::Approved => StatusToneDto::Success,
+                app::ReviewStatus::ChangesRequested => StatusToneDto::Error,
+                app::ReviewStatus::ReviewedThisHead => StatusToneDto::Muted,
+            },
+        }
+    }
+}
+
+/// One pull request, as one line of the ledger.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct HomeRowDto {
+    /// Where this row sits in the flat order the cursor walks.
+    pub index: u32,
+    pub title: String,
+    pub url: String,
+    /// `owner/name#number`.
+    pub identity: String,
+    /// Absent once GitHub has forgotten the account.
+    pub author: Option<String>,
+    /// When the pull request last moved, as epoch milliseconds, which the age
+    /// column is worked out from.
+    #[specta(type = specta_typescript::Number)]
+    pub updated_at_ms: i64,
+    pub review_status: Option<RowStatusDto>,
+    pub check_status: Option<RowStatusDto>,
+}
+
 /// One of Home's three groups, always rendered whether or not it has rows.
 #[derive(Clone, Debug, Serialize, specta::Type)]
 pub struct HomeGroupDto {
@@ -216,6 +280,54 @@ pub struct HomeGroupDto {
     pub count: u32,
     /// The one line an empty group shows in place of rows.
     pub empty_copy: String,
+    pub rows: Vec<HomeRowDto>,
+}
+
+/// How current the list is, which the header stamp reads.
+#[derive(Clone, Debug, PartialEq, Serialize, specta::Type)]
+pub enum RefreshStateDto {
+    /// There is no stamp at all until the first refresh starts.
+    NeverRefreshed,
+    Refreshing {
+        done: u32,
+        total: u32,
+    },
+    /// Epoch milliseconds, which the relative stamp is worked out from.
+    Refreshed {
+        #[specta(type = specta_typescript::Number)]
+        at_ms: i64,
+    },
+    Failed,
+}
+
+impl From<app::RefreshState> for RefreshStateDto {
+    fn from(state: app::RefreshState) -> Self {
+        match state {
+            app::RefreshState::NeverRefreshed => Self::NeverRefreshed,
+            app::RefreshState::Refreshing { done, total } => Self::Refreshing {
+                done: as_u32(done),
+                total: as_u32(total),
+            },
+            app::RefreshState::Refreshed { at_ms } => Self::Refreshed { at_ms },
+            app::RefreshState::Failed => Self::Failed,
+        }
+    }
+}
+
+/// One configured repository whose pull requests could not be fetched.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct FailedRepositoryDto {
+    /// The entry in the settings file, which is what Remove names.
+    pub path: String,
+    pub slug: String,
+    pub reason: String,
+}
+
+/// Which way the cursor is being moved.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, specta::Type)]
+pub enum CursorMoveDto {
+    Down,
+    Up,
 }
 
 /// One configured clone as the footer lists it.
@@ -240,12 +352,18 @@ pub struct HomeSnapshotDto {
     /// The header's count line, absent until there is something to count.
     pub count_line: Option<String>,
     pub groups: Vec<HomeGroupDto>,
+    /// Where the cursor sits, as a flat index across every rendered row.
+    pub cursor: u32,
+    pub refresh: RefreshStateDto,
+    /// One line each above the list, naming a repository this refresh lost.
+    pub failed_repositories: Vec<FailedRepositoryDto>,
     pub repositories: Vec<HomeRepositoryDto>,
     pub footer_summary: String,
     pub footer_expanded: bool,
     pub refusals: Vec<RefusalDto>,
-    /// What replaces the list area when Home cannot read its repositories. The
-    /// header and footer stay either way, so Add still works.
+    /// What replaces the list area when Home cannot read its repositories or
+    /// cannot use `gh`. The header and footer stay either way, so Add still
+    /// works.
     pub failure: Option<SessionFailureDto>,
     /// Why the last write did not reach the file, shown as a line above the
     /// list, which stays because reading it still worked.
@@ -253,19 +371,41 @@ pub struct HomeSnapshotDto {
 }
 
 /// Everything Home shows, from the model that decided it.
-///
-/// No pull requests have been fetched yet, so every group is empty and no
-/// repository carries a count.
 #[must_use]
 pub fn project_home(home: &app::HomeModel) -> HomeSnapshotDto {
+    // Walked in the model's own order, so a row's index is where the cursor
+    // finds it rather than something counted twice and hoped to agree.
+    let mut index = 0_u32;
+    let mut groups = Vec::with_capacity(app::HomeGroup::ALL.len());
+    for group in app::HomeGroup::ALL {
+        let rows = home
+            .rows_in(group)
+            .map(|row| {
+                let projected = project_home_row(row, index);
+                index += 1;
+                projected
+            })
+            .collect::<Vec<_>>();
+        groups.push(HomeGroupDto {
+            title: group.title().to_owned(),
+            count: as_u32(rows.len()),
+            empty_copy: group.empty_copy().to_owned(),
+            rows,
+        });
+    }
+
     HomeSnapshotDto {
         count_line: home.count_line(),
-        groups: app::HomeGroup::ALL
-            .into_iter()
-            .map(|group| HomeGroupDto {
-                title: group.title().to_owned(),
-                count: 0,
-                empty_copy: group.empty_copy().to_owned(),
+        groups,
+        cursor: as_u32(home.cursor()),
+        refresh: home.refresh_state().into(),
+        failed_repositories: home
+            .fetch_failures()
+            .iter()
+            .map(|failure| FailedRepositoryDto {
+                path: failure.path.display().to_string(),
+                slug: failure.slug.clone(),
+                reason: failure.reason.clone(),
             })
             .collect(),
         repositories: home
@@ -274,7 +414,7 @@ pub fn project_home(home: &app::HomeModel) -> HomeSnapshotDto {
             .map(|entry| HomeRepositoryDto {
                 path: entry.path.display().to_string(),
                 slug: entry.slug().map(ToOwned::to_owned),
-                failure: entry.reason().map(ToOwned::to_owned),
+                failure: home.repository_failure(&entry.path).map(ToOwned::to_owned),
             })
             .collect(),
         footer_summary: home.footer_summary(),
@@ -289,6 +429,19 @@ pub fn project_home(home: &app::HomeModel) -> HomeSnapshotDto {
             .collect(),
         failure: home.failure().map(Into::into),
         write_failure: home.write_failure().map(Into::into),
+    }
+}
+
+fn project_home_row(row: &app::HomeRow, index: u32) -> HomeRowDto {
+    HomeRowDto {
+        index,
+        title: row.title.clone(),
+        url: row.url.clone(),
+        identity: row.identity(),
+        author: row.author_login.clone(),
+        updated_at_ms: row.updated_at_ms,
+        review_status: row.review_status.map(Into::into),
+        check_status: row.check_status.map(Into::into),
     }
 }
 

--- a/apps/desktop/src-tauri/src/fake_gh.rs
+++ b/apps/desktop/src-tauri/src/fake_gh.rs
@@ -1,0 +1,73 @@
+//! A stand-in for `gh`, so the commands that call it can be driven in a test.
+//!
+//! Answers `auth status` and `api graphql` from files in its own directory,
+//! which is what lets one test refuse authentication and another hand back a
+//! recorded search result.
+
+use std::{fs, os::unix::fs::PermissionsExt, path::PathBuf};
+
+use github::GithubClient;
+use tempfile::TempDir;
+
+pub(crate) struct FakeGh {
+    directory: TempDir,
+}
+
+impl FakeGh {
+    /// A `gh` that is signed in and has no answer for any query yet.
+    pub(crate) fn new() -> Self {
+        let directory = TempDir::new().unwrap();
+        let script = format!(
+            r#"#!/bin/sh
+dir="{dir}"
+if [ "$1" = "auth" ]; then
+  if [ -f "$dir/refuse-auth" ]; then
+    echo "You are not logged into any GitHub hosts. Run gh auth login." >&2
+    exit 1
+  fi
+  exit 0
+fi
+if [ -f "$dir/graphql" ]; then
+  cat "$dir/graphql"
+  exit 0
+fi
+echo "gh: no recorded response" >&2
+exit 1
+"#,
+            dir = directory.path().display(),
+        );
+        let path = directory.path().join("gh");
+        fs::write(&path, script).unwrap();
+        let mut permissions = fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&path, permissions).unwrap();
+
+        Self { directory }
+    }
+
+    pub(crate) fn client(&self) -> GithubClient {
+        GithubClient::new(self.path())
+    }
+
+    pub(crate) fn path(&self) -> PathBuf {
+        self.directory.path().join("gh")
+    }
+
+    /// Makes `gh auth status` report no signed in account.
+    pub(crate) fn refuse_authentication(&self) -> &Self {
+        fs::write(self.directory.path().join("refuse-auth"), "").unwrap();
+        self
+    }
+
+    /// Signs `gh` back in, which is what a reviewer does between two refreshes.
+    pub(crate) fn allow_authentication(&self) -> &Self {
+        fs::remove_file(self.directory.path().join("refuse-auth")).unwrap();
+        self
+    }
+
+    /// Answers every GraphQL call with `body`.
+    pub(crate) fn answer_graphql(&self, body: &str) -> &Self {
+        fs::write(self.directory.path().join("graphql"), body).unwrap();
+        self
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -3,10 +3,14 @@
 use std::sync::{Arc, Mutex, atomic::AtomicBool};
 
 use app::{HomeModel, SessionModel};
+use github::GithubClient;
 use session::{ReviewStorage, SessionRequest};
 
 mod commands;
 mod dto;
+#[cfg(test)]
+mod fake_gh;
+mod pull_requests;
 mod repositories;
 
 /// What the binary was asked to open.
@@ -48,13 +52,17 @@ pub(crate) struct ManagedHome {
     /// reads back. Two of them interleaving would let one write a list the
     /// other had already changed, resurrecting a repository just removed.
     pub(crate) settings_action: Arc<Mutex<()>>,
+    /// How a refresh reaches GitHub. Held rather than built per call so a test
+    /// can hand Home a `gh` of its own.
+    pub(crate) client: GithubClient,
 }
 
 impl ManagedHome {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(client: GithubClient) -> Self {
         Self {
             model: Arc::new(Mutex::new(HomeModel::new())),
             settings_action: Arc::new(Mutex::new(())),
+            client,
         }
     }
 }
@@ -85,7 +93,7 @@ pub fn run(launch: Launch) {
         }),
     };
     let root = AppRoot {
-        home: ManagedHome::new(),
+        home: ManagedHome::new(GithubClient::default()),
         session,
     };
     let specta_builder = commands::specta_builder();

--- a/apps/desktop/src-tauri/src/pull_requests.rs
+++ b/apps/desktop/src-tauri/src/pull_requests.rs
@@ -1,0 +1,575 @@
+//! Fetching Home's pull requests, and reducing them to what its model reads.
+//!
+//! The Home model takes rows that already answer the questions grouping asks,
+//! so the comparisons against the viewer's own login and the shape of GitHub's
+//! reviews and threads are settled here, where the forge's types are in scope.
+
+use std::path::Path;
+
+use app::{FetchedPullRequest, RepositoryFetch};
+use domain::SessionFailure;
+use github::{
+    GithubClient, GithubError, HomePullRequest, HomeRepository, RepositorySlug, ReviewState,
+    ReviewThread,
+};
+
+/// Confirms `gh` is installed and signed in before a refresh spends anything.
+///
+/// Run in one configured clone, because that is what the check takes, though
+/// what it answers is about the machine rather than the repository.
+///
+/// # Errors
+///
+/// Returns what Home shows in place of its list when `gh` cannot be used.
+pub fn preflight(client: &GithubClient, clone_root: &Path) -> Result<(), SessionFailure> {
+    client
+        .check_authentication(clone_root)
+        .map_err(|error| preflight_failure(&error))
+}
+
+fn preflight_failure(error: &GithubError) -> SessionFailure {
+    SessionFailure::from_error("Home could not use the GitHub CLI", error)
+        .with_optional_remediation(error.remediation())
+}
+
+/// Fetches one batch of repositories, reduced to what Home's model reads.
+///
+/// A batch is what a refresh reports progress in, so it is the caller that
+/// splits the configured repositories into batches rather than the fetch.
+#[must_use]
+pub fn fetch_batch(client: &GithubClient, batch: &[RepositorySlug]) -> Vec<RepositoryFetch> {
+    let fetched = client.fetch_home_pull_requests(batch);
+    let viewer_login = fetched.viewer_login;
+    fetched
+        .repositories
+        .into_iter()
+        .map(|repository| map_repository(repository, viewer_login.as_deref()))
+        .collect()
+}
+
+/// Reduces one repository's fetch to what Home's model reads.
+///
+/// A row this cannot read fails the repository it came from rather than
+/// disappearing out of a list that would then be short without saying why.
+fn map_repository(repository: HomeRepository, viewer_login: Option<&str>) -> RepositoryFetch {
+    let slug = repository.repository.full_name();
+    let outcome = match repository.pull_requests {
+        Ok(pull_requests) => map_pull_requests(pull_requests, viewer_login),
+        Err(error) => Err(error.to_string()),
+    };
+    RepositoryFetch { slug, outcome }
+}
+
+fn map_pull_requests(
+    pull_requests: Vec<HomePullRequest>,
+    viewer_login: Option<&str>,
+) -> Result<Vec<FetchedPullRequest>, String> {
+    if pull_requests.is_empty() {
+        return Ok(Vec::new());
+    }
+    // Grouping asks whether a thread or a review is the viewer's own, and there
+    // is no answering that without knowing which account answered.
+    let viewer_login =
+        viewer_login.ok_or_else(|| "GitHub did not say who is signed in".to_owned())?;
+    pull_requests
+        .into_iter()
+        .map(|pull_request| map_pull_request(pull_request, viewer_login))
+        .collect()
+}
+
+/// Reduces one fetched pull request to what Home's model reads.
+///
+/// # Errors
+///
+/// Returns the malformed update time when GitHub sent one this cannot read,
+/// which would otherwise order the row against every other by an invented time.
+fn map_pull_request(
+    pull_request: HomePullRequest,
+    viewer_login: &str,
+) -> Result<FetchedPullRequest, String> {
+    let updated_at_ms = epoch_millis(&pull_request.updated_at).ok_or_else(|| {
+        format!(
+            "GitHub sent an update time this cannot read ({})",
+            pull_request.updated_at,
+        )
+    })?;
+    Ok(FetchedPullRequest {
+        search: match pull_request.search {
+            github::HomeSearch::ReviewRequested => app::HomeSearch::ReviewRequested,
+            github::HomeSearch::Authored => app::HomeSearch::Authored,
+        },
+        repository: pull_request.repository.full_name(),
+        number: pull_request.number,
+        title: pull_request.title,
+        url: pull_request.url,
+        author_login: pull_request.author_login,
+        updated_at_ms,
+        head_sha: pull_request.head_sha,
+        viewer_latest_review_sha: pull_request.viewer_latest_review_sha,
+        check_state: pull_request.check_state.map(map_check_state),
+        review_decision: pull_request.review_decision.map(map_review_decision),
+        changes_requested: pull_request
+            .latest_opinionated_reviews
+            .iter()
+            .any(|review| review.state == ReviewState::ChangesRequested),
+        thread_awaiting_reply: pull_request
+            .review_threads
+            .iter()
+            .any(|thread| is_awaiting_reply(thread, viewer_login)),
+    })
+}
+
+/// Whether this thread is one the author is being waited on in.
+///
+/// A thread whose last comment has no author at all counts as somebody else's,
+/// because the one thing known about it is that it is not the viewer's.
+fn is_awaiting_reply(thread: &ReviewThread, viewer_login: &str) -> bool {
+    !thread.resolved && thread.last_comment_author_login.as_deref() != Some(viewer_login)
+}
+
+const fn map_check_state(state: github::StatusCheckState) -> app::CheckState {
+    match state {
+        github::StatusCheckState::Expected => app::CheckState::Expected,
+        github::StatusCheckState::Error => app::CheckState::Error,
+        github::StatusCheckState::Failure => app::CheckState::Failure,
+        github::StatusCheckState::Pending => app::CheckState::Pending,
+        github::StatusCheckState::Success => app::CheckState::Success,
+    }
+}
+
+const fn map_review_decision(decision: github::ReviewDecision) -> app::ReviewDecision {
+    match decision {
+        github::ReviewDecision::ChangesRequested => app::ReviewDecision::ChangesRequested,
+        github::ReviewDecision::Approved => app::ReviewDecision::Approved,
+        github::ReviewDecision::ReviewRequired => app::ReviewDecision::ReviewRequired,
+    }
+}
+
+/// Reads GitHub's `YYYY-MM-DDTHH:MM:SSZ` into epoch milliseconds.
+///
+/// Returns `None` for anything else, rather than inventing a time for a row
+/// whose position in the list is decided by it.
+fn epoch_millis(timestamp: &str) -> Option<i64> {
+    let bytes = timestamp.as_bytes();
+    if bytes.len() != 20 || bytes[4] != b'-' || bytes[7] != b'-' || bytes[10] != b'T' {
+        return None;
+    }
+    if bytes[13] != b':' || bytes[16] != b':' || bytes[19] != b'Z' {
+        return None;
+    }
+    let year = timestamp[0..4].parse::<i64>().ok()?;
+    let month = timestamp[5..7].parse::<u32>().ok()?;
+    let day = timestamp[8..10].parse::<u32>().ok()?;
+    let hour = timestamp[11..13].parse::<i64>().ok()?;
+    let minute = timestamp[14..16].parse::<i64>().ok()?;
+    // 60 is a leap second, which GitHub can legitimately send.
+    let second = timestamp[17..19].parse::<i64>().ok()?;
+    if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return None;
+    }
+    if hour > 23 || minute > 59 || second > 60 {
+        return None;
+    }
+    let days = days_from_civil(year, month, day);
+    Some((days * 86_400 + hour * 3_600 + minute * 60 + second) * 1_000)
+}
+
+/// Days between the civil date and 1970-01-01, by Howard Hinnant's algorithm.
+fn days_from_civil(year: i64, month: u32, day: u32) -> i64 {
+    let year = if month <= 2 { year - 1 } else { year };
+    let era = if year >= 0 { year } else { year - 399 } / 400;
+    let year_of_era = year - era * 400;
+    let month = i64::from(month);
+    let shifted_month = if month > 2 { month - 3 } else { month + 9 };
+    let day_of_year = (153 * shifted_month + 2) / 5 + i64::from(day) - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    era * 146_097 + day_of_era - 719_468
+}
+
+#[cfg(test)]
+mod tests {
+    use github::{
+        HomePullRequest, HomeRepository, HomeSearch, OpinionatedReview, RepositorySlug,
+        ReviewDecision, StatusCheckState,
+    };
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::fake_gh::FakeGh;
+
+    /// One pull request as the GraphQL path returns it.
+    fn pull_request(search: HomeSearch, number: u64) -> HomePullRequest {
+        HomePullRequest {
+            search,
+            repository: RepositorySlug::new("acme", "widgets"),
+            number,
+            title: format!("Pull request {number}"),
+            url: format!("https://github.com/acme/widgets/pull/{number}"),
+            draft: false,
+            updated_at: "2026-09-01T12:34:56Z".to_owned(),
+            head_sha: "abc123".to_owned(),
+            author_login: Some("mlee".to_owned()),
+            viewer_latest_review_sha: None,
+            check_state: None,
+            review_decision: None,
+            latest_opinionated_reviews: Vec::new(),
+            review_threads: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn a_fetched_pull_request_carries_every_field_the_grouping_reads() {
+        let fetched = map_pull_request(pull_request(HomeSearch::ReviewRequested, 412), "braidonw")
+            .expect("a well-formed row maps");
+
+        assert_eq!(fetched.search, app::HomeSearch::ReviewRequested);
+        assert_eq!(fetched.repository, "acme/widgets");
+        assert_eq!(fetched.number, 412);
+        assert_eq!(fetched.title, "Pull request 412");
+        assert_eq!(fetched.url, "https://github.com/acme/widgets/pull/412");
+        assert_eq!(fetched.author_login.as_deref(), Some("mlee"));
+        assert_eq!(fetched.head_sha, "abc123");
+        assert_eq!(fetched.updated_at_ms, 1_788_266_096_000);
+    }
+
+    /// One authored pull request carrying `threads`, as the viewer sees it.
+    fn with_threads(threads: Vec<ReviewThread>) -> FetchedPullRequest {
+        let mut authored = pull_request(HomeSearch::Authored, 412);
+        authored.review_threads = threads;
+        map_pull_request(authored, "braidonw").expect("a well-formed row maps")
+    }
+
+    fn thread(resolved: bool, last_comment_author_login: Option<&str>) -> ReviewThread {
+        ReviewThread {
+            resolved,
+            last_comment_author_login: last_comment_author_login.map(ToOwned::to_owned),
+        }
+    }
+
+    #[test]
+    fn an_unresolved_thread_somebody_else_spoke_in_last_is_awaiting_a_reply() {
+        let fetched = with_threads(vec![thread(false, Some("priya"))]);
+
+        assert!(fetched.thread_awaiting_reply);
+    }
+
+    #[test]
+    fn an_unresolved_thread_the_viewer_spoke_in_last_is_not_awaiting_a_reply() {
+        let fetched = with_threads(vec![thread(false, Some("braidonw"))]);
+
+        assert!(!fetched.thread_awaiting_reply);
+    }
+
+    /// All that is known about a thread with no last author is that the last
+    /// word was not the viewer's.
+    #[test]
+    fn an_unresolved_thread_with_no_last_comment_author_is_awaiting_a_reply() {
+        let fetched = with_threads(vec![thread(false, None)]);
+
+        assert!(fetched.thread_awaiting_reply);
+    }
+
+    #[test]
+    fn a_resolved_thread_is_never_awaiting_a_reply() {
+        let fetched = with_threads(vec![thread(true, Some("priya"))]);
+
+        assert!(!fetched.thread_awaiting_reply);
+    }
+
+    #[test]
+    fn one_unanswered_thread_among_answered_ones_is_enough() {
+        let fetched = with_threads(vec![
+            thread(true, Some("priya")),
+            thread(false, Some("braidonw")),
+            thread(false, Some("tomas")),
+        ]);
+
+        assert!(fetched.thread_awaiting_reply);
+    }
+
+    /// One authored pull request whose standing reviews are `reviews`.
+    fn with_reviews(reviews: Vec<OpinionatedReview>) -> FetchedPullRequest {
+        let mut authored = pull_request(HomeSearch::Authored, 412);
+        authored.latest_opinionated_reviews = reviews;
+        map_pull_request(authored, "braidonw").expect("a well-formed row maps")
+    }
+
+    fn review(state: ReviewState) -> OpinionatedReview {
+        OpinionatedReview {
+            state,
+            author_login: Some("priya".to_owned()),
+        }
+    }
+
+    #[test]
+    fn a_standing_changes_requested_review_is_carried_to_the_model() {
+        let fetched = with_reviews(vec![
+            review(ReviewState::Approved),
+            review(ReviewState::ChangesRequested),
+        ]);
+
+        assert!(fetched.changes_requested);
+    }
+
+    #[test]
+    fn reviews_that_ask_for_nothing_leave_the_pull_request_alone() {
+        let fetched = with_reviews(vec![
+            review(ReviewState::Approved),
+            review(ReviewState::Commented),
+            review(ReviewState::Pending),
+            review(ReviewState::Dismissed),
+        ]);
+
+        assert!(!fetched.changes_requested);
+    }
+
+    #[test]
+    fn every_check_state_and_review_decision_reaches_the_model_unchanged() {
+        let states = [
+            (StatusCheckState::Expected, app::CheckState::Expected),
+            (StatusCheckState::Error, app::CheckState::Error),
+            (StatusCheckState::Failure, app::CheckState::Failure),
+            (StatusCheckState::Pending, app::CheckState::Pending),
+            (StatusCheckState::Success, app::CheckState::Success),
+        ];
+        for (fetched_state, expected) in states {
+            let mut row = pull_request(HomeSearch::Authored, 412);
+            row.check_state = Some(fetched_state);
+            let mapped = map_pull_request(row, "braidonw").expect("a well-formed row maps");
+            assert_eq!(mapped.check_state, Some(expected));
+        }
+
+        let decisions = [
+            (
+                ReviewDecision::ChangesRequested,
+                app::ReviewDecision::ChangesRequested,
+            ),
+            (ReviewDecision::Approved, app::ReviewDecision::Approved),
+            (
+                ReviewDecision::ReviewRequired,
+                app::ReviewDecision::ReviewRequired,
+            ),
+        ];
+        for (fetched_decision, expected) in decisions {
+            let mut row = pull_request(HomeSearch::Authored, 412);
+            row.review_decision = Some(fetched_decision);
+            let mapped = map_pull_request(row, "braidonw").expect("a well-formed row maps");
+            assert_eq!(mapped.review_decision, Some(expected));
+        }
+    }
+
+    #[test]
+    fn an_authored_search_reaches_the_model_as_an_authored_row() {
+        let fetched =
+            map_pull_request(pull_request(HomeSearch::Authored, 412), "braidonw").unwrap();
+
+        assert_eq!(fetched.search, app::HomeSearch::Authored);
+    }
+
+    /// The row's place in the list is decided by its update time, so a time
+    /// that cannot be read is refused rather than guessed at.
+    #[test]
+    fn an_update_time_github_could_not_have_sent_is_refused() {
+        let unreadable = [
+            "",
+            "2026-09-01",
+            "2026-09-01T12:34:56",
+            "2026-09-01T12:34:56+01:00",
+            "2026-13-01T12:34:56Z",
+            "2026-09-32T12:34:56Z",
+            "2026-09-01T24:34:56Z",
+            "2026-09-01T12:61:56Z",
+            "2026-09-01T12:34:61Z",
+            "yyyy-mm-ddThh:mm:ssZ",
+        ];
+
+        for timestamp in unreadable {
+            let mut row = pull_request(HomeSearch::Authored, 412);
+            row.updated_at = timestamp.to_owned();
+
+            let refused = map_pull_request(row, "braidonw").expect_err("{timestamp} should refuse");
+
+            assert!(
+                refused.contains("update time"),
+                "{timestamp} refused with {refused}",
+            );
+        }
+    }
+
+    #[test]
+    fn update_times_are_read_as_epoch_milliseconds() {
+        let read = [
+            ("1970-01-01T00:00:00Z", 0),
+            ("1969-12-31T23:59:59Z", -1_000),
+            ("2000-02-29T00:00:00Z", 951_782_400_000),
+            ("2026-09-01T12:34:56Z", 1_788_266_096_000),
+            ("2038-01-19T03:14:08Z", 2_147_483_648_000),
+        ];
+
+        for (timestamp, expected) in read {
+            assert_eq!(epoch_millis(timestamp), Some(expected), "{timestamp}");
+        }
+    }
+
+    /// One repository's fetch, having found `rows`.
+    fn loaded(rows: Vec<HomePullRequest>) -> HomeRepository {
+        HomeRepository {
+            repository: RepositorySlug::new("acme", "widgets"),
+            pull_requests: Ok(rows),
+        }
+    }
+
+    #[test]
+    fn a_repository_that_answered_carries_its_rows_under_its_slug() {
+        let fetched = map_repository(
+            loaded(vec![
+                pull_request(HomeSearch::ReviewRequested, 412),
+                pull_request(HomeSearch::Authored, 398),
+            ]),
+            Some("braidonw"),
+        );
+
+        assert_eq!(fetched.slug, "acme/widgets");
+        let rows = fetched.outcome.expect("the repository answered");
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].number, 412);
+    }
+
+    #[test]
+    fn a_repository_that_failed_carries_the_classified_error() {
+        let fetched = map_repository(
+            HomeRepository {
+                repository: RepositorySlug::new("acme", "billing"),
+                pull_requests: Err(std::sync::Arc::new(github::GithubError::Forbidden {
+                    detail: "SAML enforcement".to_owned(),
+                })),
+            },
+            Some("braidonw"),
+        );
+
+        assert_eq!(fetched.slug, "acme/billing");
+        let reason = fetched.outcome.expect_err("the repository failed");
+        assert!(reason.contains("SAML enforcement"), "{reason}");
+    }
+
+    #[test]
+    fn one_unreadable_update_time_fails_the_repository_it_came_from() {
+        let mut unreadable = pull_request(HomeSearch::Authored, 398);
+        unreadable.updated_at = "the day before yesterday".to_owned();
+
+        let fetched = map_repository(
+            loaded(vec![
+                pull_request(HomeSearch::ReviewRequested, 412),
+                unreadable,
+            ]),
+            Some("braidonw"),
+        );
+
+        let reason = fetched.outcome.expect_err("the repository failed");
+        assert!(reason.contains("update time"), "{reason}");
+    }
+
+    /// Every comparison against the viewer needs a viewer, and inventing one
+    /// would put pull requests in the wrong group without saying so.
+    #[test]
+    fn rows_that_arrived_without_a_signed_in_account_fail_the_repository() {
+        let fetched = map_repository(loaded(vec![pull_request(HomeSearch::Authored, 412)]), None);
+
+        let reason = fetched.outcome.expect_err("the repository failed");
+        assert!(reason.contains("who is signed in"), "{reason}");
+    }
+
+    #[test]
+    fn a_repository_that_answered_with_nothing_needs_no_signed_in_account() {
+        let fetched = map_repository(loaded(Vec::new()), None);
+
+        assert_eq!(fetched.outcome, Ok(Vec::new()));
+    }
+
+    #[test]
+    fn a_preflight_against_a_signed_in_gh_lets_the_refresh_go_on() {
+        let gh = FakeGh::new();
+        let clone = TempDir::new().unwrap();
+
+        assert_eq!(preflight(&gh.client(), clone.path()), Ok(()));
+    }
+
+    #[test]
+    fn a_preflight_against_an_unauthenticated_gh_says_what_to_fix() {
+        let gh = FakeGh::new();
+        gh.refuse_authentication();
+        let clone = TempDir::new().unwrap();
+
+        let failure = preflight(&gh.client(), clone.path()).expect_err("gh is not signed in");
+
+        assert_eq!(failure.summary, "Home could not use the GitHub CLI");
+        assert!(
+            failure
+                .detail
+                .expect("the classified error rides along")
+                .contains("not logged into any GitHub hosts"),
+        );
+        assert!(
+            failure
+                .remediation
+                .expect("signing in is something a reviewer can do")
+                .contains("gh auth login"),
+        );
+    }
+
+    /// The one search result the fake hands back, with one row in each search.
+    const RECORDED_SEARCH: &str = r#"{"data":{
+        "viewer":{"login":"braidonw"},
+        "rateLimit":{"cost":1,"remaining":4999,"resetAt":"2026-09-01T13:00:00Z"},
+        "toReview":{"issueCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+          {"number":412,"title":"Retry webhook deliveries","url":"https://github.com/acme/widgets/pull/412",
+           "isDraft":false,"updatedAt":"2026-09-01T12:34:56Z","headRefOid":"abc123",
+           "repository":{"nameWithOwner":"acme/widgets"},"author":{"login":"mlee"},
+           "viewerLatestReview":null,"statusCheckRollup":{"state":"SUCCESS"}}
+        ]},
+        "authored":{"issueCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+          {"number":398,"title":"Split the renderer","url":"https://github.com/acme/widgets/pull/398",
+           "isDraft":false,"updatedAt":"2026-09-01T11:00:00Z","headRefOid":"def456",
+           "repository":{"nameWithOwner":"acme/widgets"},"author":{"login":"braidonw"},
+           "viewerLatestReview":null,"statusCheckRollup":null,"reviewDecision":"CHANGES_REQUESTED",
+           "latestOpinionatedReviews":{"nodes":[{"state":"CHANGES_REQUESTED","author":{"login":"priya"}}]},
+           "reviewThreads":{"totalCount":0,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}
+        ]}
+    }}"#;
+
+    #[test]
+    fn a_fetched_batch_comes_back_as_one_entry_per_repository_with_its_rows() {
+        let gh = FakeGh::new();
+        gh.answer_graphql(RECORDED_SEARCH);
+
+        let fetched = fetch_batch(&gh.client(), &[RepositorySlug::new("acme", "widgets")]);
+
+        assert_eq!(fetched.len(), 1);
+        assert_eq!(fetched[0].slug, "acme/widgets");
+        let rows = fetched[0]
+            .outcome
+            .as_ref()
+            .expect("the repository answered");
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].search, app::HomeSearch::ReviewRequested);
+        assert_eq!(rows[0].check_state, Some(app::CheckState::Success));
+        assert_eq!(rows[1].search, app::HomeSearch::Authored);
+        assert!(rows[1].changes_requested);
+    }
+
+    #[test]
+    fn a_batch_gh_could_not_answer_fails_every_repository_in_it() {
+        let gh = FakeGh::new();
+
+        let fetched = fetch_batch(
+            &gh.client(),
+            &[
+                RepositorySlug::new("acme", "widgets"),
+                RepositorySlug::new("acme", "billing"),
+            ],
+        );
+
+        assert_eq!(fetched.len(), 2);
+        assert!(fetched.iter().all(|entry| entry.outcome.is_err()));
+    }
+}

--- a/apps/desktop/src-tauri/src/pull_requests.rs
+++ b/apps/desktop/src-tauri/src/pull_requests.rs
@@ -9,8 +9,8 @@ use std::path::Path;
 use app::{FetchedPullRequest, RepositoryFetch};
 use domain::SessionFailure;
 use github::{
-    GithubClient, GithubError, HomePullRequest, HomeRepository, RepositorySlug, ReviewState,
-    ReviewThread,
+    GithubClient, GithubError, HomeFetch, HomePullRequest, HomeRepository, RepositorySlug,
+    ReviewState, ReviewThread,
 };
 
 /// Confirms `gh` is installed and signed in before a refresh spends anything.
@@ -21,7 +21,7 @@ use github::{
 /// # Errors
 ///
 /// Returns what Home shows in place of its list when `gh` cannot be used.
-pub fn preflight(client: &GithubClient, clone_root: &Path) -> Result<(), SessionFailure> {
+pub(crate) fn preflight(client: &GithubClient, clone_root: &Path) -> Result<(), SessionFailure> {
     client
         .check_authentication(clone_root)
         .map_err(|error| preflight_failure(&error))
@@ -32,18 +32,26 @@ fn preflight_failure(error: &GithubError) -> SessionFailure {
         .with_optional_remediation(error.remediation())
 }
 
-/// Fetches one batch of repositories, reduced to what Home's model reads.
+/// Fetches `repositories`, handing `on_batch` each batch as it answers.
 ///
-/// A batch is what a refresh reports progress in, so it is the caller that
-/// splits the configured repositories into batches rather than the fetch.
-#[must_use]
-pub fn fetch_batch(client: &GithubClient, batch: &[RepositorySlug]) -> Vec<RepositoryFetch> {
-    let fetched = client.fetch_home_pull_requests(batch);
-    let viewer_login = fetched.viewer_login;
-    fetched
+/// Batching and the collapsing of two clones that name one repository belong to
+/// the fetch, which is the one place that knows how GitHub compares two names.
+pub(crate) fn fetch(
+    client: &GithubClient,
+    repositories: &[RepositorySlug],
+    on_batch: &dyn Fn(Vec<RepositoryFetch>),
+) {
+    let _fetched = client.fetch_home_pull_requests_with_progress(repositories, &|batch| {
+        on_batch(map_batch(batch));
+    });
+}
+
+/// Reduces one batch's answer to what Home's model reads.
+fn map_batch(batch: &HomeFetch) -> Vec<RepositoryFetch> {
+    batch
         .repositories
-        .into_iter()
-        .map(|repository| map_repository(repository, viewer_login.as_deref()))
+        .iter()
+        .map(|repository| map_repository(repository.clone(), batch.viewer_login.as_deref()))
         .collect()
 }
 
@@ -164,7 +172,7 @@ fn epoch_millis(timestamp: &str) -> Option<i64> {
     let minute = timestamp[14..16].parse::<i64>().ok()?;
     // 60 is a leap second, which GitHub can legitimately send.
     let second = timestamp[17..19].parse::<i64>().ok()?;
-    if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+    if !(1..=12).contains(&month) || day < 1 || day > days_in_month(year, month) {
         return None;
     }
     if hour > 23 || minute > 59 || second > 60 {
@@ -172,6 +180,22 @@ fn epoch_millis(timestamp: &str) -> Option<i64> {
     }
     let days = days_from_civil(year, month, day);
     Some((days * 86_400 + hour * 3_600 + minute * 60 + second) * 1_000)
+}
+
+/// How many days that month of that year holds.
+const fn days_in_month(year: i64, month: u32) -> u32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap_year(year) => 29,
+        2 => 28,
+        // The caller has already refused every month outside the year.
+        _ => 0,
+    }
+}
+
+const fn is_leap_year(year: i64) -> bool {
+    year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
 }
 
 /// Days between the civil date and 1970-01-01, by Howard Hinnant's algorithm.
@@ -377,6 +401,11 @@ mod tests {
             "2026-09-01T12:34:56+01:00",
             "2026-13-01T12:34:56Z",
             "2026-09-32T12:34:56Z",
+            "2026-00-01T12:34:56Z",
+            "2026-09-00T12:34:56Z",
+            "2026-02-31T12:34:56Z",
+            "2026-02-29T12:34:56Z",
+            "2026-04-31T12:34:56Z",
             "2026-09-01T24:34:56Z",
             "2026-09-01T12:61:56Z",
             "2026-09-01T12:34:61Z",
@@ -393,6 +422,38 @@ mod tests {
                 refused.contains("update time"),
                 "{timestamp} refused with {refused}",
             );
+        }
+    }
+
+    /// A leap second is a real second GitHub can legitimately send.
+    #[test]
+    fn a_leap_second_is_read_rather_than_refused() {
+        assert_eq!(
+            epoch_millis("2016-12-31T23:59:60Z"),
+            Some(1_483_228_800_000),
+            "the leap second reads as the instant that follows it",
+        );
+    }
+
+    #[test]
+    fn the_last_day_of_every_month_is_read() {
+        let last_days = [
+            ("2026-01-31T00:00:00Z", true),
+            ("2026-02-28T00:00:00Z", true),
+            ("2024-02-29T00:00:00Z", true),
+            ("2000-02-29T00:00:00Z", true),
+            ("1900-02-29T00:00:00Z", false),
+            ("2026-03-31T00:00:00Z", true),
+            ("2026-04-30T00:00:00Z", true),
+            ("2026-04-31T00:00:00Z", false),
+            ("2026-06-31T00:00:00Z", false),
+            ("2026-09-31T00:00:00Z", false),
+            ("2026-11-31T00:00:00Z", false),
+            ("2026-12-31T00:00:00Z", true),
+        ];
+
+        for (timestamp, readable) in last_days {
+            assert_eq!(epoch_millis(timestamp).is_some(), readable, "{timestamp}");
         }
     }
 
@@ -537,12 +598,21 @@ mod tests {
         ]}
     }}"#;
 
+    /// Everything a batch answered, gathered from the reports as they land.
+    fn fetch_all(client: &GithubClient, repositories: &[RepositorySlug]) -> Vec<RepositoryFetch> {
+        let gathered = std::cell::RefCell::new(Vec::new());
+        fetch(client, repositories, &|batch| {
+            gathered.borrow_mut().extend(batch);
+        });
+        gathered.into_inner()
+    }
+
     #[test]
     fn a_fetched_batch_comes_back_as_one_entry_per_repository_with_its_rows() {
         let gh = FakeGh::new();
         gh.answer_graphql(RECORDED_SEARCH);
 
-        let fetched = fetch_batch(&gh.client(), &[RepositorySlug::new("acme", "widgets")]);
+        let fetched = fetch_all(&gh.client(), &[RepositorySlug::new("acme", "widgets")]);
 
         assert_eq!(fetched.len(), 1);
         assert_eq!(fetched[0].slug, "acme/widgets");
@@ -561,7 +631,7 @@ mod tests {
     fn a_batch_gh_could_not_answer_fails_every_repository_in_it() {
         let gh = FakeGh::new();
 
-        let fetched = fetch_batch(
+        let fetched = fetch_all(
             &gh.client(),
             &[
                 RepositorySlug::new("acme", "widgets"),

--- a/apps/desktop/src/Home.test.tsx
+++ b/apps/desktop/src/Home.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { HomeSnapshotDto } from "./bindings";
 import App from "./App";
@@ -234,6 +234,216 @@ describe("Home", () => {
 
     await waitFor(() => expect(screen.queryByText("/Developer/zreview")).toBeNull());
     expect(screen.getByText("/Developer/moved")).toBeTruthy();
+  });
+
+  // Three rows across the three groups, which is what the cursor walks.
+  function listed() {
+    return makeHomeSnapshot({
+      count_line: "3 pull requests across 2 repositories",
+      groups: makeHomeGroups([
+        [
+          makeHomeRow({
+            index: 0,
+            identity: "acme/widgets#412",
+            title: "Retry webhook deliveries",
+            check_status: { label: "checks passing", tone: "Success" },
+          }),
+          makeHomeRow({
+            index: 1,
+            identity: "acme/widgets#398",
+            title: "Split the invoice renderer",
+            author: "priya",
+            review_status: { label: "you reviewed this head", tone: "Muted" },
+            check_status: { label: "checks failing", tone: "Error" },
+          }),
+        ],
+        [
+          makeHomeRow({
+            index: 2,
+            identity: "braidonw/zreview#77",
+            title: "Bound the retry ceiling",
+            author: "braidonw",
+            review_status: { label: "changes requested", tone: "Error" },
+            check_status: { label: "checks running", tone: "Warning" },
+          }),
+        ],
+        [],
+      ]),
+      repositories: [makeHomeRepository()],
+      footer_summary: "2 repositories",
+      // Two and a half minutes back, so a second either way still reads as 2 min.
+      refresh: { Refreshed: { at_ms: Date.now() - 150_000 } },
+    });
+  }
+
+  it("renders every row in group order with its statuses and its age", async () => {
+    refreshHome.mockResolvedValue(ok(listed()));
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText("Retry webhook deliveries")).toBeTruthy());
+    const rows = screen.getAllByRole("listitem");
+    expect(rows.map((row) => row.getAttribute("data-identity"))).toEqual([
+      "acme/widgets#412",
+      "acme/widgets#398",
+      "braidonw/zreview#77",
+    ]);
+    expect(screen.getByText("you reviewed this head")).toBeTruthy();
+    expect(screen.getByText("changes requested")).toBeTruthy();
+    expect(screen.getByText("checks passing")).toBeTruthy();
+    expect(screen.getByText("checks failing")).toBeTruthy();
+    expect(screen.getByText("checks running")).toBeTruthy();
+    expect(screen.getByText("Nothing waiting on others.")).toBeTruthy();
+  });
+
+  it("leaves an aligned gap where a row has no status", async () => {
+    refreshHome.mockResolvedValue(ok(listed()));
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText("Retry webhook deliveries")).toBeTruthy());
+    // Every row carries the same columns whether or not they say anything.
+    for (const row of screen.getAllByRole("listitem")) {
+      expect(row.querySelectorAll(".home__cell").length).toBe(6);
+    }
+  });
+
+  it("shows the stamp counting off the repositories while a refresh runs", async () => {
+    refreshHome.mockResolvedValue(
+      ok(makeHomeSnapshot({ refresh: { Refreshing: { done: 2, total: 4 } } })),
+    );
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText("Refreshing 2 of 4")).toBeTruthy());
+  });
+
+  it("shows the stamp as how long ago the refresh settled", async () => {
+    refreshHome.mockResolvedValue(ok(listed()));
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText("Refreshed 2 min ago")).toBeTruthy());
+    expect(screen.getByText("r")).toBeTruthy();
+  });
+
+  it("shows the stamp as a failure when nothing loaded", async () => {
+    refreshHome.mockResolvedValue(ok(makeHomeSnapshot({ refresh: "Failed" })));
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText("Refresh failed")).toBeTruthy());
+  });
+
+  it("shows no stamp at all before the first refresh answers", async () => {
+    refreshHome.mockResolvedValue(ok(makeHomeSnapshot({ refresh: "NeverRefreshed" })));
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText("No repositories yet")).toBeTruthy());
+    expect(screen.queryByText(/^Refresh/)).toBeNull();
+  });
+
+  it("moves the cursor down on j and up on k", async () => {
+    const user = userEvent.setup();
+    refreshHome.mockResolvedValue(ok(listed()));
+    moveHomeCursor.mockImplementation((moveTo: string) =>
+      Promise.resolve({ ...listed(), cursor: moveTo === "Down" ? 1 : 0 }),
+    );
+
+    render(<App />);
+    await waitFor(() => expect(screen.getByText("Retry webhook deliveries")).toBeTruthy());
+
+    await user.keyboard("j");
+
+    await waitFor(() => expect(moveHomeCursor).toHaveBeenCalledWith("Down"));
+    await waitFor(() =>
+      expect(
+        screen.getAllByRole("listitem")[1].getAttribute("data-cursor"),
+      ).toBe("true"),
+    );
+
+    await user.keyboard("k");
+
+    await waitFor(() => expect(moveHomeCursor).toHaveBeenCalledWith("Up"));
+    await waitFor(() =>
+      expect(
+        screen.getAllByRole("listitem")[0].getAttribute("data-cursor"),
+      ).toBe("true"),
+    );
+  });
+
+  it("shows a failed repository above the list with a Remove beside it", async () => {
+    refreshHome.mockResolvedValue(
+      ok({
+        ...listed(),
+        failed_repositories: [
+          {
+            path: "/Developer/billing",
+            slug: "acme/billing",
+            reason: "GitHub refused the request: SAML enforcement",
+          },
+        ],
+      }),
+    );
+
+    render(<App />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/acme\/billing.*SAML enforcement/),
+      ).toBeTruthy(),
+    );
+    const line = screen.getByText(/acme\/billing/).closest(".home__failed-repository");
+    expect(line).toBeTruthy();
+    expect(within(line as HTMLElement).getByRole("button", { name: "Remove" })).toBeTruthy();
+  });
+
+  it("removes the repository the failed line's Remove names", async () => {
+    const user = userEvent.setup();
+    refreshHome.mockResolvedValue(
+      ok({
+        ...listed(),
+        failed_repositories: [
+          { path: "/Developer/billing", slug: "acme/billing", reason: "GitHub refused" },
+        ],
+      }),
+    );
+    removeRepository.mockResolvedValue(ok(listed()));
+
+    render(<App />);
+    await waitFor(() => expect(screen.getByText(/acme\/billing/)).toBeTruthy());
+
+    const line = screen.getByText(/acme\/billing/).closest(".home__failed-repository");
+    await user.click(within(line as HTMLElement).getByRole("button", { name: "Remove" }));
+
+    await waitFor(() => expect(removeRepository).toHaveBeenCalledWith("/Developer/billing"));
+  });
+
+  it("stamps the progress the refresh channel reports, then the time it settled", async () => {
+    let progress: ((state: unknown) => void) | null = null;
+    let settle: ((snapshot: unknown) => void) | null = null;
+    refreshHome.mockImplementation((onProgress: { onmessage: (state: unknown) => void }) => {
+      progress = (state: unknown) => onProgress.onmessage(state);
+      return new Promise((resolve) => {
+        settle = resolve;
+      });
+    });
+
+    render(<App />);
+    await waitFor(() => expect(progress).not.toBeNull());
+
+    // The header goes up on the first report, so the window is never blank.
+    act(() => progress?.({ Refreshing: { done: 0, total: 0 } }));
+    await waitFor(() => expect(screen.getByText("Refreshing")).toBeTruthy());
+
+    act(() => progress?.({ Refreshing: { done: 1, total: 3 } }));
+    await waitFor(() => expect(screen.getByText("Refreshing 1 of 3")).toBeTruthy());
+
+    act(() => settle?.(ok(listed())));
+
+    await waitFor(() => expect(screen.getByText("Refreshed 2 min ago")).toBeTruthy());
+    expect(screen.getByText("Retry webhook deliveries")).toBeTruthy();
   });
 
   it("refreshes on r, showing what the settings file now holds", async () => {

--- a/apps/desktop/src/Home.test.tsx
+++ b/apps/desktop/src/Home.test.tsx
@@ -3,7 +3,12 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { HomeSnapshotDto } from "./bindings";
 import App from "./App";
-import { makeHomeRepository, makeHomeSnapshot } from "./test/fixtures";
+import {
+  makeHomeGroups,
+  makeHomeRepository,
+  makeHomeRow,
+  makeHomeSnapshot,
+} from "./test/fixtures";
 
 const describeLaunch = vi.fn();
 const refreshHome = vi.fn();
@@ -11,10 +16,13 @@ const addRepositories = vi.fn();
 const removeRepository = vi.fn();
 const toggleRepositoriesFooter = vi.fn();
 
+const moveHomeCursor = vi.fn();
+
 vi.mock("./bindings", () => ({
   commands: {
     describeLaunch: () => describeLaunch(),
-    refreshHome: () => refreshHome(),
+    refreshHome: (onProgress: unknown) => refreshHome(onProgress),
+    moveHomeCursor: (moveTo: unknown) => moveHomeCursor(moveTo),
     addRepositories: (folders: unknown) => addRepositories(folders),
     removeRepository: (path: unknown) => removeRepository(path),
     toggleRepositoriesFooter: () => toggleRepositoriesFooter(),
@@ -55,6 +63,7 @@ beforeEach(() => {
   addRepositories.mockReset();
   removeRepository.mockReset();
   toggleRepositoriesFooter.mockReset();
+  moveHomeCursor.mockReset();
   open.mockReset();
 });
 

--- a/apps/desktop/src/Home.test.tsx
+++ b/apps/desktop/src/Home.test.tsx
@@ -55,6 +55,21 @@ function configured() {
   });
 }
 
+/** Every listed row's identity, in the order the ledger renders them. */
+function identities() {
+  return screen
+    .getAllByRole("listitem")
+    .map((row) => row.querySelector(".home__cell--identity")?.textContent);
+}
+
+/** The identity of the row the cursor is on. */
+function selectedIdentity() {
+  const selected = screen
+    .getAllByRole("listitem")
+    .find((row) => row.getAttribute("aria-selected") === "true");
+  return selected?.querySelector(".home__cell--identity")?.textContent;
+}
+
 beforeEach(() => {
   describeLaunch.mockReset();
   describeLaunch.mockResolvedValue("Home");
@@ -171,16 +186,17 @@ describe("Home", () => {
   it("passes the picked folders to the add command and shows what it refused", async () => {
     const user = userEvent.setup();
     open.mockResolvedValue(["/Developer/notes", "/Developer/billing"]);
-    addRepositories.mockResolvedValue(
-      ok(
-        makeHomeSnapshot({
-          count_line: "0 pull requests across 1 repository",
-          repositories: [makeHomeRepository({ path: "/Developer/billing", slug: "acme/billing" })],
-          footer_summary: "1 repository",
-          refusals: [{ path: "/Developer/notes", reason: "not a Git repository" }],
-        }),
-      ),
-    );
+    const added = makeHomeSnapshot({
+      count_line: "0 pull requests across 1 repository",
+      repositories: [makeHomeRepository({ path: "/Developer/billing", slug: "acme/billing" })],
+      footer_summary: "1 repository",
+      refusals: [{ path: "/Developer/notes", reason: "not a Git repository" }],
+    });
+    addRepositories.mockImplementation(() => {
+      // The refresh that follows an Add reads the file the Add just wrote.
+      refreshHome.mockResolvedValue(ok(added));
+      return Promise.resolve(ok(added));
+    });
 
     render(<App />);
     await waitFor(() => expect(screen.getByText("No repositories yet")).toBeTruthy());
@@ -215,17 +231,18 @@ describe("Home", () => {
   it("removes the repository the Remove beside it names", async () => {
     const user = userEvent.setup();
     refreshHome.mockResolvedValue(ok({ ...configured(), footer_expanded: true }));
-    removeRepository.mockImplementation((path: string) =>
-      Promise.resolve(
-        ok({
-          ...configured(),
-          footer_expanded: true,
-          repositories: configured().repositories.filter(
-            (repository) => repository.path !== path,
-          ),
-        }),
-      ),
-    );
+    removeRepository.mockImplementation((path: string) => {
+      const left = {
+        ...configured(),
+        footer_expanded: true,
+        repositories: configured().repositories.filter(
+          (repository) => repository.path !== path,
+        ),
+      };
+      // The refresh that follows a Remove reads the file the Remove just wrote.
+      refreshHome.mockResolvedValue(ok(left));
+      return Promise.resolve(ok(left));
+    });
 
     render(<App />);
     await waitFor(() => expect(screen.getByText("braidonw/zreview")).toBeTruthy());
@@ -282,8 +299,7 @@ describe("Home", () => {
     render(<App />);
 
     await waitFor(() => expect(screen.getByText("Retry webhook deliveries")).toBeTruthy());
-    const rows = screen.getAllByRole("listitem");
-    expect(rows.map((row) => row.getAttribute("data-identity"))).toEqual([
+    expect(identities()).toEqual([
       "acme/widgets#412",
       "acme/widgets#398",
       "braidonw/zreview#77",
@@ -296,16 +312,31 @@ describe("Home", () => {
     expect(screen.getByText("Nothing waiting on others.")).toBeTruthy();
   });
 
-  it("leaves an aligned gap where a row has no status", async () => {
-    refreshHome.mockResolvedValue(ok(listed()));
+  it("shows a row's age and leaves an empty author cell where GitHub has none", async () => {
+    refreshHome.mockResolvedValue(
+      ok({
+        ...listed(),
+        groups: makeHomeGroups([
+          [
+            makeHomeRow({
+              index: 0,
+              identity: "acme/widgets#412",
+              author: null,
+              updated_at_ms: Date.now() - 150 * 60_000,
+            }),
+          ],
+          [],
+          [],
+        ]),
+      }),
+    );
 
     render(<App />);
 
-    await waitFor(() => expect(screen.getByText("Retry webhook deliveries")).toBeTruthy());
-    // Every row carries the same columns whether or not they say anything.
-    for (const row of screen.getAllByRole("listitem")) {
-      expect(row.querySelectorAll(".home__cell").length).toBe(6);
-    }
+    await waitFor(() => expect(screen.getByText("acme/widgets#412")).toBeTruthy());
+    expect(screen.getByText("2h")).toBeTruthy();
+    const row = screen.getAllByRole("listitem")[0];
+    expect(row.querySelector(".home__cell--author")?.textContent).toBe("");
   });
 
   it("shows the stamp counting off the repositories while a refresh runs", async () => {
@@ -325,6 +356,16 @@ describe("Home", () => {
 
     await waitFor(() => expect(screen.getByText("Refreshed 2 min ago")).toBeTruthy());
     expect(screen.getByText("r")).toBeTruthy();
+  });
+
+  it("counts the stamp in hours and days once it is older than that", async () => {
+    refreshHome.mockResolvedValue(
+      ok({ ...listed(), refresh: { Refreshed: { at_ms: Date.now() - 90 * 60_000 } } }),
+    );
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText("Refreshed 1 hour ago")).toBeTruthy());
   });
 
   it("shows the stamp as a failure when nothing loaded", async () => {
@@ -353,24 +394,32 @@ describe("Home", () => {
 
     render(<App />);
     await waitFor(() => expect(screen.getByText("Retry webhook deliveries")).toBeTruthy());
+    expect(selectedIdentity()).toBe("acme/widgets#412");
 
     await user.keyboard("j");
 
-    await waitFor(() => expect(moveHomeCursor).toHaveBeenCalledWith("Down"));
-    await waitFor(() =>
-      expect(
-        screen.getAllByRole("listitem")[1].getAttribute("data-cursor"),
-      ).toBe("true"),
-    );
+    await waitFor(() => expect(selectedIdentity()).toBe("acme/widgets#398"));
 
     await user.keyboard("k");
 
-    await waitFor(() => expect(moveHomeCursor).toHaveBeenCalledWith("Up"));
-    await waitFor(() =>
-      expect(
-        screen.getAllByRole("listitem")[0].getAttribute("data-cursor"),
-      ).toBe("true"),
-    );
+    await waitFor(() => expect(selectedIdentity()).toBe("acme/widgets#412"));
+  });
+
+  it("scrolls the row the cursor moved onto into view", async () => {
+    const user = userEvent.setup();
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+    refreshHome.mockResolvedValue(ok(listed()));
+    moveHomeCursor.mockResolvedValue({ ...listed(), cursor: 2 });
+
+    render(<App />);
+    await waitFor(() => expect(screen.getByText("Retry webhook deliveries")).toBeTruthy());
+    scrollIntoView.mockClear();
+
+    await user.keyboard("j");
+
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalled());
+    expect(scrollIntoView).toHaveBeenCalledWith(expect.objectContaining({ block: "nearest" }));
   });
 
   it("shows a failed repository above the list with a Remove beside it", async () => {
@@ -401,15 +450,25 @@ describe("Home", () => {
 
   it("removes the repository the failed line's Remove names", async () => {
     const user = userEvent.setup();
-    refreshHome.mockResolvedValue(
-      ok({
-        ...listed(),
-        failed_repositories: [
-          { path: "/Developer/billing", slug: "acme/billing", reason: "GitHub refused" },
-        ],
-      }),
-    );
-    removeRepository.mockResolvedValue(ok(listed()));
+    const failing = {
+      ...listed(),
+      failed_repositories: [
+        { path: "/Developer/billing", slug: "acme/billing", reason: "GitHub refused" },
+        { path: "/Developer/tokens", slug: "acme/design-tokens", reason: "GitHub refused" },
+      ],
+    };
+    refreshHome.mockResolvedValue(ok(failing));
+    // Only the repository the click named goes, so what is left says which it was.
+    removeRepository.mockImplementation((path: string) => {
+      const left = {
+        ...failing,
+        failed_repositories: failing.failed_repositories.filter(
+          (repository) => repository.path !== path,
+        ),
+      };
+      refreshHome.mockResolvedValue(ok(left));
+      return Promise.resolve(ok(left));
+    });
 
     render(<App />);
     await waitFor(() => expect(screen.getByText(/acme\/billing/)).toBeTruthy());
@@ -417,7 +476,92 @@ describe("Home", () => {
     const line = screen.getByText(/acme\/billing/).closest(".home__failed-repository");
     await user.click(within(line as HTMLElement).getByRole("button", { name: "Remove" }));
 
-    await waitFor(() => expect(removeRepository).toHaveBeenCalledWith("/Developer/billing"));
+    await waitFor(() => expect(screen.queryByText(/acme\/billing/)).toBeNull());
+    expect(screen.getByText(/acme\/design-tokens/)).toBeTruthy();
+  });
+
+  it("refreshes after a repository is added, so its rows arrive without r", async () => {
+    const user = userEvent.setup();
+    open.mockResolvedValue(["/Developer/widgets"]);
+    addRepositories.mockResolvedValue(
+      ok(
+        makeHomeSnapshot({
+          count_line: "0 pull requests across 1 repository",
+          repositories: [makeHomeRepository()],
+          footer_summary: "1 repository",
+        }),
+      ),
+    );
+
+    render(<App />);
+    await waitFor(() => expect(screen.getByText("No repositories yet")).toBeTruthy());
+    refreshHome.mockClear();
+    refreshHome.mockResolvedValue(ok(listed()));
+
+    await user.click(screen.getByRole("button", { name: "Add repository..." }));
+
+    await waitFor(() => expect(screen.getByText("Retry webhook deliveries")).toBeTruthy());
+    expect(refreshHome).toHaveBeenCalled();
+  });
+
+  it("refreshes after a repository is removed", async () => {
+    const user = userEvent.setup();
+    refreshHome.mockResolvedValue(ok({ ...configured(), footer_expanded: true }));
+    removeRepository.mockResolvedValue(ok(makeHomeSnapshot()));
+
+    render(<App />);
+    await waitFor(() => expect(screen.getByText("braidonw/zreview")).toBeTruthy());
+    refreshHome.mockClear();
+
+    await user.click(screen.getAllByRole("button", { name: "Remove" })[0]);
+
+    await waitFor(() => expect(refreshHome).toHaveBeenCalled());
+  });
+
+  it("shows a write failure on the empty state as well as above a list", async () => {
+    refreshHome.mockResolvedValue(
+      ok(
+        makeHomeSnapshot({
+          write_failure: {
+            summary: "Home could not save your settings",
+            detail: null,
+            remediation: "Check that ~/.config/zreview/settings.toml is writable.",
+          },
+        }),
+      ),
+    );
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText("No repositories yet")).toBeTruthy());
+    expect(screen.getByText("Home could not save your settings")).toBeTruthy();
+  });
+
+  it("leaves the rows and the stamp alone when r arrives mid-refresh", async () => {
+    const user = userEvent.setup();
+    let settle: ((snapshot: unknown) => void) | null = null;
+    let calls = 0;
+    refreshHome.mockImplementation((onProgress: { onmessage: (shown: unknown) => void }) => {
+      calls += 1;
+      return new Promise((resolve) => {
+        onProgress.onmessage({ ...listed(), refresh: { Refreshing: { done: 1, total: 3 } } });
+        settle = resolve;
+      });
+    });
+
+    render(<App />);
+    await waitFor(() => expect(screen.getByText("Refreshing 1 of 3")).toBeTruthy());
+    expect(identities()).toHaveLength(3);
+
+    await user.keyboard("r");
+
+    // The trigger that arrived mid-refresh started nothing.
+    expect(calls).toBe(1);
+    expect(screen.getByText("Refreshing 1 of 3")).toBeTruthy();
+    expect(identities()).toHaveLength(3);
+
+    act(() => settle?.(ok(listed())));
+    await waitFor(() => expect(screen.getByText("Refreshed 2 min ago")).toBeTruthy());
   });
 
   it("stamps the progress the refresh channel reports, then the time it settled", async () => {
@@ -434,16 +578,24 @@ describe("Home", () => {
     await waitFor(() => expect(progress).not.toBeNull());
 
     // The header goes up on the first report, so the window is never blank.
-    act(() => progress?.({ Refreshing: { done: 0, total: 0 } }));
+    act(() =>
+      progress?.({
+        ...makeHomeSnapshot(),
+        refresh: { Refreshing: { done: 0, total: 0 } },
+      }),
+    );
     await waitFor(() => expect(screen.getByText("Refreshing")).toBeTruthy());
 
-    act(() => progress?.({ Refreshing: { done: 1, total: 3 } }));
+    // The rows of the repositories that have answered arrive with their batch.
+    act(() =>
+      progress?.({ ...listed(), refresh: { Refreshing: { done: 1, total: 3 } } }),
+    );
     await waitFor(() => expect(screen.getByText("Refreshing 1 of 3")).toBeTruthy());
+    expect(screen.getByText("Retry webhook deliveries")).toBeTruthy();
 
     act(() => settle?.(ok(listed())));
 
     await waitFor(() => expect(screen.getByText("Refreshed 2 min ago")).toBeTruthy());
-    expect(screen.getByText("Retry webhook deliveries")).toBeTruthy();
   });
 
   it("refreshes on r, showing what the settings file now holds", async () => {

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -15,9 +15,10 @@ export const commands = {
 	/**
 	 *  Re-reads the settings file, then fetches what every clone it lists has open.
 	 * 
-	 *  Runs when Home opens and on `r`, reporting how far it has got on
-	 *  `on_progress` as each batch of repositories lands. A trigger that arrives
-	 *  mid-refresh starts nothing and answers with what is already on screen.
+	 *  Runs when Home opens, on `r`, and after an Add or a Remove. Everything Home
+	 *  shows goes to `on_progress` as each batch of repositories lands, so the list
+	 *  fills in as it loads. A trigger that arrives mid-refresh starts nothing and
+	 *  answers with what is already on screen.
 	 * 
 	 *  A settings file that cannot be read, or a `gh` that cannot be used, comes
 	 *  back inside the snapshot rather than as a command error, because the header
@@ -27,14 +28,17 @@ export const commands = {
 	 * 
 	 *  Returns a failure when the task doing the fetching does not finish.
 	 */
-	refreshHome: (onProgress: Channel<RefreshStateDto>) => typedError<HomeSnapshotDto, SessionFailureDto>(__TAURI_INVOKE("refresh_home", { onProgress })),
+	refreshHome: (onProgress: Channel<HomeSnapshotDto>) => typedError<HomeSnapshotDto, SessionFailureDto>(__TAURI_INVOKE("refresh_home", { onProgress })),
 	/**  Moves the cursor one row through the list, across the groups. */
 	moveHomeCursor: (moveTo: CursorMoveDto) => __TAURI_INVOKE<HomeSnapshotDto>("move_home_cursor", { moveTo }),
 	/**
-	 *  Adds the folders the reviewer picked, writing the file once and refreshing.
+	 *  Adds the folders the reviewer picked, writing the file once and reading it
+	 *  back.
 	 * 
 	 *  A folder that is not a clone of a GitHub repository is refused with its
-	 *  reason while the rest proceed, and one already listed is ignored.
+	 *  reason while the rest proceed, and one already listed is ignored. The pull
+	 *  requests of a repository just added arrive with the refresh the caller runs
+	 *  next, not with this.
 	 * 
 	 *  # Errors
 	 * 
@@ -42,7 +46,10 @@ export const commands = {
 	 */
 	addRepositories: (folders: string[]) => typedError<HomeSnapshotDto, SessionFailureDto>(__TAURI_INVOKE("add_repositories", { folders })),
 	/**
-	 *  Drops one configured clone, writing the file and refreshing.
+	 *  Drops one configured clone, writing the file and reading it back.
+	 * 
+	 *  The list is left as it stands otherwise. It is the refresh the caller runs
+	 *  next that asks GitHub about what remains.
 	 * 
 	 *  # Errors
 	 * 

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -13,17 +13,23 @@ export const commands = {
 	 */
 	describeLaunch: () => __TAURI_INVOKE<LaunchDto>("describe_launch"),
 	/**
-	 *  Re-reads the settings file and resolves every clone it lists.
+	 *  Re-reads the settings file, then fetches what every clone it lists has open.
 	 * 
-	 *  Runs when Home opens, after an Add or a Remove, and on `r`. A settings file
-	 *  that cannot be read comes back inside the snapshot rather than as a command
-	 *  error, because the header and footer stay on screen either way.
+	 *  Runs when Home opens and on `r`, reporting how far it has got on
+	 *  `on_progress` as each batch of repositories lands. A trigger that arrives
+	 *  mid-refresh starts nothing and answers with what is already on screen.
+	 * 
+	 *  A settings file that cannot be read, or a `gh` that cannot be used, comes
+	 *  back inside the snapshot rather than as a command error, because the header
+	 *  and footer stay on screen either way.
 	 * 
 	 *  # Errors
 	 * 
-	 *  Returns a failure when the task doing the reading does not finish.
+	 *  Returns a failure when the task doing the fetching does not finish.
 	 */
-	refreshHome: () => typedError<HomeSnapshotDto, SessionFailureDto>(__TAURI_INVOKE("refresh_home")),
+	refreshHome: (onProgress: Channel<RefreshStateDto>) => typedError<HomeSnapshotDto, SessionFailureDto>(__TAURI_INVOKE("refresh_home", { onProgress })),
+	/**  Moves the cursor one row through the list, across the groups. */
+	moveHomeCursor: (moveTo: CursorMoveDto) => __TAURI_INVOKE<HomeSnapshotDto>("move_home_cursor", { moveTo }),
 	/**
 	 *  Adds the folders the reviewer picked, writing the file once and refreshing.
 	 * 
@@ -110,6 +116,9 @@ export type AnchoredDraftDto = {
 	is_proposed: boolean,
 };
 
+/**  Which way the cursor is being moved. */
+export type CursorMoveDto = "Down" | "Up";
+
 export type DiffLineKindDto = "Context" | "Addition" | "Deletion" | "NoNewlineMarker";
 
 export type DiffSideDto = "Left" | "Right";
@@ -140,6 +149,14 @@ export type EmptyReasonDto = {
 	detail: string,
 };
 
+/**  One configured repository whose pull requests could not be fetched. */
+export type FailedRepositoryDto = {
+	/**  The entry in the settings file, which is what Remove names. */
+	path: string,
+	slug: string,
+	reason: string,
+};
+
 export type FileDetailDto = {
 	index: number,
 	path: string,
@@ -168,6 +185,7 @@ export type HomeGroupDto = {
 	count: number,
 	/**  The one line an empty group shows in place of rows. */
 	empty_copy: string,
+	rows: HomeRowDto[],
 };
 
 /**  One configured clone as the footer lists it. */
@@ -178,18 +196,43 @@ export type HomeRepositoryDto = {
 	failure: string | null,
 };
 
+/**  One pull request, as one line of the ledger. */
+export type HomeRowDto = {
+	/**  Where this row sits in the flat order the cursor walks. */
+	index: number,
+	title: string,
+	url: string,
+	/**  `owner/name#number`. */
+	identity: string,
+	/**  Absent once GitHub has forgotten the account. */
+	author: string | null,
+	/**
+	 *  When the pull request last moved, as epoch milliseconds, which the age
+	 *  column is worked out from.
+	 */
+	updated_at_ms: number,
+	review_status: RowStatusDto | null,
+	check_status: RowStatusDto | null,
+};
+
 /**  Everything Home renders, from its header to its footer. */
 export type HomeSnapshotDto = {
 	/**  The header's count line, absent until there is something to count. */
 	count_line: string | null,
 	groups: HomeGroupDto[],
+	/**  Where the cursor sits, as a flat index across every rendered row. */
+	cursor: number,
+	refresh: RefreshStateDto,
+	/**  One line each above the list, naming a repository this refresh lost. */
+	failed_repositories: FailedRepositoryDto[],
 	repositories: HomeRepositoryDto[],
 	footer_summary: string,
 	footer_expanded: boolean,
 	refusals: RefusalDto[],
 	/**
-	 *  What replaces the list area when Home cannot read its repositories. The
-	 *  header and footer stay either way, so Add still works.
+	 *  What replaces the list area when Home cannot read its repositories or
+	 *  cannot use `gh`. The header and footer stay either way, so Add still
+	 *  works.
 	 */
 	failure: SessionFailureDto | null,
 	/**
@@ -203,6 +246,18 @@ export type HomeSnapshotDto = {
 export type LaunchDto = "Home" | { Session: {
 	description: string,
 } };
+
+/**  How current the list is, which the header stamp reads. */
+export type RefreshStateDto = 
+/**  There is no stamp at all until the first refresh starts. */
+"NeverRefreshed" | ({ Refreshing: {
+	done: number,
+	total: number,
+} }) & { Refreshed?: never } | 
+/**  Epoch milliseconds, which the relative stamp is worked out from. */
+({ Refreshed: {
+	at_ms: number,
+} }) & { Refreshing?: never } | "Failed";
 
 /**  Something Home would not do, and why. */
 export type RefusalDto = {
@@ -223,6 +278,12 @@ export type RowDto = {
 	 */
 	hunk_header: string | null,
 	thread_count: number,
+};
+
+/**  One status column's words and the weight they carry. */
+export type RowStatusDto = {
+	label: string,
+	tone: StatusToneDto,
 };
 
 export type SessionFailureDto = {
@@ -254,6 +315,14 @@ export type StaleDraftDto = {
 	/**  Where the draft used to sit, formatted for display, e.g. "was RIGHT line 42". */
 	location: string,
 };
+
+/**
+ *  Which severity a status column paints itself in.
+ * 
+ *  Named rather than coloured, so the values themselves stay in the one style
+ *  sheet that owns them.
+ */
+export type StatusToneDto = "Success" | "Error" | "Warning" | "Muted";
 
 /* Tauri Specta runtime */
 async function typedError<T, E>(result: Promise<T>): Promise<{ status: "ok"; data: T } | { status: "error"; error: E }> {

--- a/apps/desktop/src/components/HomeScreen.css
+++ b/apps/desktop/src/components/HomeScreen.css
@@ -204,6 +204,7 @@
   flex-shrink: 0;
   overflow: hidden;
   white-space: nowrap;
+  text-overflow: ellipsis;
   font-family: var(--font-mono);
   font-size: var(--size-meta);
   color: var(--text-tertiary);
@@ -213,8 +214,9 @@
   width: 60px;
 }
 
+/* Wide enough for "you reviewed this head", the longest label it carries. */
 .home__cell--review {
-  width: 150px;
+  width: 172px;
 }
 
 .home__cell--checks {

--- a/apps/desktop/src/components/HomeScreen.css
+++ b/apps/desktop/src/components/HomeScreen.css
@@ -36,6 +36,28 @@
   color: var(--text-tertiary);
 }
 
+.home__stamp {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.home__stamp-text {
+  font-family: var(--font-mono);
+  font-size: var(--size-meta);
+  color: var(--text-tertiary);
+}
+
+.home__keycap {
+  padding: 0 4px;
+  border: 1px solid var(--border-default);
+  border-radius: 3px;
+  background: var(--surface-overlay);
+  font-family: var(--font-mono);
+  font-size: var(--size-label);
+  color: var(--text-tertiary);
+}
+
 .home__body {
   flex: 1;
   min-height: 0;
@@ -121,6 +143,113 @@
   font-family: var(--font-sans);
   font-size: var(--size-body);
   color: var(--text-faint);
+}
+
+.home__failed-repository {
+  min-height: var(--file-row-height);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.home__failed-detail {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-family: var(--font-mono);
+  font-size: var(--size-meta);
+  color: var(--severity-error-text);
+}
+
+.home__rows {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* One dense line per pull request, on the file row's scale. */
+.home__row {
+  height: var(--file-row-height);
+  padding: 0 12px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border-radius: 4px;
+  background: var(--surface-base);
+}
+
+.home__row:hover {
+  background: var(--surface-hover);
+}
+
+.home__row--cursor {
+  background: var(--surface-selected);
+}
+
+.home__row-title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-family: var(--font-sans);
+  font-size: var(--size-body);
+  color: var(--text-primary);
+}
+
+/* Every status keeps its own column, so an absent one leaves an aligned gap. */
+.home__cell {
+  flex-shrink: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: var(--size-meta);
+  color: var(--text-tertiary);
+}
+
+.home__cell--drafts {
+  width: 60px;
+}
+
+.home__cell--review {
+  width: 150px;
+}
+
+.home__cell--checks {
+  width: 105px;
+}
+
+.home__cell--identity {
+  width: 200px;
+  text-align: right;
+  color: var(--text-secondary);
+}
+
+.home__cell--author {
+  width: 70px;
+}
+
+.home__cell--age {
+  width: 32px;
+  text-align: right;
+}
+
+.home__status--success {
+  color: var(--severity-success-text);
+}
+
+.home__status--error {
+  color: var(--severity-error-text);
+}
+
+.home__status--warning {
+  color: var(--severity-warning-text);
+}
+
+.home__status--muted {
+  color: var(--text-tertiary);
 }
 
 .home__footer {

--- a/apps/desktop/src/components/HomeScreen.tsx
+++ b/apps/desktop/src/components/HomeScreen.tsx
@@ -1,32 +1,57 @@
-import type { HomeSnapshotDto } from "../bindings";
+import type { HomeRowDto, HomeSnapshotDto, RefreshStateDto } from "../bindings";
 import { useHome } from "../hooks/useHome";
+import { useNow } from "../hooks/useNow";
+import { refreshedStamp, shortAge } from "../lib/relativeTime";
 import { FailureScreen } from "./FailureScreen";
 import "./HomeScreen.css";
 
+/** What the header stamp reads, absent before the first refresh starts. */
+function stampText(refresh: RefreshStateDto, nowMs: number): string | null {
+  if (refresh === "NeverRefreshed") {
+    return null;
+  }
+  if (refresh === "Failed") {
+    return "Refresh failed";
+  }
+  if ("Refreshing" in refresh && refresh.Refreshing !== undefined) {
+    const { done, total } = refresh.Refreshing;
+    // The total is unknown until the settings file has been read.
+    return total === 0 ? "Refreshing" : `Refreshing ${done} of ${total}`;
+  }
+  return refreshedStamp(refresh.Refreshed.at_ms, nowMs);
+}
+
 /** The screen ZReview opens on when no pull request has been named. */
 export function HomeScreen() {
-  const { snapshot, failure, toggleFooter, addRepositories, removeRepository } = useHome();
+  const { snapshot, refreshState, failure, toggleFooter, addRepositories, removeRepository } =
+    useHome();
+  const nowMs = useNow();
 
   // A command that never answered leaves nothing worth trusting on screen.
   if (failure !== null) {
     return <FailureScreen failure={failure} />;
   }
-  // Nothing is drawn until the first read answers, so no empty state flashes in front of a list.
+  const stamp = refreshState === null ? null : stampText(refreshState, nowMs);
+  // Nothing is drawn until the first refresh answers, so no empty state flashes
+  // in front of a list. The header goes up as soon as the refresh says it has
+  // started, so the window is never blank while GitHub is being asked.
   if (snapshot === null) {
-    return null;
+    return stamp === null ? null : (
+      <div className="home">
+        <Header countLine={null} stamp={stamp} />
+      </div>
+    );
   }
 
   return (
     <div className="home">
-      <header className="home__header">
-        <div className="home__heading">
-          <h1 className="home__title">Home</h1>
-          {snapshot.count_line !== null && (
-            <span className="home__count">{snapshot.count_line}</span>
-          )}
-        </div>
-      </header>
-      <HomeBody snapshot={snapshot} onAdd={addRepositories} />
+      <Header countLine={snapshot.count_line} stamp={stamp} />
+      <HomeBody
+        snapshot={snapshot}
+        nowMs={nowMs}
+        onAdd={addRepositories}
+        onRemove={removeRepository}
+      />
       <footer className="home__footer">
         <div className="home__footer-line">
           <button className="home__footer-toggle" type="button" onClick={toggleFooter}>
@@ -62,8 +87,35 @@ export function HomeScreen() {
   );
 }
 
+function Header({ countLine, stamp }: { countLine: string | null; stamp: string | null }) {
+  return (
+    <header className="home__header">
+      <div className="home__heading">
+        <h1 className="home__title">Home</h1>
+        {countLine !== null && <span className="home__count">{countLine}</span>}
+      </div>
+      {stamp !== null && (
+        <div className="home__stamp">
+          <span className="home__stamp-text">{stamp}</span>
+          <span className="home__keycap">r</span>
+        </div>
+      )}
+    </header>
+  );
+}
+
 /** The list area, which the empty state and a whole-Home failure each replace. */
-function HomeBody({ snapshot, onAdd }: { snapshot: HomeSnapshotDto; onAdd: () => void }) {
+function HomeBody({
+  snapshot,
+  nowMs,
+  onAdd,
+  onRemove,
+}: {
+  snapshot: HomeSnapshotDto;
+  nowMs: number;
+  onAdd: () => void;
+  onRemove: (path: string) => void;
+}) {
   if (snapshot.failure !== null) {
     return (
       <div className="home__body">
@@ -90,12 +142,20 @@ function HomeBody({ snapshot, onAdd }: { snapshot: HomeSnapshotDto; onAdd: () =>
         <div className="home__write-failure">
           <span>{snapshot.write_failure.summary}</span>
           {snapshot.write_failure.remediation !== null && (
-            <span className="home__write-remediation">
-              {snapshot.write_failure.remediation}
-            </span>
+            <span className="home__write-remediation">{snapshot.write_failure.remediation}</span>
           )}
         </div>
       )}
+      {snapshot.failed_repositories.map((repository) => (
+        <div className="home__failed-repository" key={repository.path}>
+          <span className="home__failed-detail">
+            {`${repository.slug} · ${repository.reason}`}
+          </span>
+          <button className="home__remove" type="button" onClick={() => onRemove(repository.path)}>
+            Remove
+          </button>
+        </div>
+      ))}
       {snapshot.groups.map((group) => (
         <section className="home__group" key={group.title}>
           <div className="home__group-label">
@@ -103,8 +163,46 @@ function HomeBody({ snapshot, onAdd }: { snapshot: HomeSnapshotDto; onAdd: () =>
             <span className="home__group-count">{group.count}</span>
           </div>
           {group.count === 0 && <div className="home__group-empty">{group.empty_copy}</div>}
+          {group.count > 0 && (
+            <ul className="home__rows">
+              {group.rows.map((row) => (
+                <Row key={row.identity} row={row} cursor={row.index === snapshot.cursor} nowMs={nowMs} />
+              ))}
+            </ul>
+          )}
         </section>
       ))}
     </div>
+  );
+}
+
+/** One pull request on one line, its columns aligned whether or not they speak. */
+function Row({ row, cursor, nowMs }: { row: HomeRowDto; cursor: boolean; nowMs: number }) {
+  return (
+    <li
+      className={`home__row${cursor ? " home__row--cursor" : ""}`}
+      data-identity={row.identity}
+      data-cursor={cursor ? "true" : "false"}
+    >
+      <span className="home__row-title">{row.title}</span>
+      <span className="home__cell home__cell--drafts" />
+      <span className="home__cell home__cell--review">
+        {row.review_status !== null && (
+          <span className={`home__status home__status--${row.review_status.tone.toLowerCase()}`}>
+            {row.review_status.label}
+          </span>
+        )}
+      </span>
+      <span className="home__cell home__cell--checks">
+        {row.check_status !== null && (
+          <span className={`home__status home__status--${row.check_status.tone.toLowerCase()}`}>
+            {row.check_status.label}
+          </span>
+        )}
+      </span>
+      <span className="home__cell home__cell--identity">{row.identity}</span>
+      <span className="home__cell home__cell--author">{row.author}</span>
+      <span className="home__cell home__cell--age">{shortAge(row.updated_at_ms, nowMs)}</span>
+    </li>
   );
 }

--- a/apps/desktop/src/components/HomeScreen.tsx
+++ b/apps/desktop/src/components/HomeScreen.tsx
@@ -1,4 +1,5 @@
-import type { HomeRowDto, HomeSnapshotDto, RefreshStateDto } from "../bindings";
+import { useEffect, useRef } from "react";
+import type { HomeRowDto, HomeSnapshotDto, RefreshStateDto, SessionFailureDto } from "../bindings";
 import { useHome } from "../hooks/useHome";
 import { useNow } from "../hooks/useNow";
 import { refreshedStamp, shortAge } from "../lib/relativeTime";
@@ -23,25 +24,19 @@ function stampText(refresh: RefreshStateDto, nowMs: number): string | null {
 
 /** The screen ZReview opens on when no pull request has been named. */
 export function HomeScreen() {
-  const { snapshot, refreshState, failure, toggleFooter, addRepositories, removeRepository } =
-    useHome();
+  const { snapshot, failure, toggleFooter, addRepositories, removeRepository } = useHome();
   const nowMs = useNow();
 
   // A command that never answered leaves nothing worth trusting on screen.
   if (failure !== null) {
     return <FailureScreen failure={failure} />;
   }
-  const stamp = refreshState === null ? null : stampText(refreshState, nowMs);
-  // Nothing is drawn until the first refresh answers, so no empty state flashes
-  // in front of a list. The header goes up as soon as the refresh says it has
-  // started, so the window is never blank while GitHub is being asked.
+  // Nothing is drawn until the refresh says it has started, which it does before
+  // it asks GitHub anything, so the window is blank for no longer than that.
   if (snapshot === null) {
-    return stamp === null ? null : (
-      <div className="home">
-        <Header countLine={null} stamp={stamp} />
-      </div>
-    );
+    return null;
   }
+  const stamp = stampText(snapshot.refresh, nowMs);
 
   return (
     <div className="home">
@@ -126,6 +121,7 @@ function HomeBody({
   if (snapshot.repositories.length === 0) {
     return (
       <div className="home__body home__body--empty">
+        <WriteFailure failure={snapshot.write_failure} />
         <h2 className="home__empty-heading">No repositories yet</h2>
         <p className="home__empty-copy">
           Add a local clone and Home lists the pull requests that want you.
@@ -138,14 +134,7 @@ function HomeBody({
   }
   return (
     <div className="home__body home__body--list">
-      {snapshot.write_failure !== null && (
-        <div className="home__write-failure">
-          <span>{snapshot.write_failure.summary}</span>
-          {snapshot.write_failure.remediation !== null && (
-            <span className="home__write-remediation">{snapshot.write_failure.remediation}</span>
-          )}
-        </div>
-      )}
+      <WriteFailure failure={snapshot.write_failure} />
       {snapshot.failed_repositories.map((repository) => (
         <div className="home__failed-repository" key={repository.path}>
           <span className="home__failed-detail">
@@ -176,13 +165,36 @@ function HomeBody({
   );
 }
 
+/** Why the last write did not reach the settings file, wherever the list is. */
+function WriteFailure({ failure }: { failure: SessionFailureDto | null }) {
+  if (failure === null) {
+    return null;
+  }
+  return (
+    <div className="home__write-failure">
+      <span>{failure.summary}</span>
+      {failure.remediation !== null && (
+        <span className="home__write-remediation">{failure.remediation}</span>
+      )}
+    </div>
+  );
+}
+
 /** One pull request on one line, its columns aligned whether or not they speak. */
 function Row({ row, cursor, nowMs }: { row: HomeRowDto; cursor: boolean; nowMs: number }) {
+  const line = useRef<HTMLLIElement>(null);
+
+  useEffect(() => {
+    if (cursor) {
+      line.current?.scrollIntoView({ block: "nearest" });
+    }
+  }, [cursor]);
+
   return (
     <li
+      ref={line}
       className={`home__row${cursor ? " home__row--cursor" : ""}`}
-      data-identity={row.identity}
-      data-cursor={cursor ? "true" : "false"}
+      aria-selected={cursor}
     >
       <span className="home__row-title">{row.title}</span>
       <span className="home__cell home__cell--drafts" />

--- a/apps/desktop/src/hooks/useHome.ts
+++ b/apps/desktop/src/hooks/useHome.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { Channel } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
-import type { HomeSnapshotDto, SessionFailureDto } from "../bindings";
+import type { CursorMoveDto, HomeSnapshotDto, RefreshStateDto, SessionFailureDto } from "../bindings";
 import { commands } from "../bindings";
 import { toFailure } from "../lib/failure";
 
@@ -37,8 +38,14 @@ export function useHome() {
       .catch((error: unknown) => setFailure(toFailure(error)));
   }, []);
 
+  /** What the running refresh last reported, which outranks the snapshot's own stamp. */
+  const [progress, setProgress] = useState<RefreshStateDto | null>(null);
+
   const refresh = useCallback(() => {
-    apply(commands.refreshHome());
+    const channel = new Channel<RefreshStateDto>();
+    channel.onmessage = setProgress;
+    // The answer carries the settled stamp, so the reported one has done its job.
+    apply(commands.refreshHome(channel).finally(() => setProgress(null)));
   }, [apply]);
 
   useEffect(() => {
@@ -84,7 +91,18 @@ export function useHome() {
       .catch((error: unknown) => setFailure(toFailure(error)));
   }, [apply]);
 
-  // r refreshes and e opens or closes the Repositories footer, as the layout prototype bound them.
+  const moveCursor = useCallback((moveTo: CursorMoveDto) => {
+    commands
+      .moveHomeCursor(moveTo)
+      .then((moved) => {
+        setFailure(null);
+        setSnapshot(moved);
+      })
+      .catch((error: unknown) => setFailure(toFailure(error)));
+  }, []);
+
+  // r refreshes, e opens or closes the Repositories footer, and j and k walk the
+  // rows, as the layout prototype bound them.
   useEffect(() => {
     function handleKeydown(event: KeyboardEvent) {
       if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
@@ -102,12 +120,33 @@ export function useHome() {
       if (key === "e") {
         event.preventDefault();
         toggleFooter();
+        return;
+      }
+      if (key === "j") {
+        event.preventDefault();
+        moveCursor("Down");
+        return;
+      }
+      if (key === "k") {
+        event.preventDefault();
+        moveCursor("Up");
       }
     }
 
     window.addEventListener("keydown", handleKeydown);
     return () => window.removeEventListener("keydown", handleKeydown);
-  }, [refresh, toggleFooter]);
+  }, [moveCursor, refresh, toggleFooter]);
 
-  return { snapshot, failure, refresh, toggleFooter, addRepositories, removeRepository };
+  // What the running refresh reports outranks the stamp the last one left.
+  const refreshState = progress ?? snapshot?.refresh ?? null;
+
+  return {
+    snapshot,
+    refreshState,
+    failure,
+    refresh,
+    toggleFooter,
+    addRepositories,
+    removeRepository,
+  };
 }

--- a/apps/desktop/src/hooks/useHome.ts
+++ b/apps/desktop/src/hooks/useHome.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Channel } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
-import type { CursorMoveDto, HomeSnapshotDto, RefreshStateDto, SessionFailureDto } from "../bindings";
+import type { CursorMoveDto, HomeSnapshotDto, SessionFailureDto } from "../bindings";
 import { commands } from "../bindings";
 import { toFailure } from "../lib/failure";
 
@@ -18,38 +18,56 @@ function isTyping(target: EventTarget | null): boolean {
   return target.isContentEditable || target.closest("input, textarea") !== null;
 }
 
-/** Reads Home's repositories and exposes every action the screen can take on them. */
+/** Reads Home's pull requests and exposes every action the screen can take on them. */
 export function useHome() {
   const [snapshot, setSnapshot] = useState<HomeSnapshotDto | null>(null);
   const [failure, setFailure] = useState<SessionFailureDto | null>(null);
   const hasOpened = useRef(false);
+  const refreshing = useRef(false);
 
   /** Takes what a command answered, so a rejection is shown rather than swallowed. */
   const apply = useCallback((call: Promise<HomeResult>) => {
-    call
+    return call
       .then((result) => {
         if (result.status === "error") {
           setFailure(toFailure(result.error));
-          return;
+          return false;
         }
         setFailure(null);
         setSnapshot(result.data);
+        return true;
       })
-      .catch((error: unknown) => setFailure(toFailure(error)));
+      .catch((error: unknown) => {
+        setFailure(toFailure(error));
+        return false;
+      });
   }, []);
 
-  /** What the running refresh last reported, which outranks the snapshot's own stamp. */
-  const [progress, setProgress] = useState<RefreshStateDto | null>(null);
-
+  /**
+   * Refreshes, or leaves the running refresh alone.
+   *
+   * A trigger that arrives mid-refresh is ignored rather than queued, so the
+   * list a reviewer is reading is never replaced by an older answer to a
+   * question the running refresh is already asking.
+   */
   const refresh = useCallback(() => {
-    const channel = new Channel<RefreshStateDto>();
-    channel.onmessage = setProgress;
-    // The answer carries the settled stamp, so the reported one has done its job.
-    apply(commands.refreshHome(channel).finally(() => setProgress(null)));
+    if (refreshing.current) {
+      return;
+    }
+    refreshing.current = true;
+    // Every batch carries what Home shows by then, so the list fills in as it loads.
+    const channel = new Channel<HomeSnapshotDto>();
+    channel.onmessage = (shown) => {
+      setFailure(null);
+      setSnapshot(shown);
+    };
+    apply(commands.refreshHome(channel)).finally(() => {
+      refreshing.current = false;
+    });
   }, [apply]);
 
   useEffect(() => {
-    // Guarded so StrictMode's double mount effect does not read the file twice.
+    // Guarded so StrictMode's double mount effect does not refresh twice.
     if (hasOpened.current) {
       return;
     }
@@ -67,11 +85,23 @@ export function useHome() {
       .catch((error: unknown) => setFailure(toFailure(error)));
   }, []);
 
+  /** Runs `action`, then refreshes, so what the settings file now lists is listed. */
+  const thenRefresh = useCallback(
+    (action: Promise<HomeResult>) => {
+      apply(action).then((changed) => {
+        if (changed) {
+          refresh();
+        }
+      });
+    },
+    [apply, refresh],
+  );
+
   const removeRepository = useCallback(
     (path: string) => {
-      apply(commands.removeRepository(path));
+      thenRefresh(commands.removeRepository(path));
     },
-    [apply],
+    [thenRefresh],
   );
 
   /** Opens the native folder picker, then hands what was chosen to the add command. */
@@ -86,10 +116,10 @@ export function useHome() {
           return;
         }
         const folders = Array.isArray(picked) ? picked : [picked];
-        apply(commands.addRepositories(folders));
+        thenRefresh(commands.addRepositories(folders));
       })
       .catch((error: unknown) => setFailure(toFailure(error)));
-  }, [apply]);
+  }, [thenRefresh]);
 
   const moveCursor = useCallback((moveTo: CursorMoveDto) => {
     commands
@@ -137,16 +167,5 @@ export function useHome() {
     return () => window.removeEventListener("keydown", handleKeydown);
   }, [moveCursor, refresh, toggleFooter]);
 
-  // What the running refresh reports outranks the stamp the last one left.
-  const refreshState = progress ?? snapshot?.refresh ?? null;
-
-  return {
-    snapshot,
-    refreshState,
-    failure,
-    refresh,
-    toggleFooter,
-    addRepositories,
-    removeRepository,
-  };
+  return { snapshot, failure, toggleFooter, addRepositories, removeRepository };
 }

--- a/apps/desktop/src/hooks/useNow.test.ts
+++ b/apps/desktop/src/hooks/useNow.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useNow } from "./useNow";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-09-01T12:00:00Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useNow", () => {
+  it("starts at now and moves on once the minute is out", () => {
+    const { result } = renderHook(() => useNow());
+    const started = result.current;
+
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(result.current).toBe(started);
+
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(result.current).toBe(started + 60_000);
+  });
+
+  it("stops reading the clock once nothing is showing a time", () => {
+    const { result, unmount } = renderHook(() => useNow());
+    const started = result.current;
+
+    unmount();
+    act(() => vi.advanceTimersByTime(600_000));
+
+    expect(result.current).toBe(started);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/apps/desktop/src/hooks/useNow.ts
+++ b/apps/desktop/src/hooks/useNow.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from "react";
+
+/** Now, re-read once a minute, which is as fine as any relative time Home shows. */
+export function useNow(intervalMs = 60_000): number {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), intervalMs);
+    return () => window.clearInterval(timer);
+  }, [intervalMs]);
+
+  return now;
+}

--- a/apps/desktop/src/lib/relativeTime.test.ts
+++ b/apps/desktop/src/lib/relativeTime.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { refreshedStamp, shortAge } from "./relativeTime";
+
+const minute = 60_000;
+const hour = 60 * minute;
+const day = 24 * hour;
+const now = 1_788_266_096_000;
+
+describe("shortAge", () => {
+  it("counts minutes, then hours, then days", () => {
+    expect(shortAge(now - 40 * minute, now)).toBe("40m");
+    expect(shortAge(now - 2 * hour, now)).toBe("2h");
+    expect(shortAge(now - 1 * day, now)).toBe("1d");
+    expect(shortAge(now - 30 * day, now)).toBe("30d");
+  });
+
+  it("rounds down to the unit it is showing", () => {
+    expect(shortAge(now - (59 * minute + 59_000), now)).toBe("59m");
+    expect(shortAge(now - (23 * hour + 59 * minute), now)).toBe("23h");
+  });
+
+  it("shows anything under a minute as no minutes at all", () => {
+    expect(shortAge(now - 30_000, now)).toBe("0m");
+    expect(shortAge(now, now)).toBe("0m");
+  });
+
+  // A clock that has jumped backwards must not read as a pull request from the future.
+  it("shows a time ahead of now as no minutes at all", () => {
+    expect(shortAge(now + 5 * minute, now)).toBe("0m");
+  });
+});
+
+describe("refreshedStamp", () => {
+  it("reads just now under a minute", () => {
+    expect(refreshedStamp(now - 30_000, now)).toBe("Refreshed just now");
+  });
+
+  it("counts minutes, then hours, then days", () => {
+    expect(refreshedStamp(now - 2 * minute, now)).toBe("Refreshed 2 min ago");
+    expect(refreshedStamp(now - 3 * hour, now)).toBe("Refreshed 3 h ago");
+    expect(refreshedStamp(now - 2 * day, now)).toBe("Refreshed 2 d ago");
+  });
+
+  it("reads just now for a time ahead of now", () => {
+    expect(refreshedStamp(now + 5 * minute, now)).toBe("Refreshed just now");
+  });
+});

--- a/apps/desktop/src/lib/relativeTime.test.ts
+++ b/apps/desktop/src/lib/relativeTime.test.ts
@@ -37,8 +37,10 @@ describe("refreshedStamp", () => {
 
   it("counts minutes, then hours, then days", () => {
     expect(refreshedStamp(now - 2 * minute, now)).toBe("Refreshed 2 min ago");
-    expect(refreshedStamp(now - 3 * hour, now)).toBe("Refreshed 3 h ago");
-    expect(refreshedStamp(now - 2 * day, now)).toBe("Refreshed 2 d ago");
+    expect(refreshedStamp(now - 1 * hour, now)).toBe("Refreshed 1 hour ago");
+    expect(refreshedStamp(now - 3 * hour, now)).toBe("Refreshed 3 hours ago");
+    expect(refreshedStamp(now - 1 * day, now)).toBe("Refreshed 1 day ago");
+    expect(refreshedStamp(now - 2 * day, now)).toBe("Refreshed 2 days ago");
   });
 
   it("reads just now for a time ahead of now", () => {

--- a/apps/desktop/src/lib/relativeTime.ts
+++ b/apps/desktop/src/lib/relativeTime.ts
@@ -31,7 +31,7 @@ export function refreshedStamp(atMs: number, nowMs: number): string {
     return `Refreshed ${minutes} min ago`;
   }
   if (hours < 24) {
-    return `Refreshed ${hours} h ago`;
+    return `Refreshed ${hours} ${hours === 1 ? "hour" : "hours"} ago`;
   }
-  return `Refreshed ${days} d ago`;
+  return `Refreshed ${days} ${days === 1 ? "day" : "days"} ago`;
 }

--- a/apps/desktop/src/lib/relativeTime.ts
+++ b/apps/desktop/src/lib/relativeTime.ts
@@ -1,0 +1,37 @@
+/** How long ago a moment was, in whole units, never less than none. */
+function elapsed(atMs: number, nowMs: number) {
+  // A clock that jumped backwards would otherwise read as a time in the future.
+  const sinceMs = Math.max(nowMs - atMs, 0);
+  return {
+    minutes: Math.floor(sinceMs / 60_000),
+    hours: Math.floor(sinceMs / 3_600_000),
+    days: Math.floor(sinceMs / 86_400_000),
+  };
+}
+
+/** A row's age, in the one unit that fits, as the ledger shows it. */
+export function shortAge(updatedAtMs: number, nowMs: number): string {
+  const { minutes, hours, days } = elapsed(updatedAtMs, nowMs);
+  if (minutes < 60) {
+    return `${minutes}m`;
+  }
+  if (hours < 24) {
+    return `${hours}h`;
+  }
+  return `${days}d`;
+}
+
+/** The header stamp for a refresh that settled, in words. */
+export function refreshedStamp(atMs: number, nowMs: number): string {
+  const { minutes, hours, days } = elapsed(atMs, nowMs);
+  if (minutes < 1) {
+    return "Refreshed just now";
+  }
+  if (minutes < 60) {
+    return `Refreshed ${minutes} min ago`;
+  }
+  if (hours < 24) {
+    return `Refreshed ${hours} h ago`;
+  }
+  return `Refreshed ${days} d ago`;
+}

--- a/apps/desktop/src/test/fixtures.ts
+++ b/apps/desktop/src/test/fixtures.ts
@@ -3,7 +3,9 @@ import type {
   DraftsDto,
   FileDetailDto,
   FileSummaryDto,
+  HomeGroupDto,
   HomeRepositoryDto,
+  HomeRowDto,
   HomeSnapshotDto,
   RowDto,
   SessionSnapshotDto,
@@ -108,14 +110,41 @@ export function makeHomeRepository(overrides: Partial<HomeRepositoryDto> = {}): 
   };
 }
 
+export function makeHomeRow(overrides: Partial<HomeRowDto> = {}): HomeRowDto {
+  return {
+    index: 0,
+    title: "Retry webhook deliveries with jittered backoff",
+    url: "https://github.com/acme/widgets/pull/412",
+    identity: "acme/widgets#412",
+    author: "mlee",
+    updated_at_ms: 1_788_266_096_000,
+    review_status: null,
+    check_status: null,
+    ...overrides,
+  };
+}
+
+/** The three groups in their fixed order, holding whatever rows are given. */
+export function makeHomeGroups(rows: HomeRowDto[][] = [[], [], []]): HomeGroupDto[] {
+  const shape = [
+    { title: "To review", empty_copy: "Nothing waiting for your review." },
+    { title: "To address", empty_copy: "Nothing to address." },
+    { title: "Waiting on others", empty_copy: "Nothing waiting on others." },
+  ];
+  return shape.map((group, index) => ({
+    ...group,
+    count: rows[index].length,
+    rows: rows[index],
+  }));
+}
+
 export function makeHomeSnapshot(overrides: Partial<HomeSnapshotDto> = {}): HomeSnapshotDto {
   return {
     count_line: null,
-    groups: [
-      { title: "To review", count: 0, empty_copy: "Nothing waiting for your review." },
-      { title: "To address", count: 0, empty_copy: "Nothing to address." },
-      { title: "Waiting on others", count: 0, empty_copy: "Nothing waiting on others." },
-    ],
+    groups: makeHomeGroups(),
+    cursor: 0,
+    refresh: "NeverRefreshed",
+    failed_repositories: [],
     repositories: [],
     footer_summary: "No repositories",
     footer_expanded: false,

--- a/apps/desktop/src/test/setup.ts
+++ b/apps/desktop/src/test/setup.ts
@@ -65,6 +65,9 @@ Range.prototype.getBoundingClientRect = () => stubRect;
 Element.prototype.getClientRects = () => [stubRect] as unknown as DOMRectList;
 Element.prototype.getBoundingClientRect = () => stubRect;
 
+// jsdom has no scroll machinery, so the cursor row's scrollIntoView is not there to call.
+Element.prototype.scrollIntoView = () => {};
+
 // jsdom has no ResizeObserver at all; CodeMirror's view and the virtualizer both construct one.
 class NoOpResizeObserver implements ResizeObserver {
   observe() {}

--- a/crates/app/src/home.rs
+++ b/crates/app/src/home.rs
@@ -298,8 +298,9 @@ impl HomeModel {
 
     /// Takes what a refresh read, or the failure that stopped it reading.
     ///
-    /// A failed read empties the list, because everything in it came from the
-    /// file that could not be read.
+    /// A failed read empties the list and ends the refresh as failed, because
+    /// everything in the list came from the file that could not be read. A read
+    /// that worked drops whatever a repository no longer listed had contributed.
     pub fn refreshed(&mut self, result: Result<Vec<RepositoryEntry>, SessionFailure>) {
         match result {
             Ok(repositories) => {
@@ -322,6 +323,7 @@ impl HomeModel {
     ///
     /// Returns `false` for a trigger that arrived mid-refresh, which is ignored
     /// rather than queued, so two refreshes never race.
+    #[must_use]
     pub fn begin_refresh(&mut self) -> bool {
         if matches!(self.refresh, RefreshState::Refreshing { .. }) {
             return false;
@@ -1094,7 +1096,7 @@ mod tests {
     #[test]
     fn a_refresh_where_every_repository_failed_reads_as_failed() {
         let mut home = four_repositories();
-        home.begin_refresh();
+        assert!(home.begin_refresh());
         home.fetching(2);
 
         home.batch_fetched(vec![
@@ -1111,7 +1113,7 @@ mod tests {
     #[test]
     fn a_refresh_where_one_repository_answered_still_settles() {
         let mut home = four_repositories();
-        home.begin_refresh();
+        assert!(home.begin_refresh());
         home.fetching(2);
 
         home.batch_fetched(vec![
@@ -1132,7 +1134,7 @@ mod tests {
     #[test]
     fn a_refresh_with_nothing_configured_settles_rather_than_failing() {
         let mut home = HomeModel::new();
-        home.begin_refresh();
+        assert!(home.begin_refresh());
         home.refreshed(Ok(Vec::new()));
         home.fetching(0);
 
@@ -1149,7 +1151,7 @@ mod tests {
     #[test]
     fn a_preflight_failure_is_the_whole_home_failure_and_ends_the_refresh() {
         let mut home = four_repositories();
-        home.begin_refresh();
+        assert!(home.begin_refresh());
 
         home.preflight_failed(
             SessionFailure::new("GitHub is not authenticated")
@@ -1170,7 +1172,7 @@ mod tests {
     #[test]
     fn a_preflight_failure_does_not_stand_in_the_way_of_adding_a_repository() {
         let mut home = four_repositories();
-        home.begin_refresh();
+        assert!(home.begin_refresh());
         home.preflight_failed(SessionFailure::new("GitHub is not authenticated"));
 
         let write = home.add_repositories(
@@ -1185,7 +1187,7 @@ mod tests {
     #[test]
     fn the_next_refresh_clears_the_preflight_failure() {
         let mut home = four_repositories();
-        home.begin_refresh();
+        assert!(home.begin_refresh());
         home.preflight_failed(SessionFailure::new("GitHub is not authenticated"));
 
         assert!(home.begin_refresh());
@@ -1196,7 +1198,7 @@ mod tests {
     #[test]
     fn a_settings_file_that_cannot_be_read_ends_the_refresh_as_failed() {
         let mut home = four_repositories();
-        home.begin_refresh();
+        assert!(home.begin_refresh());
 
         home.refreshed(Err(SessionFailure::new(
             "Home could not read your settings",
@@ -1208,7 +1210,7 @@ mod tests {
     #[test]
     fn a_repository_that_could_not_be_fetched_names_itself_its_error_and_its_entry() {
         let mut home = four_repositories();
-        home.begin_refresh();
+        assert!(home.begin_refresh());
         home.fetching(4);
 
         home.batch_fetched(vec![unreachable(
@@ -1226,7 +1228,7 @@ mod tests {
     #[test]
     fn a_repository_that_could_not_be_fetched_says_so_in_the_footer_and_the_summary() {
         let mut home = four_repositories();
-        home.begin_refresh();
+        assert!(home.begin_refresh());
         home.fetching(4);
 
         home.batch_fetched(vec![unreachable("acme/billing", "GitHub refused access")]);
@@ -1252,7 +1254,7 @@ mod tests {
             "/Developer/moved",
             "the folder no longer exists",
         )]));
-        home.begin_refresh();
+        assert!(home.begin_refresh());
         home.fetching(0);
 
         assert_eq!(
@@ -1271,7 +1273,7 @@ mod tests {
             valid("/Developer/widgets", "acme/widgets"),
             valid("/Developer/widgets-worktree", "acme/widgets"),
         ]));
-        home.begin_refresh();
+        assert!(home.begin_refresh());
         home.fetching(1);
 
         home.batch_fetched(vec![unreachable("acme/widgets", "GitHub refused access")]);
@@ -1283,12 +1285,12 @@ mod tests {
     #[test]
     fn a_refresh_that_succeeds_clears_the_failure_the_last_one_reported() {
         let mut home = four_repositories();
-        home.begin_refresh();
+        assert!(home.begin_refresh());
         home.fetching(1);
         home.batch_fetched(vec![unreachable("acme/billing", "GitHub refused access")]);
         home.finish_refresh(1_700_000_000_000);
 
-        home.begin_refresh();
+        assert!(home.begin_refresh());
         home.fetching(1);
         home.batch_fetched(vec![empty("acme/billing")]);
         home.finish_refresh(1_700_000_060_000);
@@ -1343,7 +1345,7 @@ mod tests {
         home.move_cursor_down();
         assert_eq!(home.cursor(), 2);
 
-        home.begin_refresh();
+        assert!(home.begin_refresh());
         home.fetching(1);
         home.batch_fetched(vec![loaded(vec![fetched(
             HomeSearch::ReviewRequested,
@@ -1359,7 +1361,7 @@ mod tests {
         let mut home = three_groups();
         home.move_cursor_down();
 
-        home.begin_refresh();
+        assert!(home.begin_refresh());
         home.fetching(1);
         home.batch_fetched(vec![empty("acme/widgets")]);
 
@@ -1376,7 +1378,7 @@ mod tests {
             valid("/Developer/widgets", "acme/widgets"),
             valid("/Developer/zreview", "braidonw/zreview"),
         ]));
-        home.begin_refresh();
+        assert!(home.begin_refresh());
         home.fetching(2);
         home.batch_fetched(vec![
             loaded(vec![fetched(HomeSearch::ReviewRequested, 1, 300)]),

--- a/crates/app/src/home.rs
+++ b/crates/app/src/home.rs
@@ -55,11 +55,6 @@ impl RepositoryEntry {
             RepositoryOutcome::Failed { .. } => None,
         }
     }
-
-    #[must_use]
-    const fn is_failed(&self) -> bool {
-        matches!(self.outcome, RepositoryOutcome::Failed { .. })
-    }
 }
 
 /// Something Home would not do, and why.
@@ -116,6 +111,160 @@ impl HomeGroup {
     }
 }
 
+/// Which of Home's two searches a pull request came back from.
+///
+/// The search is what decides whether a row is one the reviewer was asked to
+/// look at or one of their own, which no field on the pull request says.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HomeSearch {
+    ReviewRequested,
+    Authored,
+}
+
+/// GitHub's combined state for every check on a head commit.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CheckState {
+    Expected,
+    Error,
+    Failure,
+    Pending,
+    Success,
+}
+
+/// GitHub's standing verdict on a pull request, folding in branch protection.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReviewDecision {
+    ChangesRequested,
+    Approved,
+    ReviewRequired,
+}
+
+/// One fetched pull request, carrying only what grouping and rows read.
+///
+/// Deliberately not the forge's own type. Whoever fetches reduces threads and
+/// reviews to the two questions grouping asks of them, which keeps this model
+/// free of the API those answers came from.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FetchedPullRequest {
+    pub search: HomeSearch,
+    /// `owner/name`, which is also what the row's identity reads.
+    pub repository: String,
+    pub number: u64,
+    pub title: String,
+    pub url: String,
+    /// `None` once GitHub has forgotten the account.
+    pub author_login: Option<String>,
+    pub updated_at_ms: i64,
+    pub head_sha: String,
+    /// The commit the viewer's own latest review was left against.
+    pub viewer_latest_review_sha: Option<String>,
+    /// `None` when the head has no checks at all, which reads differently from
+    /// a pending one.
+    pub check_state: Option<CheckState>,
+    pub review_decision: Option<ReviewDecision>,
+    /// Whether any standing review asks the author for changes.
+    pub changes_requested: bool,
+    /// Whether any unresolved thread was last spoken in by somebody else.
+    pub thread_awaiting_reply: bool,
+}
+
+/// What one repository's fetch found, or why it found nothing.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RepositoryFetch {
+    pub slug: String,
+    pub outcome: Result<Vec<FetchedPullRequest>, String>,
+}
+
+/// What a row says about its checks, or nothing when there are none.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CheckStatus {
+    Passing,
+    Failing,
+    Running,
+}
+
+impl CheckStatus {
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Passing => "checks passing",
+            Self::Failing => "checks failing",
+            Self::Running => "checks running",
+        }
+    }
+}
+
+/// What a row says about its reviews, or nothing when it has none to report.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReviewStatus {
+    ChangesRequested,
+    Approved,
+    ReviewedThisHead,
+}
+
+impl ReviewStatus {
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::ChangesRequested => "changes requested",
+            Self::Approved => "approved",
+            Self::ReviewedThisHead => "you reviewed this head",
+        }
+    }
+}
+
+/// One pull request as Home lists it, in the group it belongs to.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HomeRow {
+    pub group: HomeGroup,
+    pub repository: String,
+    pub number: u64,
+    pub title: String,
+    pub url: String,
+    pub author_login: Option<String>,
+    pub updated_at_ms: i64,
+    pub review_status: Option<ReviewStatus>,
+    pub check_status: Option<CheckStatus>,
+}
+
+impl HomeRow {
+    /// `owner/name#number`, which is how a row names its pull request.
+    #[must_use]
+    pub fn identity(&self) -> String {
+        format!("{}#{}", self.repository, self.number)
+    }
+}
+
+/// One configured repository whose pull requests could not be fetched.
+///
+/// Named by path as well as by slug, because the line it shows carries Remove,
+/// and Remove names the entry the settings file holds.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FetchFailure {
+    pub path: PathBuf,
+    pub slug: String,
+    pub reason: String,
+}
+
+/// How current the list is, which the header stamp reads.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum RefreshState {
+    /// Nothing has been fetched yet, so there is no stamp to show.
+    #[default]
+    NeverRefreshed,
+    Refreshing {
+        done: usize,
+        total: usize,
+    },
+    /// Epoch milliseconds at which the last refresh settled.
+    Refreshed {
+        at_ms: i64,
+    },
+    /// Nothing loaded at all, from the preflight, the settings file, or every
+    /// configured repository failing.
+    Failed,
+}
+
 /// Everything Home is, and every action that changes it.
 ///
 /// Held behind a lock and shared by whatever is displaying it, as the session
@@ -123,10 +272,21 @@ impl HomeGroup {
 #[derive(Debug, Default)]
 pub struct HomeModel {
     repositories: Vec<RepositoryEntry>,
-    failure: Option<SessionFailure>,
+    settings_failure: Option<SessionFailure>,
+    preflight_failure: Option<SessionFailure>,
     write_failure: Option<SessionFailure>,
     footer_expanded: bool,
     refusals: Vec<Refusal>,
+    /// Every listed row, in the order Home renders them, which is also the
+    /// order the cursor walks.
+    rows: Vec<HomeRow>,
+    fetch_failures: Vec<FetchFailure>,
+    refresh: RefreshState,
+    cursor: usize,
+    /// How many repositories this refresh has loaded and lost, which is what
+    /// separates "nothing loaded" from a list with a hole in it.
+    loaded_repositories: usize,
+    failed_repositories: usize,
 }
 
 impl HomeModel {
@@ -144,13 +304,194 @@ impl HomeModel {
         match result {
             Ok(repositories) => {
                 self.repositories = repositories;
-                self.failure = None;
+                self.settings_failure = None;
+                self.drop_unlisted_rows();
             }
             Err(failure) => {
                 self.repositories.clear();
-                self.failure = Some(failure);
+                self.settings_failure = Some(failure);
+                self.rows.clear();
+                self.fetch_failures.clear();
+                self.refresh = RefreshState::Failed;
             }
         }
+        self.clamp_cursor();
+    }
+
+    /// Starts a refresh, or leaves the one already running alone.
+    ///
+    /// Returns `false` for a trigger that arrived mid-refresh, which is ignored
+    /// rather than queued, so two refreshes never race.
+    pub fn begin_refresh(&mut self) -> bool {
+        if matches!(self.refresh, RefreshState::Refreshing { .. }) {
+            return false;
+        }
+        self.preflight_failure = None;
+        self.refresh = RefreshState::Refreshing { done: 0, total: 0 };
+        true
+    }
+
+    /// Stops the refresh before it fetched anything, `gh` being unusable.
+    ///
+    /// The list stays as it was, because nothing about it has been disproved.
+    /// It is the failure block in front of it that says why it is not moving.
+    pub fn preflight_failed(&mut self, failure: SessionFailure) {
+        self.preflight_failure = Some(failure);
+        self.refresh = RefreshState::Failed;
+    }
+
+    /// Says how many repositories this refresh is about to fetch.
+    ///
+    /// The rows the last refresh listed go now, because from here on this one's
+    /// rows arrive a batch at a time and the two must not be mixed.
+    pub fn fetching(&mut self, total: usize) {
+        self.rows.clear();
+        self.fetch_failures.clear();
+        self.loaded_repositories = 0;
+        self.failed_repositories = 0;
+        self.refresh = RefreshState::Refreshing { done: 0, total };
+        self.clamp_cursor();
+    }
+
+    /// Takes what one batch of repositories found, advancing the progress count.
+    pub fn batch_fetched(&mut self, batch: Vec<RepositoryFetch>) {
+        for fetch in batch {
+            match fetch.outcome {
+                Ok(pull_requests) => {
+                    self.loaded_repositories += 1;
+                    self.rows.extend(pull_requests.into_iter().map(into_row));
+                }
+                Err(reason) => {
+                    self.failed_repositories += 1;
+                    self.record_fetch_failure(&fetch.slug, &reason);
+                }
+            }
+            self.advance_progress();
+        }
+        self.order_rows();
+        self.clamp_cursor();
+    }
+
+    /// Ends the refresh, settled at `at_ms` or failed with nothing to show.
+    ///
+    /// A refresh that reached no repository at all is not a failure. There was
+    /// nothing configured to fail.
+    pub fn finish_refresh(&mut self, at_ms: i64) {
+        self.refresh = if self.loaded_repositories == 0 && self.failed_repositories > 0 {
+            RefreshState::Failed
+        } else {
+            RefreshState::Refreshed { at_ms }
+        };
+    }
+
+    #[must_use]
+    pub const fn refresh_state(&self) -> RefreshState {
+        self.refresh
+    }
+
+    /// Every listed row, in the order Home renders them.
+    #[must_use]
+    pub fn rows(&self) -> &[HomeRow] {
+        &self.rows
+    }
+
+    /// The rows in one group, newest updated first.
+    pub fn rows_in(&self, group: HomeGroup) -> impl Iterator<Item = &HomeRow> {
+        self.rows.iter().filter(move |row| row.group == group)
+    }
+
+    /// Every configured repository this refresh could not fetch.
+    #[must_use]
+    pub fn fetch_failures(&self) -> &[FetchFailure] {
+        &self.fetch_failures
+    }
+
+    /// Why the clone listed at `path` shows nothing, from resolving it or from
+    /// fetching it.
+    #[must_use]
+    pub fn repository_failure(&self, path: &Path) -> Option<&str> {
+        self.repositories
+            .iter()
+            .find(|entry| entry.path == path)
+            .and_then(|entry| {
+                entry.reason().or_else(|| {
+                    self.fetch_failures
+                        .iter()
+                        .find(|failure| Some(failure.slug.as_str()) == entry.slug())
+                        .map(|failure| failure.reason.as_str())
+                })
+            })
+    }
+
+    /// Where the cursor sits, as a flat index across every rendered row.
+    #[must_use]
+    pub const fn cursor(&self) -> usize {
+        self.cursor
+    }
+
+    /// Moves the cursor one row down, stopping at the last one.
+    pub fn move_cursor_down(&mut self) {
+        self.cursor = (self.cursor + 1).min(self.rows.len().saturating_sub(1));
+    }
+
+    /// Moves the cursor one row up, stopping at the first one.
+    pub const fn move_cursor_up(&mut self) {
+        self.cursor = self.cursor.saturating_sub(1);
+    }
+
+    /// Files every fetched repository's failure against every clone that points
+    /// at it, so two checkouts of one repository each say why they are empty.
+    fn record_fetch_failure(&mut self, slug: &str, reason: &str) {
+        let paths = self
+            .repositories
+            .iter()
+            .filter(|entry| entry.slug() == Some(slug))
+            .map(|entry| entry.path.clone())
+            .collect::<Vec<_>>();
+        self.fetch_failures
+            .extend(paths.into_iter().map(|path| FetchFailure {
+                path,
+                slug: slug.to_owned(),
+                reason: reason.to_owned(),
+            }));
+    }
+
+    fn advance_progress(&mut self) {
+        if let RefreshState::Refreshing { done, total } = self.refresh {
+            self.refresh = RefreshState::Refreshing {
+                done: (done + 1).min(total),
+                total,
+            };
+        }
+    }
+
+    /// Groups in their fixed order, and within a group the newest update first.
+    fn order_rows(&mut self) {
+        self.rows.sort_by(|left, right| {
+            group_order(left.group)
+                .cmp(&group_order(right.group))
+                .then(right.updated_at_ms.cmp(&left.updated_at_ms))
+        });
+    }
+
+    /// Drops what a repository that is no longer configured contributed.
+    ///
+    /// A removed clone's rows would otherwise sit in the list until the next
+    /// refresh, promising pull requests from somewhere Home no longer reads.
+    fn drop_unlisted_rows(&mut self) {
+        let listed = self
+            .repositories
+            .iter()
+            .filter_map(RepositoryEntry::slug)
+            .map(ToOwned::to_owned)
+            .collect::<Vec<_>>();
+        self.rows.retain(|row| listed.contains(&row.repository));
+        self.fetch_failures
+            .retain(|failure| listed.contains(&failure.slug));
+    }
+
+    fn clamp_cursor(&mut self) {
+        self.cursor = self.cursor.min(self.rows.len().saturating_sub(1));
     }
 
     /// Takes what came of writing the settings file.
@@ -169,11 +510,14 @@ impl HomeModel {
 
     /// What stops Home listing anything at all, if anything does.
     ///
-    /// Only a settings file that could not be read, or no home directory to look
-    /// for one in. A write that failed is [`Self::write_failure`].
+    /// A settings file that could not be read, no home directory to look for one
+    /// in, or a `gh` the refresh could not get past. A write that failed is
+    /// [`Self::write_failure`], which leaves a list worth showing.
     #[must_use]
-    pub const fn failure(&self) -> Option<&SessionFailure> {
-        self.failure.as_ref()
+    pub fn failure(&self) -> Option<&SessionFailure> {
+        self.settings_failure
+            .as_ref()
+            .or(self.preflight_failure.as_ref())
     }
 
     /// Why the last write did not reach the file, if it did not.
@@ -182,24 +526,23 @@ impl HomeModel {
         self.write_failure.as_ref()
     }
 
-    /// How many configured clones could not be resolved.
+    /// How many configured clones list nothing, from either cause.
     #[must_use]
     pub fn failed_count(&self) -> usize {
         self.repositories
             .iter()
-            .filter(|entry| entry.is_failed())
+            .filter(|entry| self.repository_failure(&entry.path).is_some())
             .count()
     }
 
     /// The header's count line, absent while there is nothing to count.
-    ///
-    /// No pull requests have been fetched yet, so the count of them is zero.
     #[must_use]
     pub fn count_line(&self) -> Option<String> {
         (!self.repositories.is_empty()).then(|| {
             format!(
-                "0 pull requests across {}",
-                repository_count(self.repositories.len())
+                "{} across {}",
+                pull_request_count(self.rows.len()),
+                repository_count(self.repositories.len()),
             )
         })
     }
@@ -282,7 +625,7 @@ impl HomeModel {
     /// A write replaces the whole file, and what an unreadable one holds is
     /// unknown, so writing would silently drop repositories Home never saw.
     fn unreadable_settings_refusal(&self, settings_path: &Path) -> Option<Refusal> {
-        self.failure.is_some().then(|| Refusal {
+        self.settings_failure.is_some().then(|| Refusal {
             path: settings_path.to_path_buf(),
             reason: "fix this file before changing your repositories".to_owned(),
         })
@@ -334,6 +677,84 @@ fn repository_count(count: usize) -> String {
     }
 }
 
+/// "1 pull request" or "8 pull requests", as the count requires.
+fn pull_request_count(count: usize) -> String {
+    if count == 1 {
+        "1 pull request".to_owned()
+    } else {
+        format!("{count} pull requests")
+    }
+}
+
+/// Where a group sits in the fixed order Home renders them in.
+const fn group_order(group: HomeGroup) -> usize {
+    match group {
+        HomeGroup::ToReview => 0,
+        HomeGroup::ToAddress => 1,
+        HomeGroup::WaitingOnOthers => 2,
+    }
+}
+
+/// Which group a fetched pull request belongs to.
+///
+/// The search it came back from decides first. Only the reviewer's own pull
+/// requests can be waiting on them, and everything asked of them is to review
+/// whether or not they have looked at it before.
+fn group_of(fetched: &FetchedPullRequest) -> HomeGroup {
+    match fetched.search {
+        HomeSearch::ReviewRequested => HomeGroup::ToReview,
+        HomeSearch::Authored => {
+            if fetched.changes_requested || fetched.thread_awaiting_reply {
+                HomeGroup::ToAddress
+            } else {
+                HomeGroup::WaitingOnOthers
+            }
+        }
+    }
+}
+
+/// What a row says about its checks, absent when the head has none.
+const fn check_status_of(state: Option<CheckState>) -> Option<CheckStatus> {
+    match state {
+        Some(CheckState::Success) => Some(CheckStatus::Passing),
+        Some(CheckState::Failure | CheckState::Error) => Some(CheckStatus::Failing),
+        Some(CheckState::Pending | CheckState::Expected) => Some(CheckStatus::Running),
+        None => None,
+    }
+}
+
+/// What a row says about its reviews, absent when it has nothing to report.
+///
+/// A standing request for changes outranks an approval, and both outrank the
+/// reviewer's own note that they have already looked at this head.
+fn review_status_of(fetched: &FetchedPullRequest) -> Option<ReviewStatus> {
+    if fetched.changes_requested {
+        return Some(ReviewStatus::ChangesRequested);
+    }
+    if matches!(fetched.review_decision, Some(ReviewDecision::Approved)) {
+        return Some(ReviewStatus::Approved);
+    }
+    let reviewed_this_head = fetched
+        .viewer_latest_review_sha
+        .as_ref()
+        .is_some_and(|sha| *sha == fetched.head_sha);
+    reviewed_this_head.then_some(ReviewStatus::ReviewedThisHead)
+}
+
+fn into_row(fetched: FetchedPullRequest) -> HomeRow {
+    HomeRow {
+        group: group_of(&fetched),
+        review_status: review_status_of(&fetched),
+        check_status: check_status_of(fetched.check_state),
+        repository: fetched.repository,
+        number: fetched.number,
+        title: fetched.title,
+        url: fetched.url,
+        author_login: fetched.author_login,
+        updated_at_ms: fetched.updated_at_ms,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::{Path, PathBuf};
@@ -359,6 +780,633 @@ mod tests {
                 reason: reason.to_owned(),
             },
         }
+    }
+
+    /// One fetched pull request, with nothing standing between it and its group.
+    fn fetched(search: HomeSearch, number: u64, updated_at_ms: i64) -> FetchedPullRequest {
+        FetchedPullRequest {
+            search,
+            repository: "acme/widgets".to_owned(),
+            number,
+            title: format!("Pull request {number}"),
+            url: format!("https://github.com/acme/widgets/pull/{number}"),
+            author_login: Some("mlee".to_owned()),
+            updated_at_ms,
+            head_sha: "head".to_owned(),
+            viewer_latest_review_sha: None,
+            check_state: None,
+            review_decision: None,
+            changes_requested: false,
+            thread_awaiting_reply: false,
+        }
+    }
+
+    /// One repository's fetch, having found `rows`.
+    fn loaded(rows: Vec<FetchedPullRequest>) -> RepositoryFetch {
+        RepositoryFetch {
+            slug: "acme/widgets".to_owned(),
+            outcome: Ok(rows),
+        }
+    }
+
+    #[test]
+    fn every_row_from_the_review_requested_search_lands_in_to_review() {
+        let mut home = HomeModel::new();
+        home.refreshed(Ok(vec![valid("/Developer/widgets", "acme/widgets")]));
+
+        home.batch_fetched(vec![loaded(vec![
+            fetched(HomeSearch::ReviewRequested, 412, 200),
+            fetched(HomeSearch::ReviewRequested, 398, 100),
+        ])]);
+
+        let rows = home.rows();
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|row| row.group == HomeGroup::ToReview));
+    }
+
+    /// Home with one repository configured, listing whatever it fetched.
+    fn listing(rows: Vec<FetchedPullRequest>) -> HomeModel {
+        let mut home = HomeModel::new();
+        home.refreshed(Ok(vec![valid("/Developer/widgets", "acme/widgets")]));
+        home.batch_fetched(vec![loaded(rows)]);
+        home
+    }
+
+    /// The single row a test that built one expects to find.
+    fn only_row(home: &HomeModel) -> &HomeRow {
+        assert_eq!(home.rows().len(), 1, "exactly one row was fetched");
+        &home.rows()[0]
+    }
+
+    /// A pull request the reviewer has already looked at, at this very head.
+    #[test]
+    fn a_review_request_already_answered_at_this_head_still_lands_in_to_review() {
+        let mut already_reviewed = fetched(HomeSearch::ReviewRequested, 398, 100);
+        already_reviewed.viewer_latest_review_sha = Some("head".to_owned());
+
+        let home = listing(vec![already_reviewed]);
+
+        let row = only_row(&home);
+        assert_eq!(row.group, HomeGroup::ToReview);
+        assert_eq!(row.review_status, Some(ReviewStatus::ReviewedThisHead));
+    }
+
+    #[test]
+    fn a_review_left_against_an_earlier_head_is_no_row_status_at_all() {
+        let mut reviewed_before = fetched(HomeSearch::ReviewRequested, 398, 100);
+        reviewed_before.viewer_latest_review_sha = Some("an older commit".to_owned());
+
+        let home = listing(vec![reviewed_before]);
+
+        assert_eq!(only_row(&home).review_status, None);
+    }
+
+    #[test]
+    fn an_authored_pull_request_with_a_standing_changes_requested_review_is_to_address() {
+        let mut changes_requested = fetched(HomeSearch::Authored, 412, 100);
+        changes_requested.changes_requested = true;
+
+        let home = listing(vec![changes_requested]);
+
+        let row = only_row(&home);
+        assert_eq!(row.group, HomeGroup::ToAddress);
+        assert_eq!(row.review_status, Some(ReviewStatus::ChangesRequested));
+    }
+
+    #[test]
+    fn an_authored_pull_request_whose_unresolved_thread_someone_else_answered_last_is_to_address() {
+        let mut awaiting_reply = fetched(HomeSearch::Authored, 412, 100);
+        awaiting_reply.thread_awaiting_reply = true;
+
+        let home = listing(vec![awaiting_reply]);
+
+        assert_eq!(only_row(&home).group, HomeGroup::ToAddress);
+    }
+
+    /// The reviewer having spoken last is what takes it off their hands, which
+    /// is the whole difference between the two authored groups.
+    #[test]
+    fn an_authored_pull_request_whose_unresolved_thread_the_viewer_answered_last_is_waiting() {
+        let answered = fetched(HomeSearch::Authored, 412, 100);
+
+        let home = listing(vec![answered]);
+
+        assert_eq!(only_row(&home).group, HomeGroup::WaitingOnOthers);
+    }
+
+    #[test]
+    fn every_other_authored_pull_request_is_waiting_on_others() {
+        let mut approved = fetched(HomeSearch::Authored, 412, 100);
+        approved.review_decision = Some(ReviewDecision::Approved);
+        approved.check_state = Some(CheckState::Success);
+
+        let home = listing(vec![approved]);
+
+        let row = only_row(&home);
+        assert_eq!(row.group, HomeGroup::WaitingOnOthers);
+        assert_eq!(row.review_status, Some(ReviewStatus::Approved));
+        assert_eq!(row.check_status, Some(CheckStatus::Passing));
+    }
+
+    #[test]
+    fn rows_are_grouped_in_a_fixed_order_and_newest_updated_first_within_each() {
+        let mut changes_requested = fetched(HomeSearch::Authored, 1, 100);
+        changes_requested.changes_requested = true;
+
+        let mut home = HomeModel::new();
+        home.refreshed(Ok(vec![valid("/Developer/widgets", "acme/widgets")]));
+        home.batch_fetched(vec![loaded(vec![
+            fetched(HomeSearch::Authored, 2, 300),
+            fetched(HomeSearch::ReviewRequested, 3, 200),
+            changes_requested,
+            fetched(HomeSearch::ReviewRequested, 4, 400),
+        ])]);
+
+        let listed = home
+            .rows()
+            .iter()
+            .map(|row| (row.group, row.number))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            listed,
+            [
+                (HomeGroup::ToReview, 4),
+                (HomeGroup::ToReview, 3),
+                (HomeGroup::ToAddress, 1),
+                (HomeGroup::WaitingOnOthers, 2),
+            ],
+        );
+    }
+
+    #[test]
+    fn a_row_names_its_pull_request_as_owner_name_and_number() {
+        let home = listing(vec![fetched(HomeSearch::ReviewRequested, 412, 100)]);
+
+        assert_eq!(only_row(&home).identity(), "acme/widgets#412");
+    }
+
+    #[test]
+    fn every_check_state_maps_to_one_of_three_statuses_or_a_gap() {
+        let mapped = [
+            (Some(CheckState::Success), Some(CheckStatus::Passing)),
+            (Some(CheckState::Failure), Some(CheckStatus::Failing)),
+            (Some(CheckState::Error), Some(CheckStatus::Failing)),
+            (Some(CheckState::Pending), Some(CheckStatus::Running)),
+            (Some(CheckState::Expected), Some(CheckStatus::Running)),
+            (None, None),
+        ];
+
+        for (state, expected) in mapped {
+            let mut row = fetched(HomeSearch::ReviewRequested, 412, 100);
+            row.check_state = state;
+
+            let home = listing(vec![row]);
+
+            assert_eq!(only_row(&home).check_status, expected, "{state:?}");
+        }
+    }
+
+    /// Precedence, top down. A request for changes is what the author has to
+    /// act on, and it says so even where GitHub's own decision has moved on.
+    #[test]
+    fn a_standing_request_for_changes_outranks_an_approval_and_a_review_of_this_head() {
+        let mut contested = fetched(HomeSearch::Authored, 412, 100);
+        contested.changes_requested = true;
+        contested.review_decision = Some(ReviewDecision::Approved);
+        contested.viewer_latest_review_sha = Some("head".to_owned());
+
+        let home = listing(vec![contested]);
+
+        assert_eq!(
+            only_row(&home).review_status,
+            Some(ReviewStatus::ChangesRequested),
+        );
+    }
+
+    #[test]
+    fn an_approval_outranks_a_review_of_this_head() {
+        let mut approved = fetched(HomeSearch::Authored, 412, 100);
+        approved.review_decision = Some(ReviewDecision::Approved);
+        approved.viewer_latest_review_sha = Some("head".to_owned());
+
+        let home = listing(vec![approved]);
+
+        assert_eq!(only_row(&home).review_status, Some(ReviewStatus::Approved));
+    }
+
+    /// Nobody has reviewed it, which is not something a row has to say.
+    #[test]
+    fn a_review_still_required_leaves_the_review_column_empty() {
+        let mut untouched = fetched(HomeSearch::Authored, 412, 100);
+        untouched.review_decision = Some(ReviewDecision::ReviewRequired);
+
+        let home = listing(vec![untouched]);
+
+        assert_eq!(only_row(&home).review_status, None);
+    }
+
+    /// One repository's fetch that could not be made.
+    fn unreachable(slug: &str, reason: &str) -> RepositoryFetch {
+        RepositoryFetch {
+            slug: slug.to_owned(),
+            outcome: Err(reason.to_owned()),
+        }
+    }
+
+    /// One repository's fetch that found nothing, which is not a failure.
+    fn empty(slug: &str) -> RepositoryFetch {
+        RepositoryFetch {
+            slug: slug.to_owned(),
+            outcome: Ok(Vec::new()),
+        }
+    }
+
+    /// Four configured clones, which is what a batch's progress counts against.
+    fn four_repositories() -> HomeModel {
+        let mut home = HomeModel::new();
+        home.refreshed(Ok(vec![
+            valid("/Developer/zreview", "braidonw/zreview"),
+            valid("/Developer/widgets", "acme/widgets"),
+            valid("/Developer/billing", "acme/billing"),
+            valid("/Developer/tokens", "acme/design-tokens"),
+        ]));
+        home
+    }
+
+    #[test]
+    fn there_is_no_stamp_at_all_before_the_first_refresh() {
+        let home = HomeModel::new();
+
+        assert_eq!(home.refresh_state(), RefreshState::NeverRefreshed);
+    }
+
+    #[test]
+    fn a_refresh_counts_off_the_repositories_as_each_batch_lands() {
+        let mut home = four_repositories();
+
+        assert!(home.begin_refresh());
+        assert_eq!(
+            home.refresh_state(),
+            RefreshState::Refreshing { done: 0, total: 0 },
+            "the total is unknown until the settings file has been read",
+        );
+
+        home.fetching(4);
+        assert_eq!(
+            home.refresh_state(),
+            RefreshState::Refreshing { done: 0, total: 4 },
+        );
+
+        home.batch_fetched(vec![empty("braidonw/zreview"), empty("acme/widgets")]);
+        assert_eq!(
+            home.refresh_state(),
+            RefreshState::Refreshing { done: 2, total: 4 },
+        );
+
+        home.batch_fetched(vec![empty("acme/billing"), empty("acme/design-tokens")]);
+        home.finish_refresh(1_700_000_000_000);
+        assert_eq!(
+            home.refresh_state(),
+            RefreshState::Refreshed {
+                at_ms: 1_700_000_000_000,
+            },
+        );
+    }
+
+    #[test]
+    fn a_trigger_that_arrives_while_a_refresh_runs_starts_nothing() {
+        let mut home = four_repositories();
+        assert!(home.begin_refresh());
+        home.fetching(4);
+        home.batch_fetched(vec![empty("braidonw/zreview")]);
+
+        assert!(
+            !home.begin_refresh(),
+            "a second trigger is ignored, not queued",
+        );
+        assert_eq!(
+            home.refresh_state(),
+            RefreshState::Refreshing { done: 1, total: 4 },
+            "the running refresh keeps its own progress",
+        );
+    }
+
+    #[test]
+    fn a_refresh_where_every_repository_failed_reads_as_failed() {
+        let mut home = four_repositories();
+        home.begin_refresh();
+        home.fetching(2);
+
+        home.batch_fetched(vec![
+            unreachable("braidonw/zreview", "GitHub could not be reached"),
+            unreachable("acme/widgets", "GitHub could not be reached"),
+        ]);
+        home.finish_refresh(1_700_000_000_000);
+
+        assert_eq!(home.refresh_state(), RefreshState::Failed);
+    }
+
+    /// One repository still answering is a list with a hole in it, not a
+    /// failure, and the stamp says when it was fetched.
+    #[test]
+    fn a_refresh_where_one_repository_answered_still_settles() {
+        let mut home = four_repositories();
+        home.begin_refresh();
+        home.fetching(2);
+
+        home.batch_fetched(vec![
+            unreachable("braidonw/zreview", "GitHub refused access"),
+            empty("acme/widgets"),
+        ]);
+        home.finish_refresh(1_700_000_000_000);
+
+        assert_eq!(
+            home.refresh_state(),
+            RefreshState::Refreshed {
+                at_ms: 1_700_000_000_000,
+            },
+        );
+    }
+
+    /// Nothing was configured, so nothing failed.
+    #[test]
+    fn a_refresh_with_nothing_configured_settles_rather_than_failing() {
+        let mut home = HomeModel::new();
+        home.begin_refresh();
+        home.refreshed(Ok(Vec::new()));
+        home.fetching(0);
+
+        home.finish_refresh(1_700_000_000_000);
+
+        assert_eq!(
+            home.refresh_state(),
+            RefreshState::Refreshed {
+                at_ms: 1_700_000_000_000,
+            },
+        );
+    }
+
+    #[test]
+    fn a_preflight_failure_is_the_whole_home_failure_and_ends_the_refresh() {
+        let mut home = four_repositories();
+        home.begin_refresh();
+
+        home.preflight_failed(
+            SessionFailure::new("GitHub is not authenticated")
+                .with_remediation("Run `gh auth login`, then press r."),
+        );
+
+        let failure = home.failure().expect("the preflight failure shows");
+        assert_eq!(failure.summary, "GitHub is not authenticated");
+        assert_eq!(home.refresh_state(), RefreshState::Failed);
+        assert_eq!(
+            home.repositories().len(),
+            4,
+            "an unusable gh says nothing about the configured clones",
+        );
+    }
+
+    /// The settings file is fine, so there is nothing about it to fix first.
+    #[test]
+    fn a_preflight_failure_does_not_stand_in_the_way_of_adding_a_repository() {
+        let mut home = four_repositories();
+        home.begin_refresh();
+        home.preflight_failed(SessionFailure::new("GitHub is not authenticated"));
+
+        let write = home.add_repositories(
+            &settings_path(),
+            vec![picked("/Developer/notes", "/Developer/notes", "acme/notes")],
+        );
+
+        assert!(write.is_some(), "the settings file can still be written");
+        assert!(home.refusals().is_empty());
+    }
+
+    #[test]
+    fn the_next_refresh_clears_the_preflight_failure() {
+        let mut home = four_repositories();
+        home.begin_refresh();
+        home.preflight_failed(SessionFailure::new("GitHub is not authenticated"));
+
+        assert!(home.begin_refresh());
+
+        assert!(home.failure().is_none());
+    }
+
+    #[test]
+    fn a_settings_file_that_cannot_be_read_ends_the_refresh_as_failed() {
+        let mut home = four_repositories();
+        home.begin_refresh();
+
+        home.refreshed(Err(SessionFailure::new(
+            "Home could not read your settings",
+        )));
+
+        assert_eq!(home.refresh_state(), RefreshState::Failed);
+    }
+
+    #[test]
+    fn a_repository_that_could_not_be_fetched_names_itself_its_error_and_its_entry() {
+        let mut home = four_repositories();
+        home.begin_refresh();
+        home.fetching(4);
+
+        home.batch_fetched(vec![unreachable(
+            "acme/billing",
+            "GitHub refused access to acme/billing",
+        )]);
+
+        let failures = home.fetch_failures();
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].slug, "acme/billing");
+        assert_eq!(failures[0].reason, "GitHub refused access to acme/billing");
+        assert_eq!(failures[0].path, Path::new("/Developer/billing"));
+    }
+
+    #[test]
+    fn a_repository_that_could_not_be_fetched_says_so_in_the_footer_and_the_summary() {
+        let mut home = four_repositories();
+        home.begin_refresh();
+        home.fetching(4);
+
+        home.batch_fetched(vec![unreachable("acme/billing", "GitHub refused access")]);
+
+        assert_eq!(
+            home.repository_failure(Path::new("/Developer/billing")),
+            Some("GitHub refused access"),
+        );
+        assert_eq!(
+            home.repository_failure(Path::new("/Developer/widgets")),
+            None,
+        );
+        assert_eq!(home.failed_count(), 1);
+        assert_eq!(home.footer_summary(), "4 repositories \u{00B7} 1 failed");
+    }
+
+    /// A clone that never resolved was never fetched, so its own reason is the
+    /// only thing it has to say.
+    #[test]
+    fn a_clone_that_did_not_resolve_keeps_reporting_its_own_reason() {
+        let mut home = HomeModel::new();
+        home.refreshed(Ok(vec![failed(
+            "/Developer/moved",
+            "the folder no longer exists",
+        )]));
+        home.begin_refresh();
+        home.fetching(0);
+
+        assert_eq!(
+            home.repository_failure(Path::new("/Developer/moved")),
+            Some("the folder no longer exists"),
+        );
+        assert_eq!(home.failed_count(), 1);
+    }
+
+    /// Two checkouts of one repository are two entries with two Removes, and
+    /// the failure belongs to both of them.
+    #[test]
+    fn one_repository_failing_marks_every_clone_that_points_at_it() {
+        let mut home = HomeModel::new();
+        home.refreshed(Ok(vec![
+            valid("/Developer/widgets", "acme/widgets"),
+            valid("/Developer/widgets-worktree", "acme/widgets"),
+        ]));
+        home.begin_refresh();
+        home.fetching(1);
+
+        home.batch_fetched(vec![unreachable("acme/widgets", "GitHub refused access")]);
+
+        assert_eq!(home.fetch_failures().len(), 2);
+        assert_eq!(home.failed_count(), 2);
+    }
+
+    #[test]
+    fn a_refresh_that_succeeds_clears_the_failure_the_last_one_reported() {
+        let mut home = four_repositories();
+        home.begin_refresh();
+        home.fetching(1);
+        home.batch_fetched(vec![unreachable("acme/billing", "GitHub refused access")]);
+        home.finish_refresh(1_700_000_000_000);
+
+        home.begin_refresh();
+        home.fetching(1);
+        home.batch_fetched(vec![empty("acme/billing")]);
+        home.finish_refresh(1_700_000_060_000);
+
+        assert!(home.fetch_failures().is_empty());
+        assert_eq!(home.failed_count(), 0);
+    }
+
+    /// Home listing one row per group, which is what the cursor walks across.
+    fn three_groups() -> HomeModel {
+        let mut changes_requested = fetched(HomeSearch::Authored, 2, 200);
+        changes_requested.changes_requested = true;
+        listing(vec![
+            fetched(HomeSearch::ReviewRequested, 1, 300),
+            changes_requested,
+            fetched(HomeSearch::Authored, 3, 100),
+        ])
+    }
+
+    #[test]
+    fn the_cursor_walks_every_row_across_the_groups() {
+        let mut home = three_groups();
+        assert_eq!(home.cursor(), 0);
+
+        home.move_cursor_down();
+        assert_eq!(home.rows()[home.cursor()].number, 2, "into To address");
+
+        home.move_cursor_down();
+        assert_eq!(home.rows()[home.cursor()].number, 3, "into Waiting");
+
+        home.move_cursor_up();
+        assert_eq!(home.rows()[home.cursor()].number, 2);
+    }
+
+    #[test]
+    fn the_cursor_stops_at_the_ends_of_the_list() {
+        let mut home = three_groups();
+
+        home.move_cursor_up();
+        assert_eq!(home.cursor(), 0);
+
+        for _ in 0..10 {
+            home.move_cursor_down();
+        }
+        assert_eq!(home.cursor(), 2);
+    }
+
+    #[test]
+    fn the_cursor_is_pulled_back_onto_a_list_a_refresh_shortened() {
+        let mut home = three_groups();
+        home.move_cursor_down();
+        home.move_cursor_down();
+        assert_eq!(home.cursor(), 2);
+
+        home.begin_refresh();
+        home.fetching(1);
+        home.batch_fetched(vec![loaded(vec![fetched(
+            HomeSearch::ReviewRequested,
+            1,
+            300,
+        )])]);
+
+        assert_eq!(home.cursor(), 0, "the row it was on is gone");
+    }
+
+    #[test]
+    fn the_cursor_sits_at_the_top_of_a_list_that_has_emptied() {
+        let mut home = three_groups();
+        home.move_cursor_down();
+
+        home.begin_refresh();
+        home.fetching(1);
+        home.batch_fetched(vec![empty("acme/widgets")]);
+
+        assert_eq!(home.cursor(), 0);
+        assert!(home.rows().is_empty());
+    }
+
+    /// A removed clone takes its rows with it, so the list never promises pull
+    /// requests from somewhere Home no longer reads.
+    #[test]
+    fn removing_a_repository_takes_its_rows_out_of_the_list() {
+        let mut home = HomeModel::new();
+        home.refreshed(Ok(vec![
+            valid("/Developer/widgets", "acme/widgets"),
+            valid("/Developer/zreview", "braidonw/zreview"),
+        ]));
+        home.begin_refresh();
+        home.fetching(2);
+        home.batch_fetched(vec![
+            loaded(vec![fetched(HomeSearch::ReviewRequested, 1, 300)]),
+            RepositoryFetch {
+                slug: "braidonw/zreview".to_owned(),
+                outcome: Ok(vec![FetchedPullRequest {
+                    repository: "braidonw/zreview".to_owned(),
+                    ..fetched(HomeSearch::ReviewRequested, 2, 200)
+                }]),
+            },
+        ]);
+        assert_eq!(home.rows().len(), 2);
+
+        home.refreshed(Ok(vec![valid("/Developer/widgets", "acme/widgets")]));
+
+        assert_eq!(home.rows().len(), 1);
+        assert_eq!(home.rows()[0].repository, "acme/widgets");
+    }
+
+    #[test]
+    fn every_status_carries_the_words_its_column_shows() {
+        assert_eq!(CheckStatus::Passing.label(), "checks passing");
+        assert_eq!(CheckStatus::Failing.label(), "checks failing");
+        assert_eq!(CheckStatus::Running.label(), "checks running");
+        assert_eq!(ReviewStatus::ChangesRequested.label(), "changes requested");
+        assert_eq!(ReviewStatus::Approved.label(), "approved");
+        assert_eq!(
+            ReviewStatus::ReviewedThisHead.label(),
+            "you reviewed this head",
+        );
     }
 
     #[test]
@@ -420,6 +1468,53 @@ mod tests {
 
         assert!(home.failure().is_none());
         assert_eq!(home.repositories().len(), 1);
+    }
+
+    #[test]
+    fn the_count_line_counts_the_listed_rows_and_the_configured_repositories() {
+        let mut home = HomeModel::new();
+        home.refreshed(Ok(vec![valid("/Developer/widgets", "acme/widgets")]));
+
+        home.batch_fetched(vec![loaded(vec![
+            fetched(HomeSearch::ReviewRequested, 1, 100),
+            fetched(HomeSearch::Authored, 2, 200),
+        ])]);
+
+        assert_eq!(
+            home.count_line().as_deref(),
+            Some("2 pull requests across 1 repository"),
+        );
+    }
+
+    #[test]
+    fn the_count_line_counts_one_pull_request_in_the_singular() {
+        let mut home = HomeModel::new();
+        home.refreshed(Ok(vec![valid("/Developer/widgets", "acme/widgets")]));
+
+        home.batch_fetched(vec![loaded(vec![fetched(
+            HomeSearch::ReviewRequested,
+            1,
+            100,
+        )])]);
+
+        assert_eq!(
+            home.count_line().as_deref(),
+            Some("1 pull request across 1 repository"),
+        );
+    }
+
+    #[test]
+    fn a_group_holds_only_its_own_rows() {
+        let mut changes_requested = fetched(HomeSearch::Authored, 1, 100);
+        changes_requested.changes_requested = true;
+        let home = listing(vec![
+            fetched(HomeSearch::ReviewRequested, 2, 300),
+            changes_requested,
+        ]);
+
+        assert_eq!(home.rows_in(HomeGroup::ToReview).count(), 1);
+        assert_eq!(home.rows_in(HomeGroup::ToAddress).count(), 1);
+        assert_eq!(home.rows_in(HomeGroup::WaitingOnOthers).count(), 0);
     }
 
     #[test]

--- a/crates/app/src/home.rs
+++ b/crates/app/src/home.rs
@@ -273,7 +273,9 @@ pub enum RefreshState {
 pub struct HomeModel {
     repositories: Vec<RepositoryEntry>,
     settings_failure: Option<SessionFailure>,
-    preflight_failure: Option<SessionFailure>,
+    /// What stopped the last refresh, from the preflight or from the refresh
+    /// giving up part way.
+    refresh_failure: Option<SessionFailure>,
     write_failure: Option<SessionFailure>,
     footer_expanded: bool,
     refusals: Vec<Refusal>,
@@ -319,18 +321,14 @@ impl HomeModel {
         self.clamp_cursor();
     }
 
-    /// Starts a refresh, or leaves the one already running alone.
+    /// Starts a refresh, clearing what stopped the last one.
     ///
-    /// Returns `false` for a trigger that arrived mid-refresh, which is ignored
-    /// rather than queued, so two refreshes never race.
-    #[must_use]
-    pub fn begin_refresh(&mut self) -> bool {
-        if matches!(self.refresh, RefreshState::Refreshing { .. }) {
-            return false;
-        }
-        self.preflight_failure = None;
+    /// Whoever calls this has already established that no other refresh is
+    /// running. The guard that orders Home's actions is what decides that, and
+    /// a second gate here could only ever disagree with it.
+    pub fn begin_refresh(&mut self) {
+        self.refresh_failure = None;
         self.refresh = RefreshState::Refreshing { done: 0, total: 0 };
-        true
     }
 
     /// Stops the refresh before it fetched anything, `gh` being unusable.
@@ -338,30 +336,52 @@ impl HomeModel {
     /// The list stays as it was, because nothing about it has been disproved.
     /// It is the failure block in front of it that says why it is not moving.
     pub fn preflight_failed(&mut self, failure: SessionFailure) {
-        self.preflight_failure = Some(failure);
+        self.refresh_failure = Some(failure);
+        self.refresh = RefreshState::Failed;
+    }
+
+    /// Ends a refresh that stopped without ever finishing.
+    ///
+    /// Called when a refresh is abandoned rather than completed, so the stamp
+    /// stops claiming that repositories are still being counted off. A refresh
+    /// that did finish is left exactly as it left itself.
+    pub fn refresh_abandoned(&mut self) {
+        if !matches!(self.refresh, RefreshState::Refreshing { .. }) {
+            return;
+        }
+        self.refresh_failure = Some(
+            SessionFailure::new("Home could not finish the refresh")
+                .with_remediation("Press r to try again."),
+        );
         self.refresh = RefreshState::Failed;
     }
 
     /// Says how many repositories this refresh is about to fetch.
     ///
-    /// The rows the last refresh listed go now, because from here on this one's
-    /// rows arrive a batch at a time and the two must not be mixed.
+    /// The rows the last refresh listed stay up. Each repository replaces its
+    /// own as it answers, so a reviewer is never left reading a blank list
+    /// while GitHub is asked about it again.
     pub fn fetching(&mut self, total: usize) {
-        self.rows.clear();
-        self.fetch_failures.clear();
         self.loaded_repositories = 0;
         self.failed_repositories = 0;
         self.refresh = RefreshState::Refreshing { done: 0, total };
-        self.clamp_cursor();
     }
 
     /// Takes what one batch of repositories found, advancing the progress count.
+    ///
+    /// A repository's answer replaces everything the last refresh had from it,
+    /// and nothing from anywhere else.
     pub fn batch_fetched(&mut self, batch: Vec<RepositoryFetch>) {
         for fetch in batch {
+            self.rows
+                .retain(|row| !same_slug(&row.repository, &fetch.slug));
+            self.fetch_failures
+                .retain(|failure| !same_slug(&failure.slug, &fetch.slug));
             match fetch.outcome {
                 Ok(pull_requests) => {
                     self.loaded_repositories += 1;
-                    self.rows.extend(pull_requests.into_iter().map(into_row));
+                    self.rows
+                        .extend(one_row_each(pull_requests).into_iter().map(into_row));
                 }
                 Err(reason) => {
                     self.failed_repositories += 1;
@@ -376,14 +396,24 @@ impl HomeModel {
 
     /// Ends the refresh, settled at `at_ms` or failed with nothing to show.
     ///
-    /// A refresh that reached no repository at all is not a failure. There was
-    /// nothing configured to fail.
+    /// A clone that never resolved counts against it as much as one that could
+    /// not be fetched, because either way it listed nothing. A refresh with
+    /// nothing configured at all is not a failure. There was nothing to fail.
     pub fn finish_refresh(&mut self, at_ms: i64) {
-        self.refresh = if self.loaded_repositories == 0 && self.failed_repositories > 0 {
+        let lost = self.failed_repositories + self.unresolved_count();
+        self.refresh = if self.loaded_repositories == 0 && lost > 0 {
             RefreshState::Failed
         } else {
             RefreshState::Refreshed { at_ms }
         };
+    }
+
+    /// How many configured clones never resolved to a repository at all.
+    fn unresolved_count(&self) -> usize {
+        self.repositories
+            .iter()
+            .filter(|entry| entry.slug().is_none())
+            .count()
     }
 
     #[must_use]
@@ -417,9 +447,10 @@ impl HomeModel {
             .find(|entry| entry.path == path)
             .and_then(|entry| {
                 entry.reason().or_else(|| {
+                    let slug = entry.slug()?;
                     self.fetch_failures
                         .iter()
-                        .find(|failure| Some(failure.slug.as_str()) == entry.slug())
+                        .find(|failure| same_slug(&failure.slug, slug))
                         .map(|failure| failure.reason.as_str())
                 })
             })
@@ -447,7 +478,7 @@ impl HomeModel {
         let paths = self
             .repositories
             .iter()
-            .filter(|entry| entry.slug() == Some(slug))
+            .filter(|entry| entry.slug().is_some_and(|listed| same_slug(listed, slug)))
             .map(|entry| entry.path.clone())
             .collect::<Vec<_>>();
         self.fetch_failures
@@ -487,9 +518,10 @@ impl HomeModel {
             .filter_map(RepositoryEntry::slug)
             .map(ToOwned::to_owned)
             .collect::<Vec<_>>();
-        self.rows.retain(|row| listed.contains(&row.repository));
+        self.rows
+            .retain(|row| listed.iter().any(|slug| same_slug(slug, &row.repository)));
         self.fetch_failures
-            .retain(|failure| listed.contains(&failure.slug));
+            .retain(|failure| listed.iter().any(|slug| same_slug(slug, &failure.slug)));
     }
 
     fn clamp_cursor(&mut self) {
@@ -519,7 +551,7 @@ impl HomeModel {
     pub fn failure(&self) -> Option<&SessionFailure> {
         self.settings_failure
             .as_ref()
-            .or(self.preflight_failure.as_ref())
+            .or(self.refresh_failure.as_ref())
     }
 
     /// Why the last write did not reach the file, if it did not.
@@ -689,12 +721,39 @@ fn pull_request_count(count: usize) -> String {
 }
 
 /// Where a group sits in the fixed order Home renders them in.
-const fn group_order(group: HomeGroup) -> usize {
-    match group {
-        HomeGroup::ToReview => 0,
-        HomeGroup::ToAddress => 1,
-        HomeGroup::WaitingOnOthers => 2,
-    }
+fn group_order(group: HomeGroup) -> usize {
+    HomeGroup::ALL
+        .iter()
+        .position(|listed| *listed == group)
+        .expect("every group is in ALL")
+}
+
+/// Whether two slugs name one repository, which GitHub decides without regard
+/// to case, so nothing downstream of it may either.
+fn same_slug(left: &str, right: &str) -> bool {
+    left.eq_ignore_ascii_case(right)
+}
+
+/// Keeps one row per pull request, preferring what the authored search said.
+///
+/// A pull request the reviewer wrote and is also asked to review comes back
+/// from both searches. It is theirs to move along, so the authored row is the
+/// one that survives, and the spec puts it in the authored groups.
+fn one_row_each(pull_requests: Vec<FetchedPullRequest>) -> Vec<FetchedPullRequest> {
+    let authored = pull_requests
+        .iter()
+        .filter(|row| row.search == HomeSearch::Authored)
+        .map(|row| (row.repository.clone(), row.number))
+        .collect::<Vec<_>>();
+    pull_requests
+        .into_iter()
+        .filter(|row| {
+            row.search == HomeSearch::Authored
+                || !authored.iter().any(|(repository, number)| {
+                    *number == row.number && same_slug(repository, &row.repository)
+                })
+        })
+        .collect()
 }
 
 /// Which group a fetched pull request belongs to.
@@ -733,8 +792,11 @@ fn review_status_of(fetched: &FetchedPullRequest) -> Option<ReviewStatus> {
     if fetched.changes_requested {
         return Some(ReviewStatus::ChangesRequested);
     }
-    if matches!(fetched.review_decision, Some(ReviewDecision::Approved)) {
-        return Some(ReviewStatus::Approved);
+    match fetched.review_decision {
+        Some(ReviewDecision::ChangesRequested) => return Some(ReviewStatus::ChangesRequested),
+        Some(ReviewDecision::Approved) => return Some(ReviewStatus::Approved),
+        // Nobody has reviewed it, which is not something a row has to say.
+        Some(ReviewDecision::ReviewRequired) | None => {}
     }
     let reviewed_this_head = fetched
         .viewer_latest_review_sha
@@ -1015,6 +1077,17 @@ mod tests {
         }
     }
 
+    /// One other repository's fetch, having found one pull request.
+    fn elsewhere(slug: &str, number: u64, updated_at_ms: i64) -> RepositoryFetch {
+        RepositoryFetch {
+            slug: slug.to_owned(),
+            outcome: Ok(vec![FetchedPullRequest {
+                repository: slug.to_owned(),
+                ..fetched(HomeSearch::ReviewRequested, number, updated_at_ms)
+            }]),
+        }
+    }
+
     /// One repository's fetch that found nothing, which is not a failure.
     fn empty(slug: &str) -> RepositoryFetch {
         RepositoryFetch {
@@ -1046,7 +1119,7 @@ mod tests {
     fn a_refresh_counts_off_the_repositories_as_each_batch_lands() {
         let mut home = four_repositories();
 
-        assert!(home.begin_refresh());
+        home.begin_refresh();
         assert_eq!(
             home.refresh_state(),
             RefreshState::Refreshing { done: 0, total: 0 },
@@ -1076,27 +1149,9 @@ mod tests {
     }
 
     #[test]
-    fn a_trigger_that_arrives_while_a_refresh_runs_starts_nothing() {
-        let mut home = four_repositories();
-        assert!(home.begin_refresh());
-        home.fetching(4);
-        home.batch_fetched(vec![empty("braidonw/zreview")]);
-
-        assert!(
-            !home.begin_refresh(),
-            "a second trigger is ignored, not queued",
-        );
-        assert_eq!(
-            home.refresh_state(),
-            RefreshState::Refreshing { done: 1, total: 4 },
-            "the running refresh keeps its own progress",
-        );
-    }
-
-    #[test]
     fn a_refresh_where_every_repository_failed_reads_as_failed() {
         let mut home = four_repositories();
-        assert!(home.begin_refresh());
+        home.begin_refresh();
         home.fetching(2);
 
         home.batch_fetched(vec![
@@ -1113,7 +1168,7 @@ mod tests {
     #[test]
     fn a_refresh_where_one_repository_answered_still_settles() {
         let mut home = four_repositories();
-        assert!(home.begin_refresh());
+        home.begin_refresh();
         home.fetching(2);
 
         home.batch_fetched(vec![
@@ -1134,7 +1189,7 @@ mod tests {
     #[test]
     fn a_refresh_with_nothing_configured_settles_rather_than_failing() {
         let mut home = HomeModel::new();
-        assert!(home.begin_refresh());
+        home.begin_refresh();
         home.refreshed(Ok(Vec::new()));
         home.fetching(0);
 
@@ -1151,7 +1206,7 @@ mod tests {
     #[test]
     fn a_preflight_failure_is_the_whole_home_failure_and_ends_the_refresh() {
         let mut home = four_repositories();
-        assert!(home.begin_refresh());
+        home.begin_refresh();
 
         home.preflight_failed(
             SessionFailure::new("GitHub is not authenticated")
@@ -1172,7 +1227,7 @@ mod tests {
     #[test]
     fn a_preflight_failure_does_not_stand_in_the_way_of_adding_a_repository() {
         let mut home = four_repositories();
-        assert!(home.begin_refresh());
+        home.begin_refresh();
         home.preflight_failed(SessionFailure::new("GitHub is not authenticated"));
 
         let write = home.add_repositories(
@@ -1187,10 +1242,10 @@ mod tests {
     #[test]
     fn the_next_refresh_clears_the_preflight_failure() {
         let mut home = four_repositories();
-        assert!(home.begin_refresh());
+        home.begin_refresh();
         home.preflight_failed(SessionFailure::new("GitHub is not authenticated"));
 
-        assert!(home.begin_refresh());
+        home.begin_refresh();
 
         assert!(home.failure().is_none());
     }
@@ -1198,7 +1253,7 @@ mod tests {
     #[test]
     fn a_settings_file_that_cannot_be_read_ends_the_refresh_as_failed() {
         let mut home = four_repositories();
-        assert!(home.begin_refresh());
+        home.begin_refresh();
 
         home.refreshed(Err(SessionFailure::new(
             "Home could not read your settings",
@@ -1210,7 +1265,7 @@ mod tests {
     #[test]
     fn a_repository_that_could_not_be_fetched_names_itself_its_error_and_its_entry() {
         let mut home = four_repositories();
-        assert!(home.begin_refresh());
+        home.begin_refresh();
         home.fetching(4);
 
         home.batch_fetched(vec![unreachable(
@@ -1228,7 +1283,7 @@ mod tests {
     #[test]
     fn a_repository_that_could_not_be_fetched_says_so_in_the_footer_and_the_summary() {
         let mut home = four_repositories();
-        assert!(home.begin_refresh());
+        home.begin_refresh();
         home.fetching(4);
 
         home.batch_fetched(vec![unreachable("acme/billing", "GitHub refused access")]);
@@ -1254,7 +1309,7 @@ mod tests {
             "/Developer/moved",
             "the folder no longer exists",
         )]));
-        assert!(home.begin_refresh());
+        home.begin_refresh();
         home.fetching(0);
 
         assert_eq!(
@@ -1273,7 +1328,7 @@ mod tests {
             valid("/Developer/widgets", "acme/widgets"),
             valid("/Developer/widgets-worktree", "acme/widgets"),
         ]));
-        assert!(home.begin_refresh());
+        home.begin_refresh();
         home.fetching(1);
 
         home.batch_fetched(vec![unreachable("acme/widgets", "GitHub refused access")]);
@@ -1285,12 +1340,12 @@ mod tests {
     #[test]
     fn a_refresh_that_succeeds_clears_the_failure_the_last_one_reported() {
         let mut home = four_repositories();
-        assert!(home.begin_refresh());
+        home.begin_refresh();
         home.fetching(1);
         home.batch_fetched(vec![unreachable("acme/billing", "GitHub refused access")]);
         home.finish_refresh(1_700_000_000_000);
 
-        assert!(home.begin_refresh());
+        home.begin_refresh();
         home.fetching(1);
         home.batch_fetched(vec![empty("acme/billing")]);
         home.finish_refresh(1_700_000_060_000);
@@ -1345,7 +1400,7 @@ mod tests {
         home.move_cursor_down();
         assert_eq!(home.cursor(), 2);
 
-        assert!(home.begin_refresh());
+        home.begin_refresh();
         home.fetching(1);
         home.batch_fetched(vec![loaded(vec![fetched(
             HomeSearch::ReviewRequested,
@@ -1361,7 +1416,7 @@ mod tests {
         let mut home = three_groups();
         home.move_cursor_down();
 
-        assert!(home.begin_refresh());
+        home.begin_refresh();
         home.fetching(1);
         home.batch_fetched(vec![empty("acme/widgets")]);
 
@@ -1378,7 +1433,7 @@ mod tests {
             valid("/Developer/widgets", "acme/widgets"),
             valid("/Developer/zreview", "braidonw/zreview"),
         ]));
-        assert!(home.begin_refresh());
+        home.begin_refresh();
         home.fetching(2);
         home.batch_fetched(vec![
             loaded(vec![fetched(HomeSearch::ReviewRequested, 1, 300)]),
@@ -1396,6 +1451,211 @@ mod tests {
 
         assert_eq!(home.rows().len(), 1);
         assert_eq!(home.rows()[0].repository, "acme/widgets");
+    }
+
+    /// A pull request the reviewer wrote and is also asked to review, which a
+    /// team review request makes possible.
+    #[test]
+    fn a_pull_request_in_both_searches_is_listed_once_among_the_authored_groups() {
+        let mut authored = fetched(HomeSearch::Authored, 412, 100);
+        authored.changes_requested = true;
+
+        let home = listing(vec![
+            fetched(HomeSearch::ReviewRequested, 412, 100),
+            authored,
+        ]);
+
+        assert_eq!(home.rows().len(), 1, "one pull request is one row");
+        assert_eq!(home.rows()[0].group, HomeGroup::ToAddress);
+    }
+
+    #[test]
+    fn a_review_request_the_reviewer_asked_changes_of_stays_in_to_review() {
+        let mut asked = fetched(HomeSearch::ReviewRequested, 412, 100);
+        asked.changes_requested = true;
+
+        let home = listing(vec![asked]);
+
+        let row = only_row(&home);
+        assert_eq!(row.group, HomeGroup::ToReview);
+        assert_eq!(row.review_status, Some(ReviewStatus::ChangesRequested));
+    }
+
+    /// GitHub's own decision is a review status in its own right, on a pull
+    /// request whose standing reviews said nothing.
+    #[test]
+    fn a_changes_requested_decision_alone_is_a_review_status() {
+        let mut decided = fetched(HomeSearch::Authored, 412, 100);
+        decided.review_decision = Some(ReviewDecision::ChangesRequested);
+
+        let home = listing(vec![decided]);
+
+        let row = only_row(&home);
+        assert_eq!(row.review_status, Some(ReviewStatus::ChangesRequested));
+        assert_eq!(
+            row.group,
+            HomeGroup::WaitingOnOthers,
+            "grouping stays on the standing reviews the To address rule names",
+        );
+    }
+
+    /// A remote spelled in mixed case is the same repository, and every later
+    /// read of the settings file has to agree that it is.
+    #[test]
+    fn a_repository_spelled_in_another_case_keeps_its_rows() {
+        let mut home = HomeModel::new();
+        home.refreshed(Ok(vec![valid("/Developer/widgets", "Acme/Widgets")]));
+        home.begin_refresh();
+        home.fetching(1);
+        home.batch_fetched(vec![loaded(vec![fetched(
+            HomeSearch::ReviewRequested,
+            412,
+            100,
+        )])]);
+        assert_eq!(home.rows().len(), 1);
+
+        home.refreshed(Ok(vec![valid("/Developer/widgets", "Acme/Widgets")]));
+
+        assert_eq!(home.rows().len(), 1, "the row survives a re-read");
+        assert_eq!(
+            home.repository_failure(Path::new("/Developer/widgets")),
+            None,
+        );
+    }
+
+    #[test]
+    fn two_clones_of_one_repository_spelled_differently_both_carry_its_failure() {
+        let mut home = HomeModel::new();
+        home.refreshed(Ok(vec![
+            valid("/Developer/widgets", "acme/widgets"),
+            valid("/Developer/Widgets", "Acme/Widgets"),
+        ]));
+        home.begin_refresh();
+        home.fetching(1);
+
+        home.batch_fetched(vec![unreachable("acme/widgets", "GitHub refused access")]);
+
+        assert_eq!(home.fetch_failures().len(), 2);
+        assert_eq!(
+            home.refresh_state(),
+            RefreshState::Refreshing { done: 1, total: 1 },
+            "one repository answered for both clones",
+        );
+    }
+
+    /// Nothing could be listed, which is a failed refresh however far it got.
+    #[test]
+    fn a_refresh_of_clones_that_none_of_them_resolved_reads_as_failed() {
+        let mut home = HomeModel::new();
+        home.refreshed(Ok(vec![failed(
+            "/Developer/moved",
+            "the folder no longer exists",
+        )]));
+        home.begin_refresh();
+        home.fetching(0);
+
+        home.finish_refresh(1_700_000_000_000);
+
+        assert_eq!(home.refresh_state(), RefreshState::Failed);
+    }
+
+    /// The rows a reviewer is reading stay up while the next refresh runs, and
+    /// each repository replaces its own as it answers.
+    #[test]
+    fn a_running_refresh_replaces_the_rows_one_repository_at_a_time() {
+        let mut home = HomeModel::new();
+        home.refreshed(Ok(vec![
+            valid("/Developer/widgets", "acme/widgets"),
+            valid("/Developer/zreview", "braidonw/zreview"),
+        ]));
+        home.begin_refresh();
+        home.fetching(2);
+        home.batch_fetched(vec![
+            loaded(vec![fetched(HomeSearch::ReviewRequested, 1, 300)]),
+            elsewhere("braidonw/zreview", 2, 200),
+        ]);
+        home.finish_refresh(1_700_000_000_000);
+
+        home.begin_refresh();
+        home.fetching(2);
+        assert_eq!(
+            home.rows().len(),
+            2,
+            "the list a reviewer is reading stays up while the next refresh runs",
+        );
+
+        home.batch_fetched(vec![loaded(vec![
+            fetched(HomeSearch::ReviewRequested, 1, 300),
+            fetched(HomeSearch::ReviewRequested, 3, 400),
+        ])]);
+
+        let listed = home
+            .rows()
+            .iter()
+            .map(|row| (row.repository.clone(), row.number))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            listed,
+            [
+                ("acme/widgets".to_owned(), 3),
+                ("acme/widgets".to_owned(), 1),
+                ("braidonw/zreview".to_owned(), 2),
+            ],
+            "only the repository that answered was replaced",
+        );
+    }
+
+    #[test]
+    fn a_repository_that_answers_with_nothing_takes_its_rows_out_of_the_list() {
+        let mut home = HomeModel::new();
+        home.refreshed(Ok(vec![valid("/Developer/widgets", "acme/widgets")]));
+        home.begin_refresh();
+        home.fetching(1);
+        home.batch_fetched(vec![loaded(vec![fetched(
+            HomeSearch::ReviewRequested,
+            1,
+            300,
+        )])]);
+
+        home.begin_refresh();
+        home.fetching(1);
+        home.batch_fetched(vec![empty("acme/widgets")]);
+
+        assert!(home.rows().is_empty());
+    }
+
+    /// A refresh that stopped without finishing leaves a stamp that would
+    /// otherwise claim for ever that it is still running.
+    #[test]
+    fn a_refresh_that_was_abandoned_ends_as_failed_with_a_reason() {
+        let mut home = four_repositories();
+        home.begin_refresh();
+        home.fetching(4);
+
+        home.refresh_abandoned();
+
+        assert_eq!(home.refresh_state(), RefreshState::Failed);
+        let failure = home.failure().expect("an abandoned refresh says so");
+        assert_eq!(failure.summary, "Home could not finish the refresh");
+    }
+
+    #[test]
+    fn a_refresh_that_finished_is_not_marked_abandoned() {
+        let mut home = four_repositories();
+        home.begin_refresh();
+        home.fetching(1);
+        home.batch_fetched(vec![empty("braidonw/zreview")]);
+        home.finish_refresh(1_700_000_000_000);
+
+        home.refresh_abandoned();
+
+        assert_eq!(
+            home.refresh_state(),
+            RefreshState::Refreshed {
+                at_ms: 1_700_000_000_000,
+            },
+        );
+        assert!(home.failure().is_none());
     }
 
     #[test]

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -19,7 +19,11 @@ mod review;
 mod session;
 
 pub use handoff::Handoff;
-pub use home::{HomeGroup, HomeModel, Refusal, RepositoryEntry, RepositoryOutcome, SettingsWrite};
+pub use home::{
+    CheckState, CheckStatus, FetchFailure, FetchedPullRequest, HomeGroup, HomeModel, HomeRow,
+    HomeSearch, RefreshState, Refusal, RepositoryEntry, RepositoryFetch, RepositoryOutcome,
+    ReviewDecision, ReviewStatus, SettingsWrite,
+};
 pub use review::{FindingDisposition, ReviewModel, ReviewRunState};
 pub use session::{PendingSend, SessionModel, SessionPhase, SubmissionState};
 

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -11,7 +11,7 @@
 //! [`domain::ReviewStateSink`] and [`domain::ReviewSubmitter`]. Nothing here
 //! knows about a database, a forge, or a UI framework.
 
-use std::sync::{Mutex, MutexGuard, PoisonError};
+use std::sync::{Mutex, MutexGuard, PoisonError, TryLockError};
 
 mod handoff;
 mod home;
@@ -32,4 +32,17 @@ pub use session::{PendingSend, SessionModel, SessionPhase, SubmissionState};
 /// poisoned it.
 pub fn lock<T>(model: &Mutex<T>) -> MutexGuard<'_, T> {
     model.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+/// Takes a model's lock only if it is free, recovering from poisoning as
+/// [`lock`] does.
+///
+/// `None` means somebody else holds it, which is an answer rather than a wait.
+/// An action that would rather be dropped than queued asks with this.
+pub fn try_lock<T>(model: &Mutex<T>) -> Option<MutexGuard<'_, T>> {
+    match model.try_lock() {
+        Ok(guard) => Some(guard),
+        Err(TryLockError::Poisoned(poisoned)) => Some(poisoned.into_inner()),
+        Err(TryLockError::WouldBlock) => None,
+    }
 }

--- a/crates/github/src/home.rs
+++ b/crates/github/src/home.rs
@@ -25,10 +25,7 @@ use crate::{
 /// GitHub documents a 256 character ceiling on a search query and at most five
 /// boolean operators, and eight `repo:` terms is what fits under the advanced
 /// syntax the query plan was measured against.
-///
-/// Public because a caller that reports progress per batch has to ask for one
-/// batch at a time, and a batch is this many repositories.
-pub const REPOSITORIES_PER_BATCH: usize = 8;
+const REPOSITORIES_PER_BATCH: usize = 8;
 
 /// GitHub serves at most 1,000 search results, which is twenty pages of fifty.
 /// Anything past that is a runaway rather than a long list.
@@ -40,6 +37,13 @@ const MAX_THREAD_PAGES: usize = 20;
 
 /// How long one `gh api graphql` call may take before it is killed.
 pub const DEFAULT_GRAPHQL_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// How long `gh auth status` may take before it is killed.
+///
+/// Shorter than a fetch because it asks nothing of the network, and it runs
+/// while the settings actions are held, so a `gh` waiting on a keychain prompt
+/// must not be able to freeze Home behind it.
+pub const DEFAULT_AUTHENTICATION_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// How often a running `gh` is checked for having exited.
 const POLL_INTERVAL: Duration = Duration::from_millis(5);
@@ -173,7 +177,23 @@ impl GithubClient {
     /// entry per distinct repository.
     #[must_use]
     pub fn fetch_home_pull_requests(&self, repositories: &[RepositorySlug]) -> HomeFetch {
-        let requested = distinct(repositories);
+        self.fetch_home_pull_requests_with_progress(repositories, &|_batch| {})
+    }
+
+    /// Fetches as [`Self::fetch_home_pull_requests`] does, handing each batch's
+    /// answer to `on_batch` as soon as it arrives.
+    ///
+    /// A caller showing progress, or filling a list in as it loads, reads each
+    /// batch here rather than waiting for the last one. Every batch is in the
+    /// returned fetch as well, so a caller with no use for progress sees no
+    /// difference.
+    #[must_use]
+    pub fn fetch_home_pull_requests_with_progress(
+        &self,
+        repositories: &[RepositorySlug],
+        on_batch: &dyn Fn(&HomeFetch),
+    ) -> HomeFetch {
+        let requested = distinct_repositories(repositories);
         let mut fetch = HomeFetch {
             viewer_login: None,
             rate_limit: None,
@@ -182,15 +202,20 @@ impl GithubClient {
 
         for batch in requested.chunks(REPOSITORIES_PER_BATCH) {
             let fetched = self.fetch_batch(batch);
+            let answered = HomeFetch {
+                viewer_login: fetched.viewer_login,
+                rate_limit: fetched.rate_limit,
+                repositories: into_repositories(batch, fetched.pull_requests),
+            };
+            on_batch(&answered);
+
             if fetch.viewer_login.is_none() {
-                fetch.viewer_login = fetched.viewer_login;
+                fetch.viewer_login = answered.viewer_login;
             }
-            if fetched.rate_limit.is_some() {
-                fetch.rate_limit = fetched.rate_limit;
+            if answered.rate_limit.is_some() {
+                fetch.rate_limit = answered.rate_limit;
             }
-            fetch
-                .repositories
-                .extend(into_repositories(batch, fetched.pull_requests));
+            fetch.repositories.extend(answered.repositories);
         }
 
         fetch
@@ -414,46 +439,59 @@ impl GithubClient {
 
     /// Spawns `gh` with stdin closed and kills it if it outlives the timeout.
     fn run_gh(&self, arguments: &[String]) -> Result<Output, GithubError> {
-        let mut child = Command::new(&self.gh_executable)
-            .args(arguments)
-            .env("GH_PROMPT_DISABLED", "1")
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .map_err(spawn_error)?;
+        let mut command = Command::new(&self.gh_executable);
+        command.args(arguments);
+        run_bounded(command, self.graphql_timeout, spawn_error)
+    }
+}
 
-        // Both pipes are drained on their own threads, so a large response
-        // cannot fill a pipe buffer and deadlock the child against this wait.
-        let stdout = drain(child.stdout.take());
-        let stderr = drain(child.stderr.take());
+/// Runs `command` with stdin closed, killing it if it outlives `timeout`.
+///
+/// Every call `gh` is asked to make is bounded here, so nothing it does, on the
+/// network or at a keychain prompt, can hold a caller for ever.
+pub(crate) fn run_bounded(
+    mut command: Command,
+    timeout: Duration,
+    on_spawn_failure: impl Fn(std::io::Error) -> GithubError,
+) -> Result<Output, GithubError> {
+    let mut child = command
+        .env("GH_PROMPT_DISABLED", "1")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(&on_spawn_failure)?;
 
-        let deadline = Instant::now() + self.graphql_timeout;
-        loop {
-            match child.try_wait() {
-                Ok(Some(status)) => {
-                    // A process gh started can outlive it holding these pipes, so
-                    // reading them is bounded by the same deadline as the wait.
-                    return Ok(Output {
-                        status,
-                        stdout: stdout.collect(deadline, self.graphql_timeout)?,
-                        stderr: stderr.collect(deadline, self.graphql_timeout)?,
-                    });
-                }
-                Ok(None) => {}
-                Err(source) => return Err(spawn_error(source)),
-            }
-            if Instant::now() >= deadline {
-                // The readers are left to unwind on their own. Joining them here
-                // would wait on any grandchild still holding the pipe open.
-                let _ = child.kill();
-                let _ = child.wait();
-                return Err(GithubError::Timeout {
-                    timeout_ms: timeout_ms(self.graphql_timeout),
+    // Both pipes are drained on their own threads, so a large response
+    // cannot fill a pipe buffer and deadlock the child against this wait.
+    let stdout = drain(child.stdout.take());
+    let stderr = drain(child.stderr.take());
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                // A process gh started can outlive it holding these pipes, so
+                // reading them is bounded by the same deadline as the wait.
+                return Ok(Output {
+                    status,
+                    stdout: stdout.collect(deadline, timeout)?,
+                    stderr: stderr.collect(deadline, timeout)?,
                 });
             }
-            std::thread::sleep(POLL_INTERVAL);
+            Ok(None) => {}
+            Err(source) => return Err(on_spawn_failure(source)),
         }
+        if Instant::now() >= deadline {
+            // The readers are left to unwind on their own. Joining them here
+            // would wait on any grandchild still holding the pipe open.
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(GithubError::Timeout {
+                timeout_ms: timeout_ms(timeout),
+            });
+        }
+        std::thread::sleep(POLL_INTERVAL);
     }
 }
 
@@ -796,7 +834,11 @@ fn strip_cursors(rows: Vec<CollectedRow>) -> Vec<HomePullRequest> {
 }
 
 /// Keeps the first occurrence of each repository, comparing the way GitHub does.
-fn distinct(repositories: &[RepositorySlug]) -> Vec<RepositorySlug> {
+///
+/// Public because a caller has to be able to say how many repositories a fetch
+/// will answer for before it starts, and that is this many.
+#[must_use]
+pub fn distinct_repositories(repositories: &[RepositorySlug]) -> Vec<RepositorySlug> {
     let mut seen = Vec::new();
     let mut kept = Vec::new();
     for repository in repositories {
@@ -1294,6 +1336,60 @@ mod tests {
         );
     }
 
+    /// A caller that fills a list in as it loads reads each batch as it lands,
+    /// so it has to be handed one the moment it is answered.
+    #[test]
+    fn every_batch_is_reported_as_it_answers_and_again_at_the_end() {
+        let fake = FakeGh::new();
+        fake.respond(EMPTY_RESPONSE).respond(EMPTY_RESPONSE);
+        let reported = std::cell::RefCell::new(Vec::new());
+
+        let fetch = GithubClient::new(fake.path()).fetch_home_pull_requests_with_progress(
+            &slugs(1..=9),
+            &|batch| {
+                reported.borrow_mut().push(
+                    batch
+                        .repositories
+                        .iter()
+                        .map(|repository| repository.repository.full_name())
+                        .collect::<Vec<_>>(),
+                );
+            },
+        );
+
+        let reported = reported.into_inner();
+        assert_eq!(reported.len(), 2, "one report per batch");
+        assert_eq!(reported[0].len(), 8);
+        assert_eq!(reported[1], ["acme/repo-9"]);
+        assert_eq!(fetch.repositories.len(), 9);
+    }
+
+    /// Two clones of one repository that spell it differently are one fetch, so
+    /// a caller counting repositories off never waits on a ninth that is really
+    /// the first again.
+    #[test]
+    fn repositories_that_differ_only_in_case_are_fetched_once() {
+        let fake = FakeGh::new();
+        fake.respond(EMPTY_RESPONSE);
+
+        let fetch = GithubClient::new(fake.path()).fetch_home_pull_requests(&[
+            RepositorySlug::new("acme", "widgets"),
+            RepositorySlug::new("Acme", "Widgets"),
+        ]);
+
+        assert_eq!(fake.calls(), 1);
+        assert_eq!(fetch.repositories.len(), 1);
+        assert_eq!(
+            super::distinct_repositories(&[
+                RepositorySlug::new("acme", "widgets"),
+                RepositorySlug::new("Acme", "Widgets"),
+            ])
+            .len(),
+            1,
+            "a caller asking how many will answer gets the same count",
+        );
+    }
+
     #[test]
     fn an_alias_with_more_results_is_paged_by_cursor_until_exhausted() {
         let fake = FakeGh::new();
@@ -1685,6 +1781,31 @@ mod tests {
 
     /// A refresh that hangs would leave Home refreshing forever, so the call is
     /// killed rather than waited on.
+    /// The preflight runs while Home's settings actions are held, so a `gh`
+    /// waiting on a keychain prompt must not be able to freeze them behind it.
+    #[test]
+    fn an_authentication_check_that_outlives_its_timeout_is_killed_and_reported() {
+        let fake = FakeGh::new();
+        fake.hang(10);
+        let clone = TempDir::new().unwrap();
+
+        let started = Instant::now();
+        let error = GithubClient::new(fake.path())
+            .with_authentication_timeout(Duration::from_millis(150))
+            .check_authentication(clone.path())
+            .expect_err("a gh that never answers cannot say it is signed in");
+        let elapsed = started.elapsed();
+
+        assert!(
+            matches!(error, GithubError::Timeout { timeout_ms: 150 }),
+            "unexpected error: {error}",
+        );
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "the check waited {elapsed:?} on a gh it should have killed",
+        );
+    }
+
     #[test]
     fn a_call_that_outlives_its_timeout_is_killed_and_reported() {
         let fake = FakeGh::new();

--- a/crates/github/src/home.rs
+++ b/crates/github/src/home.rs
@@ -25,7 +25,10 @@ use crate::{
 /// GitHub documents a 256 character ceiling on a search query and at most five
 /// boolean operators, and eight `repo:` terms is what fits under the advanced
 /// syntax the query plan was measured against.
-const REPOSITORIES_PER_BATCH: usize = 8;
+///
+/// Public because a caller that reports progress per batch has to ask for one
+/// batch at a time, and a batch is this many repositories.
+pub const REPOSITORIES_PER_BATCH: usize = 8;
 
 /// GitHub serves at most 1,000 search results, which is twenty pages of fifty.
 /// Anything past that is a runaway rather than a long list.

--- a/crates/github/src/lib.rs
+++ b/crates/github/src/lib.rs
@@ -14,9 +14,9 @@ use thiserror::Error;
 mod home;
 
 pub use home::{
-    DEFAULT_GRAPHQL_TIMEOUT, HomeFetch, HomePullRequest, HomeRepository, HomeSearch,
-    OpinionatedReview, REPOSITORIES_PER_BATCH, RateLimit, ReviewDecision, ReviewState,
-    ReviewThread, StatusCheckState,
+    DEFAULT_AUTHENTICATION_TIMEOUT, DEFAULT_GRAPHQL_TIMEOUT, HomeFetch, HomePullRequest,
+    HomeRepository, HomeSearch, OpinionatedReview, RateLimit, ReviewDecision, ReviewState,
+    ReviewThread, StatusCheckState, distinct_repositories,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -290,6 +290,7 @@ impl GithubError {
 pub struct GithubClient {
     gh_executable: PathBuf,
     graphql_timeout: Duration,
+    authentication_timeout: Duration,
 }
 
 impl Default for GithubClient {
@@ -304,6 +305,7 @@ impl GithubClient {
         Self {
             gh_executable: executable.into(),
             graphql_timeout: DEFAULT_GRAPHQL_TIMEOUT,
+            authentication_timeout: DEFAULT_AUTHENTICATION_TIMEOUT,
         }
     }
 
@@ -311,6 +313,13 @@ impl GithubClient {
     #[must_use]
     pub const fn with_graphql_timeout(mut self, timeout: Duration) -> Self {
         self.graphql_timeout = timeout;
+        self
+    }
+
+    /// Sets how long the authentication check may run before `gh` is killed.
+    #[must_use]
+    pub const fn with_authentication_timeout(mut self, timeout: Duration) -> Self {
+        self.authentication_timeout = timeout;
         self
     }
 
@@ -379,15 +388,15 @@ impl GithubClient {
     ///
     /// # Errors
     ///
-    /// Returns [`GithubError::GhMissing`] when the CLI is not installed and
-    /// [`GithubError::Unauthenticated`] when it is not logged in.
+    /// Returns [`GithubError::GhMissing`] when the CLI is not installed,
+    /// [`GithubError::Unauthenticated`] when it is not logged in, and
+    /// [`GithubError::Timeout`] when `gh` does not answer in time.
     pub fn check_authentication(&self, repository: &Path) -> Result<(), GithubError> {
-        let output = Command::new(&self.gh_executable)
-            .current_dir(repository)
-            .args(["auth", "status"])
-            .env("GH_PROMPT_DISABLED", "1")
-            .output()
-            .map_err(|source| execution_error(repository, source))?;
+        let mut command = Command::new(&self.gh_executable);
+        command.current_dir(repository).args(["auth", "status"]);
+        let output = home::run_bounded(command, self.authentication_timeout, |source| {
+            execution_error(repository, source)
+        })?;
 
         if output.status.success() {
             return Ok(());

--- a/crates/github/src/lib.rs
+++ b/crates/github/src/lib.rs
@@ -15,7 +15,8 @@ mod home;
 
 pub use home::{
     DEFAULT_GRAPHQL_TIMEOUT, HomeFetch, HomePullRequest, HomeRepository, HomeSearch,
-    OpinionatedReview, RateLimit, ReviewDecision, ReviewState, ReviewThread, StatusCheckState,
+    OpinionatedReview, REPOSITORIES_PER_BATCH, RateLimit, ReviewDecision, ReviewState,
+    ReviewThread, StatusCheckState,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -876,7 +877,12 @@ fn parse_remote_url(value: &str) -> Option<RepositorySlug> {
     parse_full_name(path)
 }
 
-fn parse_full_name(value: &str) -> Option<RepositorySlug> {
+/// Reads `owner/name` back into a slug, refusing anything else.
+///
+/// Public so a caller holding a formatted slug can ask for it in the shape the
+/// fetches take, without a parse of its own that could disagree with this one.
+#[must_use]
+pub fn parse_full_name(value: &str) -> Option<RepositorySlug> {
     let (owner, name) = value.split_once('/')?;
     if name.contains('/')
         || validate_slug_component(owner, value).is_err()


### PR DESCRIPTION
Closes #16

Home could manage its repositories but listed nothing. This is the slice that makes it useful. A refresh preflights gh, fetches every configured repository, and groups the pull requests by what each one wants from the reviewer.

What changed:
- A refresh preflights gh, re-reads the settings file, then fetches in batches, filling the list in as each batch lands and reporting progress in the header stamp
- Rows are grouped locally into To review, To address, and Waiting on others by the decided rules, newest first, with check and review status in fixed columns
- The refreshed stamp shows progress, a relative time, or Refresh failed, and is hidden until the first refresh
- j and k move a cursor across every group, clamped when the list shortens, scrolling the row into view
- A failed repository shows its error in the footer and as a line above To review with Remove; an unauthenticated gh replaces the list with the remediation block until r after fixing it
- A trigger during a running refresh is ignored and leaves the screen alone, a panic during a refresh ends it as failed rather than wedging it, and the preflight has a timeout
- The github crate owns batching and dedup and reports each batch to the caller; slugs are compared case-insensitively everywhere

Notes:
Start with the grouping and status rules in the Home model, then the refresh orchestration in the commands module. Opening a row, the Drafts count, and refresh on window focus are later tickets. The layout could not be seen from an agent session, so please launch it with a configured repository and check the columns against the prototype.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189um4LrckqAAq5fgnixT1p
