### PR TITLE
Show the Drafts count on Home rows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1733,6 +1733,7 @@ dependencies = [
  "settings",
  "specta",
  "specta-typescript",
+ "store",
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -21,6 +21,7 @@ domain.workspace = true
 github.workspace = true
 session.workspace = true
 settings.workspace = true
+store.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tauri = { version = "=2.11.5", features = [] }

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -14,7 +14,7 @@ use session::{ReviewStorage, SessionRequest};
 use tauri::ipc::Channel;
 use tauri_specta::collect_commands;
 
-use crate::{AppRoot, ManagedHome, ManagedSession, dto, pull_requests, repositories};
+use crate::{AppRoot, ManagedHome, ManagedSession, drafts, dto, pull_requests, repositories};
 
 /// The specta builder, shared between the invoke handler and the bindings export.
 #[must_use]
@@ -41,11 +41,16 @@ pub fn specta_builder() -> tauri_specta::Builder<tauri::Wry> {
 /// It is not queued, because a refresh only ever asks what is true now, and the
 /// one already running is about to answer that.
 ///
+/// Once the fetch has landed, `database_path` is read for the Drafts count on
+/// every row. A missing database means no Drafts anywhere; anything else that
+/// stops it opening or reading is the failure Home shows above the list.
+///
 /// Takes the reporter as a plain callback so it can be tested without a Tauri
 /// channel, as `run_load` does.
 fn refresh_home_on_model(
     home: &ManagedHome,
     settings_path: &Path,
+    database_path: &Path,
     report: &dyn Fn(dto::HomeSnapshotDto),
 ) {
     let Some(_ordered) = try_lock(&home.settings_action) else {
@@ -79,6 +84,8 @@ fn refresh_home_on_model(
         lock(&home.model).batch_fetched(batch);
         report_home(home, report);
     });
+    let fetched_rows = lock(&home.model).rows().to_vec();
+    lock(&home.model).drafts_read(drafts::read(database_path, &fetched_rows));
     lock(&home.model).finish_refresh(now_ms());
     report_home(home, report);
 }
@@ -471,7 +478,9 @@ pub async fn refresh_home(
     let home = state.home.clone();
     off_the_ui_thread(move || {
         on_settings_file(&home, |home, settings_path| {
-            refresh_home_on_model(home, settings_path, &|shown| {
+            let database_path = store::default_database_path()
+                .expect("HOME is set, since the settings path just resolved from it");
+            refresh_home_on_model(home, settings_path, &database_path, &|shown| {
                 let _ = on_progress.send(shown);
             });
         })
@@ -994,9 +1003,15 @@ mod tests {
         settings::load(settings_path).unwrap().repositories
     }
 
+    /// A database path guaranteed not to exist, for tests that are not
+    /// exercising Drafts and want a refresh to see none.
+    fn no_drafts_database() -> PathBuf {
+        TempDir::new().unwrap().path().join("review-data.sqlite3")
+    }
+
     /// A refresh with nothing listening to its progress.
     fn refresh(home: &ManagedHome, settings_path: &Path) {
-        refresh_home_on_model(home, settings_path, &|_progress| {});
+        refresh_home_on_model(home, settings_path, &no_drafts_database(), &|_progress| {});
     }
 
     /// A settings file listing `clones`.
@@ -1077,7 +1092,7 @@ mod tests {
     /// Everything a refresh reported, in the order it said it.
     fn reported_by(home: &ManagedHome, settings_path: &Path) -> Vec<dto::HomeSnapshotDto> {
         let reported = Mutex::new(Vec::new());
-        refresh_home_on_model(home, settings_path, &|shown| {
+        refresh_home_on_model(home, settings_path, &no_drafts_database(), &|shown| {
             reported.lock().unwrap().push(shown);
         });
         reported.into_inner().unwrap()
@@ -1178,7 +1193,7 @@ mod tests {
         let reports = std::sync::atomic::AtomicUsize::new(0);
 
         let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            refresh_home_on_model(&home, &settings_path, &|_shown| {
+            refresh_home_on_model(&home, &settings_path, &no_drafts_database(), &|_shown| {
                 assert!(
                     reports.fetch_add(1, Ordering::AcqRel) < 2,
                     "the refresh gave up here"
@@ -1205,7 +1220,9 @@ mod tests {
         let settings_path = settings_listing(&directory, &[&clone]);
         let home = home_with(&gh);
         let _panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            refresh_home_on_model(&home, &settings_path, &|_shown| panic!("gave up"));
+            refresh_home_on_model(&home, &settings_path, &no_drafts_database(), &|_shown| {
+                panic!("gave up")
+            });
         }));
 
         refresh(&home, &settings_path);

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -84,8 +84,10 @@ fn refresh_home_on_model(
         lock(&home.model).batch_fetched(batch);
         report_home(home, report);
     });
-    let fetched_rows = lock(&home.model).rows().to_vec();
-    lock(&home.model).drafts_read(drafts::read(database_path, &fetched_rows));
+    // Evaluated before the lock is taken, so the store open and query never
+    // hold the model mutex against every other command waiting on it.
+    let drafts_result = drafts::read(database_path);
+    lock(&home.model).drafts_read(drafts_result);
     lock(&home.model).finish_refresh(now_ms());
     report_home(home, report);
 }

--- a/apps/desktop/src-tauri/src/drafts.rs
+++ b/apps/desktop/src-tauri/src/drafts.rs
@@ -8,30 +8,35 @@ use std::{collections::HashMap, path::Path};
 use domain::SessionFailure;
 use store::{ReviewStore, StoreError};
 
-/// Counts of stored Drafts per row, keyed by [`app::HomeRow::draft_scope`].
+/// Every stored Drafts count, by scope.
 ///
-/// A database that does not exist yet means no Drafts anywhere, which is not a
-/// failure.
+/// The table is the reviewer's own unsent comments, never large enough to ask
+/// for less than all of it, so the model joins rows onto this rather than the
+/// other way around. A database that does not exist yet means no Drafts
+/// anywhere, which is not a failure.
 ///
 /// # Errors
 ///
 /// Returns what Home shows above the list when the database cannot be opened
 /// or read.
-pub(crate) fn read(
-    database_path: &Path,
-    rows: &[app::HomeRow],
-) -> Result<HashMap<String, usize>, SessionFailure> {
+pub(crate) fn read(database_path: &Path) -> Result<HashMap<String, usize>, SessionFailure> {
     let store = match ReviewStore::open_read_only(database_path) {
         Ok(store) => store,
         Err(StoreError::Missing) => return Ok(HashMap::new()),
-        Err(error) => return Err(drafts_failure(&error)),
+        Err(
+            error @ (StoreError::CreateDirectory { .. }
+            | StoreError::Open(_)
+            | StoreError::Migrate(_)
+            | StoreError::Read(_)
+            | StoreError::Write(_)
+            | StoreError::UnknownSide(_)
+            | StoreError::UnknownOrigin(_)
+            | StoreError::NoHomeDirectory
+            | StoreError::UnsupportedSchemaVersion(_)),
+        ) => return Err(drafts_failure(&error)),
     };
-    let scopes = rows
-        .iter()
-        .map(app::HomeRow::draft_scope)
-        .collect::<Vec<_>>();
     store
-        .count_by_scopes(&scopes)
+        .count_by_scope()
         .map_err(|error| drafts_failure(&error))
 }
 
@@ -45,27 +50,12 @@ mod tests {
 
     use super::*;
 
-    fn row(repository: &str, number: u64) -> app::HomeRow {
-        app::HomeRow {
-            group: app::HomeGroup::ToReview,
-            repository: repository.to_owned(),
-            number,
-            title: "a pull request".to_owned(),
-            url: format!("https://github.com/{repository}/pull/{number}"),
-            author_login: None,
-            updated_at_ms: 0,
-            review_status: None,
-            check_status: None,
-            drafts: None,
-        }
-    }
-
     #[test]
     fn a_missing_database_reads_as_no_drafts() {
         let directory = TempDir::new().unwrap();
         let path = directory.path().join("review-data.sqlite3");
 
-        let counts = read(&path, &[row("acme/widgets", 412)]).unwrap();
+        let counts = read(&path).unwrap();
 
         assert!(counts.is_empty());
     }
@@ -91,7 +81,7 @@ mod tests {
                 .unwrap();
         }
 
-        let counts = read(&path, &[row("acme/widgets", 412)]).unwrap();
+        let counts = read(&path).unwrap();
 
         assert_eq!(counts["github:acme/widgets#412"], 1);
     }
@@ -102,7 +92,7 @@ mod tests {
         let path = directory.path().join("review-data.sqlite3");
         std::fs::write(&path, b"not a database").unwrap();
 
-        let failure = read(&path, &[row("acme/widgets", 412)]).unwrap_err();
+        let failure = read(&path).unwrap_err();
 
         assert_eq!(failure.summary, "Drafts could not be read");
     }

--- a/apps/desktop/src-tauri/src/drafts.rs
+++ b/apps/desktop/src-tauri/src/drafts.rs
@@ -1,0 +1,109 @@
+//! Reading Home's Drafts counts from the local store.
+//!
+//! Runs read-only, after a refresh has fetched its rows, so a broken database
+//! never blocks the pull requests Home did manage to list.
+
+use std::{collections::HashMap, path::Path};
+
+use domain::SessionFailure;
+use store::{ReviewStore, StoreError};
+
+/// Counts of stored Drafts per row, keyed by [`app::HomeRow::draft_scope`].
+///
+/// A database that does not exist yet means no Drafts anywhere, which is not a
+/// failure.
+///
+/// # Errors
+///
+/// Returns what Home shows above the list when the database cannot be opened
+/// or read.
+pub(crate) fn read(
+    database_path: &Path,
+    rows: &[app::HomeRow],
+) -> Result<HashMap<String, usize>, SessionFailure> {
+    let store = match ReviewStore::open_read_only(database_path) {
+        Ok(store) => store,
+        Err(StoreError::Missing) => return Ok(HashMap::new()),
+        Err(error) => return Err(drafts_failure(&error)),
+    };
+    let scopes = rows
+        .iter()
+        .map(app::HomeRow::draft_scope)
+        .collect::<Vec<_>>();
+    store
+        .count_by_scopes(&scopes)
+        .map_err(|error| drafts_failure(&error))
+}
+
+fn drafts_failure(error: &StoreError) -> SessionFailure {
+    SessionFailure::from_error("Drafts could not be read", error)
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn row(repository: &str, number: u64) -> app::HomeRow {
+        app::HomeRow {
+            group: app::HomeGroup::ToReview,
+            repository: repository.to_owned(),
+            number,
+            title: "a pull request".to_owned(),
+            url: format!("https://github.com/{repository}/pull/{number}"),
+            author_login: None,
+            updated_at_ms: 0,
+            review_status: None,
+            check_status: None,
+            drafts: None,
+        }
+    }
+
+    #[test]
+    fn a_missing_database_reads_as_no_drafts() {
+        let directory = TempDir::new().unwrap();
+        let path = directory.path().join("review-data.sqlite3");
+
+        let counts = read(&path, &[row("acme/widgets", 412)]).unwrap();
+
+        assert!(counts.is_empty());
+    }
+
+    #[test]
+    fn an_existing_database_answers_with_its_counts() {
+        let directory = TempDir::new().unwrap();
+        let path = directory.path().join("review-data.sqlite3");
+        {
+            let store = ReviewStore::open(&path).unwrap();
+            store
+                .upsert(
+                    "github:acme/widgets#412",
+                    &domain::DiffAnchor {
+                        path: "src/a.rs".into(),
+                        side: domain::DiffSide::Right,
+                        line: 1,
+                        start_line: None,
+                        head_sha: "a".repeat(40).into(),
+                    },
+                    "a draft",
+                )
+                .unwrap();
+        }
+
+        let counts = read(&path, &[row("acme/widgets", 412)]).unwrap();
+
+        assert_eq!(counts["github:acme/widgets#412"], 1);
+    }
+
+    #[test]
+    fn a_database_that_is_not_a_valid_sqlite_file_is_a_failure() {
+        let directory = TempDir::new().unwrap();
+        let path = directory.path().join("review-data.sqlite3");
+        std::fs::write(&path, b"not a database").unwrap();
+
+        let failure = read(&path, &[row("acme/widgets", 412)]).unwrap_err();
+
+        assert_eq!(failure.summary, "Drafts could not be read");
+    }
+}

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -271,6 +271,8 @@ pub struct HomeRowDto {
     pub updated_at_ms: i64,
     pub review_status: Option<RowStatusDto>,
     pub check_status: Option<RowStatusDto>,
+    /// "1 draft" or "N drafts", absent for a blank cell.
+    pub drafts: Option<String>,
 }
 
 /// One of Home's three groups, always rendered whether or not it has rows.
@@ -368,6 +370,9 @@ pub struct HomeSnapshotDto {
     /// Why the last write did not reach the file, shown as a line above the
     /// list, which stays because reading it still worked.
     pub write_failure: Option<SessionFailureDto>,
+    /// Why the last Drafts read failed, shown as a line above the list beside
+    /// the failed repositories, with every row's Drafts column left blank.
+    pub drafts_failure: Option<SessionFailureDto>,
 }
 
 /// Everything Home shows, from the model that decided it.
@@ -429,6 +434,7 @@ pub fn project_home(home: &app::HomeModel) -> HomeSnapshotDto {
             .collect(),
         failure: home.failure().map(Into::into),
         write_failure: home.write_failure().map(Into::into),
+        drafts_failure: home.drafts_failure().map(Into::into),
     }
 }
 
@@ -442,6 +448,7 @@ fn project_home_row(row: &app::HomeRow, index: u32) -> HomeRowDto {
         updated_at_ms: row.updated_at_ms,
         review_status: row.review_status.map(Into::into),
         check_status: row.check_status.map(Into::into),
+        drafts: row.drafts_label(),
     }
 }
 
@@ -899,6 +906,88 @@ mod tests {
         );
         assert_eq!(snapshot.footer_summary, "No repositories");
         assert!(snapshot.count_line.is_none());
+    }
+
+    #[test]
+    fn home_projects_a_rows_drafts_as_its_singular_or_plural_label_or_blank() {
+        let mut home = app::HomeModel::new();
+        home.refreshed(Ok(vec![app::RepositoryEntry {
+            path: std::path::PathBuf::from("/Developer/widgets"),
+            outcome: app::RepositoryOutcome::Valid {
+                root: std::path::PathBuf::from("/Developer/widgets"),
+                slug: "acme/widgets".to_owned(),
+            },
+        }]));
+        home.batch_fetched(vec![app::RepositoryFetch {
+            slug: "acme/widgets".to_owned(),
+            outcome: Ok(vec![
+                app::FetchedPullRequest {
+                    search: app::HomeSearch::ReviewRequested,
+                    repository: "acme/widgets".to_owned(),
+                    number: 412,
+                    title: "Retry webhook deliveries".to_owned(),
+                    url: "https://github.com/acme/widgets/pull/412".to_owned(),
+                    author_login: Some("mlee".to_owned()),
+                    updated_at_ms: 100,
+                    head_sha: "head".to_owned(),
+                    viewer_latest_review_sha: None,
+                    check_state: None,
+                    review_decision: None,
+                    changes_requested: false,
+                    thread_awaiting_reply: false,
+                },
+                app::FetchedPullRequest {
+                    search: app::HomeSearch::ReviewRequested,
+                    repository: "acme/widgets".to_owned(),
+                    number: 398,
+                    title: "Split the renderer".to_owned(),
+                    url: "https://github.com/acme/widgets/pull/398".to_owned(),
+                    author_login: Some("priya".to_owned()),
+                    updated_at_ms: 50,
+                    head_sha: "head".to_owned(),
+                    viewer_latest_review_sha: None,
+                    check_state: None,
+                    review_decision: None,
+                    changes_requested: false,
+                    thread_awaiting_reply: false,
+                },
+            ]),
+        }]);
+        home.drafts_read(Ok(std::collections::HashMap::from([(
+            "github:acme/widgets#412".to_owned(),
+            3,
+        )])));
+
+        let snapshot = project_home(&home);
+
+        let by_identity = |identity: &str| {
+            snapshot.groups[0]
+                .rows
+                .iter()
+                .find(|row| row.identity == identity)
+                .unwrap()
+        };
+        assert_eq!(
+            by_identity("acme/widgets#412").drafts.as_deref(),
+            Some("3 drafts")
+        );
+        assert_eq!(by_identity("acme/widgets#398").drafts, None);
+    }
+
+    #[test]
+    fn home_projects_the_drafts_failure_beside_the_failed_repository_lines() {
+        let mut home = app::HomeModel::new();
+        home.drafts_read(Err(SessionFailure::new("Drafts could not be read")));
+
+        let snapshot = project_home(&home);
+
+        assert_eq!(
+            snapshot
+                .drafts_failure
+                .expect("the failure should be shown")
+                .summary,
+            "Drafts could not be read",
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -272,7 +272,7 @@ pub struct HomeRowDto {
     pub review_status: Option<RowStatusDto>,
     pub check_status: Option<RowStatusDto>,
     /// "1 draft" or "N drafts", absent for a blank cell.
-    pub drafts: Option<String>,
+    pub drafts_label: Option<String>,
 }
 
 /// One of Home's three groups, always rendered whether or not it has rows.
@@ -448,7 +448,7 @@ fn project_home_row(row: &app::HomeRow, index: u32) -> HomeRowDto {
         updated_at_ms: row.updated_at_ms,
         review_status: row.review_status.map(Into::into),
         check_status: row.check_status.map(Into::into),
-        drafts: row.drafts_label(),
+        drafts_label: row.drafts_label(),
     }
 }
 
@@ -968,10 +968,10 @@ mod tests {
                 .unwrap()
         };
         assert_eq!(
-            by_identity("acme/widgets#412").drafts.as_deref(),
+            by_identity("acme/widgets#412").drafts_label.as_deref(),
             Some("3 drafts")
         );
-        assert_eq!(by_identity("acme/widgets#398").drafts, None);
+        assert_eq!(by_identity("acme/widgets#398").drafts_label, None);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ use github::GithubClient;
 use session::{ReviewStorage, SessionRequest};
 
 mod commands;
+mod drafts;
 mod dto;
 #[cfg(test)]
 mod fake_gh;

--- a/apps/desktop/src/Home.test.tsx
+++ b/apps/desktop/src/Home.test.tsx
@@ -422,14 +422,14 @@ describe("Home", () => {
     expect(scrollIntoView).toHaveBeenCalledWith(expect.objectContaining({ block: "nearest" }));
   });
 
-  it("shows the Drafts badge on a row that has some, and a blank cell where it has none", async () => {
+  it("shows the Drafts badge on a row that has one, and a blank cell on a row with none", async () => {
     refreshHome.mockResolvedValue(
       ok({
         ...listed(),
         groups: makeHomeGroups([
           [
-            makeHomeRow({ index: 0, identity: "acme/widgets#412", drafts: "3 drafts" }),
-            makeHomeRow({ index: 1, identity: "acme/widgets#398", drafts: "1 draft" }),
+            makeHomeRow({ index: 0, identity: "acme/widgets#412", drafts_label: "3 drafts" }),
+            makeHomeRow({ index: 1, identity: "acme/widgets#398", drafts_label: null }),
           ],
           [],
           [],
@@ -440,15 +440,55 @@ describe("Home", () => {
     render(<App />);
 
     await waitFor(() => expect(screen.getByText("3 drafts")).toBeTruthy());
-    expect(screen.getByText("1 draft")).toBeTruthy();
     const rows = screen.getAllByRole("listitem");
     expect(rows[0].querySelector(".home__cell--drafts")?.textContent).toBe("3 drafts");
+    expect(rows[1].querySelector(".home__cell--drafts")?.textContent).toBe("");
   });
 
-  it("blanks the Drafts column and shows the reason when the store could not be read", async () => {
+  it("blanks the Drafts column and shows the reason when a later refresh cannot read the store", async () => {
+    const user = userEvent.setup();
+    const withDrafts = {
+      ...listed(),
+      groups: makeHomeGroups([
+        [
+          makeHomeRow({ index: 0, identity: "acme/widgets#412", drafts_label: "3 drafts" }),
+          makeHomeRow({ index: 1, identity: "acme/widgets#398", drafts_label: "1 draft" }),
+        ],
+        [
+          makeHomeRow({
+            index: 2,
+            identity: "braidonw/zreview#77",
+            title: "Bound the retry ceiling",
+            author: "braidonw",
+          }),
+        ],
+        [],
+      ]),
+    };
+    refreshHome.mockResolvedValue(ok(withDrafts));
+
+    render(<App />);
+    await waitFor(() => expect(screen.getByText("3 drafts")).toBeTruthy());
+    expect(screen.getByText("1 draft")).toBeTruthy();
+
     refreshHome.mockResolvedValue(
       ok({
-        ...listed(),
+        ...withDrafts,
+        groups: makeHomeGroups([
+          [
+            makeHomeRow({ index: 0, identity: "acme/widgets#412" }),
+            makeHomeRow({ index: 1, identity: "acme/widgets#398" }),
+          ],
+          [
+            makeHomeRow({
+              index: 2,
+              identity: "braidonw/zreview#77",
+              title: "Bound the retry ceiling",
+              author: "braidonw",
+            }),
+          ],
+          [],
+        ]),
         drafts_failure: {
           summary: "Drafts could not be read",
           detail: "the review database's schema version 99 is not one this build knows",
@@ -457,12 +497,14 @@ describe("Home", () => {
       }),
     );
 
-    render(<App />);
+    await user.keyboard("r");
 
     await waitFor(() => expect(screen.getByText(/Drafts could not be read/)).toBeTruthy());
     expect(
       screen.getByText(/schema version 99 is not one this build knows/),
     ).toBeTruthy();
+    expect(screen.queryByText("3 drafts")).toBeNull();
+    expect(screen.queryByText("1 draft")).toBeNull();
     const rows = screen.getAllByRole("listitem");
     expect(rows.every((row) => row.querySelector(".home__cell--drafts")?.textContent === "")).toBe(
       true,

--- a/apps/desktop/src/Home.test.tsx
+++ b/apps/desktop/src/Home.test.tsx
@@ -422,6 +422,53 @@ describe("Home", () => {
     expect(scrollIntoView).toHaveBeenCalledWith(expect.objectContaining({ block: "nearest" }));
   });
 
+  it("shows the Drafts badge on a row that has some, and a blank cell where it has none", async () => {
+    refreshHome.mockResolvedValue(
+      ok({
+        ...listed(),
+        groups: makeHomeGroups([
+          [
+            makeHomeRow({ index: 0, identity: "acme/widgets#412", drafts: "3 drafts" }),
+            makeHomeRow({ index: 1, identity: "acme/widgets#398", drafts: "1 draft" }),
+          ],
+          [],
+          [],
+        ]),
+      }),
+    );
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText("3 drafts")).toBeTruthy());
+    expect(screen.getByText("1 draft")).toBeTruthy();
+    const rows = screen.getAllByRole("listitem");
+    expect(rows[0].querySelector(".home__cell--drafts")?.textContent).toBe("3 drafts");
+  });
+
+  it("blanks the Drafts column and shows the reason when the store could not be read", async () => {
+    refreshHome.mockResolvedValue(
+      ok({
+        ...listed(),
+        drafts_failure: {
+          summary: "Drafts could not be read",
+          detail: "the review database's schema version 99 is not one this build knows",
+          remediation: null,
+        },
+      }),
+    );
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText(/Drafts could not be read/)).toBeTruthy());
+    expect(
+      screen.getByText(/schema version 99 is not one this build knows/),
+    ).toBeTruthy();
+    const rows = screen.getAllByRole("listitem");
+    expect(rows.every((row) => row.querySelector(".home__cell--drafts")?.textContent === "")).toBe(
+      true,
+    );
+  });
+
   it("shows a failed repository above the list with a Remove beside it", async () => {
     refreshHome.mockResolvedValue(
       ok({

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -220,6 +220,8 @@ export type HomeRowDto = {
 	updated_at_ms: number,
 	review_status: RowStatusDto | null,
 	check_status: RowStatusDto | null,
+	/**  "1 draft" or "N drafts", absent for a blank cell. */
+	drafts: string | null,
 };
 
 /**  Everything Home renders, from its header to its footer. */
@@ -247,6 +249,11 @@ export type HomeSnapshotDto = {
 	 *  list, which stays because reading it still worked.
 	 */
 	write_failure: SessionFailureDto | null,
+	/**
+	 *  Why the last Drafts read failed, shown as a line above the list beside
+	 *  the failed repositories, with every row's Drafts column left blank.
+	 */
+	drafts_failure: SessionFailureDto | null,
 };
 
 /**  Which screen the binary was launched into. */

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -221,7 +221,7 @@ export type HomeRowDto = {
 	review_status: RowStatusDto | null,
 	check_status: RowStatusDto | null,
 	/**  "1 draft" or "N drafts", absent for a blank cell. */
-	drafts: string | null,
+	drafts_label: string | null,
 };
 
 /**  Everything Home renders, from its header to its footer. */

--- a/apps/desktop/src/components/HomeScreen.css
+++ b/apps/desktop/src/components/HomeScreen.css
@@ -93,7 +93,7 @@
   color: var(--text-secondary);
 }
 
-.home__write-failure {
+.home__failure-line {
   min-height: var(--file-row-height);
   display: flex;
   align-items: center;
@@ -103,22 +103,7 @@
   color: var(--severity-error-text);
 }
 
-.home__write-remediation {
-  font-size: var(--size-meta);
-  color: var(--text-secondary);
-}
-
-.home__drafts-failure {
-  min-height: var(--file-row-height);
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  font-family: var(--font-sans);
-  font-size: var(--size-body);
-  color: var(--severity-error-text);
-}
-
-.home__drafts-failure-detail {
+.home__failure-detail {
   font-size: var(--size-meta);
   color: var(--text-secondary);
 }
@@ -225,8 +210,9 @@
   color: var(--text-tertiary);
 }
 
+/* Wide enough for "12 drafts", the longest label the badge carries. */
 .home__cell--drafts {
-  width: 60px;
+  width: 80px;
 }
 
 .home__drafts-badge {

--- a/apps/desktop/src/components/HomeScreen.css
+++ b/apps/desktop/src/components/HomeScreen.css
@@ -108,6 +108,21 @@
   color: var(--text-secondary);
 }
 
+.home__drafts-failure {
+  min-height: var(--file-row-height);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-family: var(--font-sans);
+  font-size: var(--size-body);
+  color: var(--severity-error-text);
+}
+
+.home__drafts-failure-detail {
+  font-size: var(--size-meta);
+  color: var(--text-secondary);
+}
+
 .home__group {
   padding-top: 20px;
   display: flex;
@@ -212,6 +227,15 @@
 
 .home__cell--drafts {
   width: 60px;
+}
+
+.home__drafts-badge {
+  padding: 0 6px;
+  border-radius: 4px;
+  background: var(--accent-dim);
+  color: var(--accent-text);
+  font-family: var(--font-mono);
+  font-size: var(--size-label);
 }
 
 /* Wide enough for "you reviewed this head", the longest label it carries. */

--- a/apps/desktop/src/components/HomeScreen.tsx
+++ b/apps/desktop/src/components/HomeScreen.tsx
@@ -135,6 +135,7 @@ function HomeBody({
   return (
     <div className="home__body home__body--list">
       <WriteFailure failure={snapshot.write_failure} />
+      <DraftsFailure failure={snapshot.drafts_failure} />
       {snapshot.failed_repositories.map((repository) => (
         <div className="home__failed-repository" key={repository.path}>
           <span className="home__failed-detail">
@@ -180,6 +181,19 @@ function WriteFailure({ failure }: { failure: SessionFailureDto | null }) {
   );
 }
 
+/** Why the last Drafts read failed, above the list beside the failed repositories. */
+function DraftsFailure({ failure }: { failure: SessionFailureDto | null }) {
+  if (failure === null) {
+    return null;
+  }
+  return (
+    <div className="home__drafts-failure">
+      <span>{failure.summary}</span>
+      {failure.detail !== null && <span className="home__drafts-failure-detail">{failure.detail}</span>}
+    </div>
+  );
+}
+
 /** One pull request on one line, its columns aligned whether or not they speak. */
 function Row({ row, cursor, nowMs }: { row: HomeRowDto; cursor: boolean; nowMs: number }) {
   const line = useRef<HTMLLIElement>(null);
@@ -197,7 +211,9 @@ function Row({ row, cursor, nowMs }: { row: HomeRowDto; cursor: boolean; nowMs: 
       aria-selected={cursor}
     >
       <span className="home__row-title">{row.title}</span>
-      <span className="home__cell home__cell--drafts" />
+      <span className="home__cell home__cell--drafts">
+        {row.drafts !== null && <span className="home__drafts-badge">{row.drafts}</span>}
+      </span>
       <span className="home__cell home__cell--review">
         {row.review_status !== null && (
           <span className={`home__status home__status--${row.review_status.tone.toLowerCase()}`}>

--- a/apps/desktop/src/components/HomeScreen.tsx
+++ b/apps/desktop/src/components/HomeScreen.tsx
@@ -121,7 +121,7 @@ function HomeBody({
   if (snapshot.repositories.length === 0) {
     return (
       <div className="home__body home__body--empty">
-        <WriteFailure failure={snapshot.write_failure} />
+        <FailureLine failure={snapshot.write_failure} />
         <h2 className="home__empty-heading">No repositories yet</h2>
         <p className="home__empty-copy">
           Add a local clone and Home lists the pull requests that want you.
@@ -134,8 +134,8 @@ function HomeBody({
   }
   return (
     <div className="home__body home__body--list">
-      <WriteFailure failure={snapshot.write_failure} />
-      <DraftsFailure failure={snapshot.drafts_failure} />
+      <FailureLine failure={snapshot.write_failure} />
+      <FailureLine failure={snapshot.drafts_failure} />
       {snapshot.failed_repositories.map((repository) => (
         <div className="home__failed-repository" key={repository.path}>
           <span className="home__failed-detail">
@@ -166,30 +166,23 @@ function HomeBody({
   );
 }
 
-/** Why the last write did not reach the settings file, wherever the list is. */
-function WriteFailure({ failure }: { failure: SessionFailureDto | null }) {
+/**
+ * One failure as a line above the list: summary, then remediation, then
+ * detail, whichever of the two are present. Shared by the settings write
+ * failure and the Drafts read failure, which sit in the same place and read
+ * the same way.
+ */
+function FailureLine({ failure }: { failure: SessionFailureDto | null }) {
   if (failure === null) {
     return null;
   }
   return (
-    <div className="home__write-failure">
+    <div className="home__failure-line">
       <span>{failure.summary}</span>
       {failure.remediation !== null && (
-        <span className="home__write-remediation">{failure.remediation}</span>
+        <span className="home__failure-detail">{failure.remediation}</span>
       )}
-    </div>
-  );
-}
-
-/** Why the last Drafts read failed, above the list beside the failed repositories. */
-function DraftsFailure({ failure }: { failure: SessionFailureDto | null }) {
-  if (failure === null) {
-    return null;
-  }
-  return (
-    <div className="home__drafts-failure">
-      <span>{failure.summary}</span>
-      {failure.detail !== null && <span className="home__drafts-failure-detail">{failure.detail}</span>}
+      {failure.detail !== null && <span className="home__failure-detail">{failure.detail}</span>}
     </div>
   );
 }
@@ -212,7 +205,9 @@ function Row({ row, cursor, nowMs }: { row: HomeRowDto; cursor: boolean; nowMs: 
     >
       <span className="home__row-title">{row.title}</span>
       <span className="home__cell home__cell--drafts">
-        {row.drafts !== null && <span className="home__drafts-badge">{row.drafts}</span>}
+        {row.drafts_label !== null && (
+          <span className="home__drafts-badge">{row.drafts_label}</span>
+        )}
       </span>
       <span className="home__cell home__cell--review">
         {row.review_status !== null && (

--- a/apps/desktop/src/test/fixtures.ts
+++ b/apps/desktop/src/test/fixtures.ts
@@ -120,6 +120,7 @@ export function makeHomeRow(overrides: Partial<HomeRowDto> = {}): HomeRowDto {
     updated_at_ms: 1_788_266_096_000,
     review_status: null,
     check_status: null,
+    drafts: null,
     ...overrides,
   };
 }
@@ -151,6 +152,7 @@ export function makeHomeSnapshot(overrides: Partial<HomeSnapshotDto> = {}): Home
     refusals: [],
     failure: null,
     write_failure: null,
+    drafts_failure: null,
     ...overrides,
   };
 }

--- a/apps/desktop/src/test/fixtures.ts
+++ b/apps/desktop/src/test/fixtures.ts
@@ -120,7 +120,7 @@ export function makeHomeRow(overrides: Partial<HomeRowDto> = {}): HomeRowDto {
     updated_at_ms: 1_788_266_096_000,
     review_status: null,
     check_status: null,
-    drafts: null,
+    drafts_label: null,
     ...overrides,
   };
 }

--- a/crates/app/src/home.rs
+++ b/crates/app/src/home.rs
@@ -231,7 +231,7 @@ pub struct HomeRow {
     /// Unsent Drafts on this pull request, regardless of which head they were
     /// written against. Absent means none, and a store failure blanks it too,
     /// so neither reads as a zero.
-    pub drafts: Option<usize>,
+    pub draft_count: Option<usize>,
 }
 
 impl HomeRow {
@@ -242,15 +242,29 @@ impl HomeRow {
     }
 
     /// The scope this row's Drafts are stored under.
+    ///
+    /// `repository` always carries `owner/name` in one field here, unlike
+    /// [`domain::SessionSource`], which keeps them apart; splitting it back is
+    /// cheaper than a second field that would only ever be joined right back
+    /// together for the identity column.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `repository` has no `/`, which nothing that fetches a row
+    /// ever produces.
     #[must_use]
     pub fn draft_scope(&self) -> String {
-        domain::github_draft_scope(&self.repository, self.number)
+        let (owner, name) = self
+            .repository
+            .split_once('/')
+            .expect("a repository is always spelled owner/name");
+        domain::github_draft_scope(owner, name, self.number)
     }
 
     /// "1 draft" or "N drafts", the words the badge shows, absent for a blank cell.
     #[must_use]
     pub fn drafts_label(&self) -> Option<String> {
-        self.drafts.map(|count| {
+        self.draft_count.map(|count| {
             if count == 1 {
                 "1 draft".to_owned()
             } else {
@@ -401,6 +415,18 @@ impl HomeModel {
     /// and nothing from anywhere else.
     pub fn batch_fetched(&mut self, batch: Vec<RepositoryFetch>) {
         for fetch in batch {
+            // The store read only lands once a refresh finishes, so a row this
+            // repository already had a count for keeps it, rather than blinking
+            // out for however long the rest of the refresh takes.
+            let carried_counts = self
+                .rows
+                .iter()
+                .filter(|row| same_slug(&row.repository, &fetch.slug))
+                .filter_map(|row| {
+                    row.draft_count
+                        .map(|count| (draft_scope_key(&row.draft_scope()), count))
+                })
+                .collect::<HashMap<_, _>>();
             self.rows
                 .retain(|row| !same_slug(&row.repository, &fetch.slug));
             self.fetch_failures
@@ -408,8 +434,14 @@ impl HomeModel {
             match fetch.outcome {
                 Ok(pull_requests) => {
                     self.loaded_repositories += 1;
-                    self.rows
-                        .extend(one_row_each(pull_requests).into_iter().map(into_row));
+                    let fresh_rows = one_row_each(pull_requests).into_iter().map(|pull_request| {
+                        let mut row = into_row(pull_request);
+                        row.draft_count = carried_counts
+                            .get(&draft_scope_key(&row.draft_scope()))
+                            .copied();
+                        row
+                    });
+                    self.rows.extend(fresh_rows);
                 }
                 Err(reason) => {
                     self.failed_repositories += 1;
@@ -599,13 +631,13 @@ impl HomeModel {
         match result {
             Ok(counts) => {
                 for row in &mut self.rows {
-                    row.drafts = counts.get(&row.draft_scope()).copied();
+                    row.draft_count = counts.get(&draft_scope_key(&row.draft_scope())).copied();
                 }
                 self.drafts_failure = None;
             }
             Err(failure) => {
                 for row in &mut self.rows {
-                    row.drafts = None;
+                    row.draft_count = None;
                 }
                 self.drafts_failure = Some(failure);
             }
@@ -792,6 +824,16 @@ fn same_slug(left: &str, right: &str) -> bool {
     left.eq_ignore_ascii_case(right)
 }
 
+/// Normalizes a Drafts scope for a case-insensitive lookup.
+///
+/// A Session writes a scope with whatever casing the remote URL carried, while
+/// a fetched row carries GitHub's own casing, so the two can disagree on a
+/// repository [`same_slug`] would call equal. The store already lowercases its
+/// own keys; this lowercases a row's side of the same lookup.
+fn draft_scope_key(scope: &str) -> String {
+    scope.to_ascii_lowercase()
+}
+
 /// Keeps one row per pull request, preferring what the authored search said.
 ///
 /// A pull request the reviewer wrote and is also asked to review comes back
@@ -874,7 +916,7 @@ fn into_row(fetched: FetchedPullRequest) -> HomeRow {
         url: fetched.url,
         author_login: fetched.author_login,
         updated_at_ms: fetched.updated_at_ms,
-        drafts: None,
+        draft_count: None,
     }
 }
 
@@ -2228,7 +2270,7 @@ mod tests {
             3,
         )])));
 
-        assert_eq!(only_row(&home).drafts, Some(3));
+        assert_eq!(only_row(&home).draft_count, Some(3));
     }
 
     #[test]
@@ -2237,7 +2279,33 @@ mod tests {
 
         home.drafts_read(Ok(HashMap::new()));
 
-        assert_eq!(only_row(&home).drafts, None);
+        assert_eq!(only_row(&home).draft_count, None);
+    }
+
+    /// A Session writes its scope with whatever casing the remote URL carried,
+    /// while a fetched row carries GitHub's own casing. The store already
+    /// lowercases its keys; this is the model's own side of the same
+    /// case-insensitive lookup.
+    #[test]
+    fn a_row_finds_its_drafts_despite_a_differently_cased_repository() {
+        let mixed_case = FetchedPullRequest {
+            repository: "Acme/Widgets".to_owned(),
+            ..fetched(HomeSearch::ReviewRequested, 412, 100)
+        };
+        let mut home = HomeModel::new();
+        home.refreshed(Ok(vec![valid("/Developer/widgets", "Acme/Widgets")]));
+        home.batch_fetched(vec![RepositoryFetch {
+            slug: "Acme/Widgets".to_owned(),
+            outcome: Ok(vec![mixed_case]),
+        }]);
+        assert_eq!(only_row(&home).repository, "Acme/Widgets");
+
+        home.drafts_read(Ok(HashMap::from([(
+            "github:acme/widgets#412".to_owned(),
+            2,
+        )])));
+
+        assert_eq!(only_row(&home).draft_count, Some(2));
     }
 
     #[test]
@@ -2253,7 +2321,7 @@ mod tests {
 
         home.drafts_read(Err(SessionFailure::new("Drafts could not be read")));
 
-        assert!(home.rows().iter().all(|row| row.drafts.is_none()));
+        assert!(home.rows().iter().all(|row| row.draft_count.is_none()));
         assert_eq!(
             home.drafts_failure()
                 .expect("the failure should show")
@@ -2273,7 +2341,7 @@ mod tests {
         )])));
 
         assert!(home.drafts_failure().is_none());
-        assert_eq!(only_row(&home).drafts, Some(1));
+        assert_eq!(only_row(&home).draft_count, Some(1));
     }
 
     #[test]
@@ -2294,5 +2362,49 @@ mod tests {
 
         home.drafts_read(Ok(HashMap::new()));
         assert_eq!(only_row(&home).drafts_label(), None);
+    }
+
+    /// The store read only lands once a refresh finishes, but a progressive
+    /// refresh replaces a repository's rows batch by batch. A row's badge must
+    /// not blink out just because its repository answered again before the
+    /// store was asked.
+    #[test]
+    fn a_batch_that_replaces_a_repositorys_rows_carries_over_its_known_draft_count() {
+        let mut home = listing(vec![fetched(HomeSearch::ReviewRequested, 412, 100)]);
+        home.drafts_read(Ok(HashMap::from([(
+            "github:acme/widgets#412".to_owned(),
+            2,
+        )])));
+        assert_eq!(only_row(&home).draft_count, Some(2));
+
+        home.batch_fetched(vec![loaded(vec![fetched(
+            HomeSearch::ReviewRequested,
+            412,
+            200,
+        )])]);
+
+        assert_eq!(
+            only_row(&home).draft_count,
+            Some(2),
+            "the badge should not blink out mid-refresh",
+        );
+    }
+
+    /// A pull request new to this batch has no count to carry over.
+    #[test]
+    fn a_row_new_to_a_batch_has_no_carried_over_draft_count() {
+        let mut home = listing(vec![fetched(HomeSearch::ReviewRequested, 412, 100)]);
+        home.drafts_read(Ok(HashMap::from([(
+            "github:acme/widgets#412".to_owned(),
+            2,
+        )])));
+
+        home.batch_fetched(vec![loaded(vec![fetched(
+            HomeSearch::ReviewRequested,
+            999,
+            200,
+        )])]);
+
+        assert_eq!(only_row(&home).draft_count, None);
     }
 }

--- a/crates/app/src/home.rs
+++ b/crates/app/src/home.rs
@@ -5,7 +5,10 @@
 //! arrives already read and already validated, so this model is all decisions
 //! and no I/O, and effects on the file come back as return values.
 
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 use domain::SessionFailure;
 
@@ -225,6 +228,10 @@ pub struct HomeRow {
     pub updated_at_ms: i64,
     pub review_status: Option<ReviewStatus>,
     pub check_status: Option<CheckStatus>,
+    /// Unsent Drafts on this pull request, regardless of which head they were
+    /// written against. Absent means none, and a store failure blanks it too,
+    /// so neither reads as a zero.
+    pub drafts: Option<usize>,
 }
 
 impl HomeRow {
@@ -232,6 +239,24 @@ impl HomeRow {
     #[must_use]
     pub fn identity(&self) -> String {
         format!("{}#{}", self.repository, self.number)
+    }
+
+    /// The scope this row's Drafts are stored under.
+    #[must_use]
+    pub fn draft_scope(&self) -> String {
+        domain::github_draft_scope(&self.repository, self.number)
+    }
+
+    /// "1 draft" or "N drafts", the words the badge shows, absent for a blank cell.
+    #[must_use]
+    pub fn drafts_label(&self) -> Option<String> {
+        self.drafts.map(|count| {
+            if count == 1 {
+                "1 draft".to_owned()
+            } else {
+                format!("{count} drafts")
+            }
+        })
     }
 }
 
@@ -277,6 +302,9 @@ pub struct HomeModel {
     /// giving up part way.
     refresh_failure: Option<SessionFailure>,
     write_failure: Option<SessionFailure>,
+    /// Why the last Drafts read failed, if it did. Left standing until a read
+    /// that succeeds, unlike a row's own count, which a failure blanks at once.
+    drafts_failure: Option<SessionFailure>,
     footer_expanded: bool,
     refusals: Vec<Refusal>,
     /// Every listed row, in the order Home renders them, which is also the
@@ -560,6 +588,36 @@ impl HomeModel {
         self.write_failure.as_ref()
     }
 
+    /// Takes what a refresh's Drafts read found, keyed by [`HomeRow::draft_scope`],
+    /// or the failure that stopped it reading.
+    ///
+    /// A failure blanks every row rather than leaving stale counts standing, so
+    /// a Drafts column never shows a number the store could not back up. A
+    /// scope absent from a successful read means that pull request has no
+    /// Drafts, not that its column keeps whatever it last showed.
+    pub fn drafts_read(&mut self, result: Result<HashMap<String, usize>, SessionFailure>) {
+        match result {
+            Ok(counts) => {
+                for row in &mut self.rows {
+                    row.drafts = counts.get(&row.draft_scope()).copied();
+                }
+                self.drafts_failure = None;
+            }
+            Err(failure) => {
+                for row in &mut self.rows {
+                    row.drafts = None;
+                }
+                self.drafts_failure = Some(failure);
+            }
+        }
+    }
+
+    /// Why the last Drafts read failed, if it did.
+    #[must_use]
+    pub fn drafts_failure(&self) -> Option<&SessionFailure> {
+        self.drafts_failure.as_ref()
+    }
+
     /// How many configured clones list nothing, from either cause.
     #[must_use]
     pub fn failed_count(&self) -> usize {
@@ -816,6 +874,7 @@ fn into_row(fetched: FetchedPullRequest) -> HomeRow {
         url: fetched.url,
         author_login: fetched.author_login,
         updated_at_ms: fetched.updated_at_ms,
+        drafts: None,
     }
 }
 
@@ -2159,5 +2218,81 @@ mod tests {
         home.write_finished(Ok(()));
 
         assert!(home.write_failure().is_none());
+    }
+
+    #[test]
+    fn a_row_with_drafts_against_an_older_head_still_shows_the_count() {
+        let mut home = listing(vec![fetched(HomeSearch::ReviewRequested, 412, 100)]);
+        home.drafts_read(Ok(HashMap::from([(
+            "github:acme/widgets#412".to_owned(),
+            3,
+        )])));
+
+        assert_eq!(only_row(&home).drafts, Some(3));
+    }
+
+    #[test]
+    fn a_row_with_no_drafts_shows_a_blank_cell() {
+        let mut home = listing(vec![fetched(HomeSearch::ReviewRequested, 412, 100)]);
+
+        home.drafts_read(Ok(HashMap::new()));
+
+        assert_eq!(only_row(&home).drafts, None);
+    }
+
+    #[test]
+    fn a_store_failure_blanks_every_row_and_names_the_reason_above_the_list() {
+        let mut home = listing(vec![
+            fetched(HomeSearch::ReviewRequested, 412, 100),
+            fetched(HomeSearch::ReviewRequested, 398, 200),
+        ]);
+        home.drafts_read(Ok(HashMap::from([(
+            "github:acme/widgets#412".to_owned(),
+            2,
+        )])));
+
+        home.drafts_read(Err(SessionFailure::new("Drafts could not be read")));
+
+        assert!(home.rows().iter().all(|row| row.drafts.is_none()));
+        assert_eq!(
+            home.drafts_failure()
+                .expect("the failure should show")
+                .summary,
+            "Drafts could not be read",
+        );
+    }
+
+    #[test]
+    fn a_read_that_succeeds_after_a_failure_clears_it() {
+        let mut home = listing(vec![fetched(HomeSearch::ReviewRequested, 412, 100)]);
+        home.drafts_read(Err(SessionFailure::new("Drafts could not be read")));
+
+        home.drafts_read(Ok(HashMap::from([(
+            "github:acme/widgets#412".to_owned(),
+            1,
+        )])));
+
+        assert!(home.drafts_failure().is_none());
+        assert_eq!(only_row(&home).drafts, Some(1));
+    }
+
+    #[test]
+    fn every_draft_count_reads_as_its_singular_or_plural_label() {
+        let mut home = listing(vec![fetched(HomeSearch::ReviewRequested, 412, 100)]);
+
+        home.drafts_read(Ok(HashMap::from([(
+            "github:acme/widgets#412".to_owned(),
+            1,
+        )])));
+        assert_eq!(only_row(&home).drafts_label().as_deref(), Some("1 draft"));
+
+        home.drafts_read(Ok(HashMap::from([(
+            "github:acme/widgets#412".to_owned(),
+            4,
+        )])));
+        assert_eq!(only_row(&home).drafts_label().as_deref(), Some("4 drafts"));
+
+        home.drafts_read(Ok(HashMap::new()));
+        assert_eq!(only_row(&home).drafts_label(), None);
     }
 }

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -315,6 +315,16 @@ pub enum SessionSource {
     },
 }
 
+/// The scope Drafts are stored under for a GitHub pull request, given its
+/// repository as `owner/name` and its number.
+///
+/// Shared by [`SessionSource::draft_scope`] and by Home's Drafts count, so a
+/// Session and Home's badge agree on what a scope is spelled as.
+#[must_use]
+pub fn github_draft_scope(repository: &str, number: u64) -> String {
+    format!("github:{repository}#{number}")
+}
+
 impl SessionSource {
     /// The commit every anchor, finding, and draft in this session is keyed to.
     #[must_use]
@@ -360,7 +370,10 @@ impl SessionSource {
                 repository,
                 number,
                 ..
-            } => Some(format!("github:{owner}/{repository}#{number}")),
+            } => Some(github_draft_scope(
+                &format!("{owner}/{repository}"),
+                *number,
+            )),
         }
     }
 }
@@ -1461,6 +1474,15 @@ mod tests {
 
         // Nothing to persist for a generated fixture.
         assert!(SessionSource::Demo.draft_scope().is_none());
+    }
+
+    /// The same shape Home's Drafts count is read by.
+    #[test]
+    fn github_draft_scope_matches_a_pull_requests_own_draft_scope() {
+        assert_eq!(
+            github_draft_scope("acme/widgets", 42),
+            "github:acme/widgets#42",
+        );
     }
 
     #[test]

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -315,14 +315,13 @@ pub enum SessionSource {
     },
 }
 
-/// The scope Drafts are stored under for a GitHub pull request, given its
-/// repository as `owner/name` and its number.
+/// The scope Drafts are stored under for a GitHub pull request.
 ///
 /// Shared by [`SessionSource::draft_scope`] and by Home's Drafts count, so a
 /// Session and Home's badge agree on what a scope is spelled as.
 #[must_use]
-pub fn github_draft_scope(repository: &str, number: u64) -> String {
-    format!("github:{repository}#{number}")
+pub fn github_draft_scope(owner: &str, name: &str, number: u64) -> String {
+    format!("github:{owner}/{name}#{number}")
 }
 
 impl SessionSource {
@@ -370,10 +369,7 @@ impl SessionSource {
                 repository,
                 number,
                 ..
-            } => Some(github_draft_scope(
-                &format!("{owner}/{repository}"),
-                *number,
-            )),
+            } => Some(github_draft_scope(owner, repository, *number)),
         }
     }
 }
@@ -1480,7 +1476,7 @@ mod tests {
     #[test]
     fn github_draft_scope_matches_a_pull_requests_own_draft_scope() {
         assert_eq!(
-            github_draft_scope("acme/widgets", 42),
+            github_draft_scope("acme", "widgets", 42),
             "github:acme/widgets#42",
         );
     }

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -106,13 +106,20 @@ impl ReviewStore {
 
     /// Opens read-only, neither creating the file nor migrating its schema.
     ///
+    /// Any schema from `1` up to [`SCHEMA_VERSION`] is readable: an older build
+    /// migrated it to less than this one knows, but every table this reads has
+    /// existed since version 1. Home refreshes and reads this before a Session
+    /// has had a chance to migrate an older database, so refusing anything
+    /// less than the current version would refuse databases this build can
+    /// read perfectly well.
+    ///
     /// # Errors
     ///
     /// Returns [`StoreError::Missing`] when no database exists at `path` yet,
     /// which is not a failure to a caller for whom that means no Drafts
     /// anywhere. Returns [`StoreError::Open`] when it exists but cannot be
     /// opened, and [`StoreError::UnsupportedSchemaVersion`] when its schema is
-    /// not the one this build knows how to read.
+    /// newer than this build knows how to read.
     pub fn open_read_only(path: &Path) -> Result<Self, StoreError> {
         if !path.exists() {
             return Err(StoreError::Missing);
@@ -127,7 +134,7 @@ impl ReviewStore {
         let version: i64 = connection
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .map_err(StoreError::Read)?;
-        if version != SCHEMA_VERSION {
+        if !(1..=SCHEMA_VERSION).contains(&version) {
             return Err(StoreError::UnsupportedSchemaVersion(version));
         }
         Ok(Self { connection })
@@ -302,26 +309,32 @@ impl ReviewStore {
         Ok(drafts)
     }
 
-    /// Counts of stored Drafts per scope, summed across every head.
+    /// Counts of every stored Draft, by scope and summed across every head.
     ///
-    /// A scope in `scopes` with nothing stored is absent from the map, never a
-    /// zero, so a caller can tell "asked about and empty" from "not asked
-    /// about" without another lookup.
+    /// Grouped by `lower(scope)`, and every key comes back lowercased, so a
+    /// Session's scope and Home's row agree on one pull request whatever
+    /// casing each spelled its repository with. The table is the reviewer's
+    /// own unsent comments, never large enough to ask for less than all of it.
+    ///
+    /// A scope with nothing stored is absent from the map, never a zero, so a
+    /// caller can tell "asked about and empty" from "not asked about" without
+    /// another lookup.
     ///
     /// # Errors
     ///
     /// Returns [`StoreError::Read`] when the rows cannot be read.
-    pub fn count_by_scopes(&self, scopes: &[String]) -> Result<HashMap<String, usize>, StoreError> {
-        if scopes.is_empty() {
-            return Ok(HashMap::new());
-        }
-        let placeholders = scopes.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
-        let sql = format!(
-            "SELECT scope, COUNT(*) FROM drafts WHERE scope IN ({placeholders}) GROUP BY scope"
-        );
-        let mut statement = self.connection.prepare(&sql).map_err(StoreError::Read)?;
+    ///
+    /// # Panics
+    ///
+    /// Panics if a single scope's draft count overflows `usize`, which the
+    /// reviewer's own unsent comments never approach.
+    pub fn count_by_scope(&self) -> Result<HashMap<String, usize>, StoreError> {
+        let mut statement = self
+            .connection
+            .prepare("SELECT lower(scope), COUNT(*) FROM drafts GROUP BY lower(scope)")
+            .map_err(StoreError::Read)?;
         let rows = statement
-            .query_map(rusqlite::params_from_iter(scopes), |row| {
+            .query_map([], |row| {
                 Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
             })
             .map_err(StoreError::Read)?;
@@ -329,7 +342,10 @@ impl ReviewStore {
         let mut counts = HashMap::new();
         for row in rows {
             let (scope, count) = row.map_err(StoreError::Read)?;
-            counts.insert(scope, count.try_into().unwrap_or(usize::MAX));
+            counts.insert(
+                scope,
+                count.try_into().expect("a draft count fits in usize"),
+            );
         }
         Ok(counts)
     }
@@ -1348,7 +1364,7 @@ mod tests {
     }
 
     #[test]
-    fn counts_by_scope_sum_every_head_and_omit_scopes_with_nothing() {
+    fn count_by_scope_sums_every_head_and_every_scope_stored() {
         const OTHER_SCOPE: &str = "github:acme/widgets#43";
         let store = ReviewStore::open_in_memory().unwrap();
         store
@@ -1373,13 +1389,7 @@ mod tests {
             )
             .unwrap();
 
-        let counts = store
-            .count_by_scopes(&[
-                SCOPE.to_owned(),
-                OTHER_SCOPE.to_owned(),
-                "github:acme/widgets#99".to_owned(),
-            ])
-            .unwrap();
+        let counts = store.count_by_scope().unwrap();
 
         assert_eq!(counts.get(SCOPE), Some(&2), "both heads count");
         assert_eq!(counts.get(OTHER_SCOPE), Some(&1));
@@ -1391,13 +1401,37 @@ mod tests {
     }
 
     #[test]
-    fn counting_with_no_scopes_asked_about_reads_nothing() {
+    fn count_by_scope_reads_nothing_from_an_empty_table() {
+        let store = ReviewStore::open_in_memory().unwrap();
+
+        assert!(store.count_by_scope().unwrap().is_empty());
+    }
+
+    /// A Session writes the scope with whatever casing the remote URL carried,
+    /// while Home asks with GitHub's own canonical casing. Both must count as
+    /// the one pull request they are.
+    #[test]
+    fn count_by_scope_groups_the_same_pull_request_written_under_different_casing() {
         let store = ReviewStore::open_in_memory().unwrap();
         store
-            .upsert(SCOPE, &anchor("src/a.rs", 1, DiffSide::Right, HEAD), "body")
+            .upsert(
+                "github:Acme/Widgets#412",
+                &anchor("src/a.rs", 1, DiffSide::Right, HEAD),
+                "from a mixed-case remote",
+            )
+            .unwrap();
+        store
+            .upsert(
+                "github:acme/widgets#412",
+                &anchor("src/a.rs", 2, DiffSide::Right, HEAD),
+                "from the canonical casing",
+            )
             .unwrap();
 
-        assert!(store.count_by_scopes(&[]).unwrap().is_empty());
+        let counts = store.count_by_scope().unwrap();
+
+        assert_eq!(counts.len(), 1, "one pull request, one entry");
+        assert_eq!(counts["github:acme/widgets#412"], 2);
     }
 
     #[test]
@@ -1432,16 +1466,49 @@ mod tests {
 
         let reader = ReviewStore::open_read_only(&path).unwrap();
 
-        assert_eq!(
-            reader.count_by_scopes(&[SCOPE.to_owned()]).unwrap()[SCOPE],
-            1
-        );
+        assert_eq!(reader.count_by_scope().unwrap()[SCOPE], 1);
     }
 
-    /// A schema this build has not migrated to is unreadable, not silently
+    /// Home refreshes and reads Drafts before a Session has had a chance to
+    /// migrate an older database, so a schema this build has already migrated
+    /// past must still read, not just the exact current version.
+    #[test]
+    fn open_read_only_reads_a_schema_version_older_than_this_build() {
+        let directory = TempDir::new().unwrap();
+        let path = directory.path().join("review-data.sqlite3");
+        {
+            // Exactly what version 3 looked like: no draft_provenance yet.
+            let connection = Connection::open(&path).unwrap();
+            connection
+                .execute_batch(
+                    "CREATE TABLE drafts (
+                        scope TEXT NOT NULL, head_sha TEXT NOT NULL, path TEXT NOT NULL,
+                        side TEXT NOT NULL, line INTEGER NOT NULL, body TEXT NOT NULL,
+                        updated_at INTEGER NOT NULL, start_line INTEGER,
+                        PRIMARY KEY (scope, head_sha, path, side, line)
+                     ) STRICT;",
+                )
+                .unwrap();
+            connection
+                .execute(
+                    "INSERT INTO drafts
+                        (scope, head_sha, path, side, line, body, updated_at, start_line)
+                     VALUES (?1, ?2, 'src/old.rs', 'RIGHT', 3, 'written before the upgrade', 0, NULL)",
+                    rusqlite::params![SCOPE, HEAD],
+                )
+                .unwrap();
+            connection.pragma_update(None, "user_version", 3).unwrap();
+        }
+
+        let reader = ReviewStore::open_read_only(&path).unwrap();
+
+        assert_eq!(reader.count_by_scope().unwrap()[SCOPE], 1);
+    }
+
+    /// A schema newer than this build knows is unreadable, not silently
     /// treated as whatever the current schema means.
     #[test]
-    fn open_read_only_refuses_a_schema_version_this_build_does_not_know() {
+    fn open_read_only_refuses_a_schema_version_newer_than_this_build_knows() {
         let directory = TempDir::new().unwrap();
         let path = directory.path().join("review-data.sqlite3");
         {
@@ -1450,7 +1517,7 @@ mod tests {
         }
 
         let Err(error) = ReviewStore::open_read_only(&path) else {
-            panic!("an unknown schema version must be refused");
+            panic!("a newer schema version must be refused");
         };
 
         assert!(

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -63,6 +63,12 @@ pub enum StoreError {
 
     #[error("no home directory to store review data in")]
     NoHomeDirectory,
+
+    #[error("no review database exists yet")]
+    Missing,
+
+    #[error("the review database's schema version {0} is not one this build knows")]
+    UnsupportedSchemaVersion(i64),
 }
 
 /// The database a review's local state lives in.
@@ -96,6 +102,35 @@ impl ReviewStore {
     pub fn open_in_memory() -> Result<Self, StoreError> {
         let connection = Connection::open_in_memory().map_err(StoreError::Open)?;
         Self::prepare(connection)
+    }
+
+    /// Opens read-only, neither creating the file nor migrating its schema.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Missing`] when no database exists at `path` yet,
+    /// which is not a failure to a caller for whom that means no Drafts
+    /// anywhere. Returns [`StoreError::Open`] when it exists but cannot be
+    /// opened, and [`StoreError::UnsupportedSchemaVersion`] when its schema is
+    /// not the one this build knows how to read.
+    pub fn open_read_only(path: &Path) -> Result<Self, StoreError> {
+        if !path.exists() {
+            return Err(StoreError::Missing);
+        }
+        let connection = Connection::open_with_flags(
+            path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY
+                | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX
+                | rusqlite::OpenFlags::SQLITE_OPEN_URI,
+        )
+        .map_err(StoreError::Open)?;
+        let version: i64 = connection
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .map_err(StoreError::Read)?;
+        if version != SCHEMA_VERSION {
+            return Err(StoreError::UnsupportedSchemaVersion(version));
+        }
+        Ok(Self { connection })
     }
 
     fn prepare(connection: Connection) -> Result<Self, StoreError> {
@@ -265,6 +300,38 @@ impl ReviewStore {
             ));
         }
         Ok(drafts)
+    }
+
+    /// Counts of stored Drafts per scope, summed across every head.
+    ///
+    /// A scope in `scopes` with nothing stored is absent from the map, never a
+    /// zero, so a caller can tell "asked about and empty" from "not asked
+    /// about" without another lookup.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Read`] when the rows cannot be read.
+    pub fn count_by_scopes(&self, scopes: &[String]) -> Result<HashMap<String, usize>, StoreError> {
+        if scopes.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let placeholders = scopes.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+        let sql = format!(
+            "SELECT scope, COUNT(*) FROM drafts WHERE scope IN ({placeholders}) GROUP BY scope"
+        );
+        let mut statement = self.connection.prepare(&sql).map_err(StoreError::Read)?;
+        let rows = statement
+            .query_map(rusqlite::params_from_iter(scopes), |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+            })
+            .map_err(StoreError::Read)?;
+
+        let mut counts = HashMap::new();
+        for row in rows {
+            let (scope, count) = row.map_err(StoreError::Read)?;
+            counts.insert(scope, count.try_into().unwrap_or(usize::MAX));
+        }
+        Ok(counts)
     }
 
     /// Writes the current text at an anchor, replacing anything already there.
@@ -1278,5 +1345,117 @@ mod tests {
     fn the_default_path_is_under_application_support() {
         let path = default_database_path().unwrap();
         assert!(path.ends_with("Library/Application Support/ZReview/review-data.sqlite3"));
+    }
+
+    #[test]
+    fn counts_by_scope_sum_every_head_and_omit_scopes_with_nothing() {
+        const OTHER_SCOPE: &str = "github:acme/widgets#43";
+        let store = ReviewStore::open_in_memory().unwrap();
+        store
+            .upsert(
+                SCOPE,
+                &anchor("src/a.rs", 1, DiffSide::Right, OTHER_HEAD),
+                "before the push",
+            )
+            .unwrap();
+        store
+            .upsert(
+                SCOPE,
+                &anchor("src/a.rs", 2, DiffSide::Right, HEAD),
+                "after the push",
+            )
+            .unwrap();
+        store
+            .upsert(
+                OTHER_SCOPE,
+                &anchor("src/b.rs", 1, DiffSide::Right, HEAD),
+                "a different review",
+            )
+            .unwrap();
+
+        let counts = store
+            .count_by_scopes(&[
+                SCOPE.to_owned(),
+                OTHER_SCOPE.to_owned(),
+                "github:acme/widgets#99".to_owned(),
+            ])
+            .unwrap();
+
+        assert_eq!(counts.get(SCOPE), Some(&2), "both heads count");
+        assert_eq!(counts.get(OTHER_SCOPE), Some(&1));
+        assert_eq!(
+            counts.get("github:acme/widgets#99"),
+            None,
+            "a scope with nothing stored is absent, not zero",
+        );
+    }
+
+    #[test]
+    fn counting_with_no_scopes_asked_about_reads_nothing() {
+        let store = ReviewStore::open_in_memory().unwrap();
+        store
+            .upsert(SCOPE, &anchor("src/a.rs", 1, DiffSide::Right, HEAD), "body")
+            .unwrap();
+
+        assert!(store.count_by_scopes(&[]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn open_read_only_refuses_a_missing_database_without_creating_it() {
+        let directory = TempDir::new().unwrap();
+        let path = directory.path().join("review-data.sqlite3");
+
+        let Err(error) = ReviewStore::open_read_only(&path) else {
+            panic!("a missing database must be refused");
+        };
+
+        assert!(
+            matches!(error, StoreError::Missing),
+            "unexpected error: {error}"
+        );
+        assert!(
+            !path.exists(),
+            "a read-only open must never create the file"
+        );
+    }
+
+    #[test]
+    fn open_read_only_reads_a_database_a_writer_already_created() {
+        let directory = TempDir::new().unwrap();
+        let path = directory.path().join("review-data.sqlite3");
+        {
+            let store = ReviewStore::open(&path).unwrap();
+            store
+                .upsert(SCOPE, &anchor("src/a.rs", 1, DiffSide::Right, HEAD), "body")
+                .unwrap();
+        }
+
+        let reader = ReviewStore::open_read_only(&path).unwrap();
+
+        assert_eq!(
+            reader.count_by_scopes(&[SCOPE.to_owned()]).unwrap()[SCOPE],
+            1
+        );
+    }
+
+    /// A schema this build has not migrated to is unreadable, not silently
+    /// treated as whatever the current schema means.
+    #[test]
+    fn open_read_only_refuses_a_schema_version_this_build_does_not_know() {
+        let directory = TempDir::new().unwrap();
+        let path = directory.path().join("review-data.sqlite3");
+        {
+            let connection = Connection::open(&path).unwrap();
+            connection.pragma_update(None, "user_version", 999).unwrap();
+        }
+
+        let Err(error) = ReviewStore::open_read_only(&path) else {
+            panic!("an unknown schema version must be refused");
+        };
+
+        assert!(
+            matches!(error, StoreError::UnsupportedSchemaVersion(999)),
+            "unexpected error: {error}",
+        );
     }
 }


### PR DESCRIPTION
Closes #17

Home's rows had an empty Drafts column. A reviewer with unsent comments on a pull request had no way to see that from the list, which is the one thing the badge exists to prevent forgetting.

What changed:
- The store gains a read-only open that never migrates, accepts any schema version up to the current one, and a single grouped count of drafts per scope
- Home reads the store after each refresh, off the UI thread and outside the model lock, and joins counts onto rows by scope regardless of head, matched case-insensitively so a mixed-case remote cannot hide them
- Rows show a badge reading 1 draft or N drafts, a blank cell otherwise, and counts carry across a progressive refresh so they never blink out
- A store that cannot be read shows a line above the list and blanks every badge rather than showing zero
- The Session's draft scope and Home's share one formatter, and the two failure lines above the list share one component

Notes:
Start with the store's new read and the join in the Home model. The badge uses the accent tokens the layout prototype chose. This branch adds fields near the Drafts cell and the row DTO that the open-row branch also touches, so whichever merges second needs a small rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189um4LrckqAAq5fgnixT1p
