### PR TITLE
Open a Home row into a Session and come back

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -3,29 +3,32 @@
 use std::{
     path::{Path, PathBuf},
     sync::{
-        Mutex,
+        Arc, Mutex,
         atomic::{AtomicBool, Ordering},
     },
 };
 
-use app::{SessionPhase, SettingsWrite, lock, try_lock};
+use app::{PullRequestId, RepositoryOutcome, SessionPhase, SettingsWrite, Showing, lock, try_lock};
 use domain::DiffSide;
 use session::{ReviewStorage, SessionRequest};
 use tauri::ipc::Channel;
 use tauri_specta::collect_commands;
 
-use crate::{AppRoot, ManagedHome, ManagedSession, drafts, dto, pull_requests, repositories};
+use crate::{AppRoot, ManagedHome, Window, drafts, dto, pull_requests, repositories};
 
 /// The specta builder, shared between the invoke handler and the bindings export.
 #[must_use]
 pub fn specta_builder() -> tauri_specta::Builder<tauri::Wry> {
     tauri_specta::Builder::<tauri::Wry>::new().commands(collect_commands![
-        describe_launch,
+        describe_window,
         refresh_home,
         move_home_cursor,
         add_repositories,
         remove_repository,
         toggle_repositories_footer,
+        open_row,
+        return_to_home,
+        return_to_session,
         open_session,
         select_file,
         toggle_viewed,
@@ -433,20 +436,31 @@ pub async fn open_session(
     state: tauri::State<'_, AppRoot>,
     on_stage: Channel<String>,
 ) -> Result<dto::SessionSnapshotDto, dto::SessionFailureDto> {
-    let session = session(&state)?;
-    let model = std::sync::Arc::clone(&session.model);
-    let load_started = std::sync::Arc::clone(&session.load_started);
-    let request = session.request.clone();
-    let storage = session.storage.clone();
+    // Taken out whole, so nothing holds the window's lock across the load, and
+    // a Session replaced part way through still reports its own result.
+    let (model, load_started, request, storage) = {
+        let window = lock(&state.window);
+        let session = window
+            .session
+            .as_ref()
+            .ok_or_else(|| dto::command_failure("no session is open"))?;
+        (
+            Arc::clone(&session.model),
+            Arc::clone(&session.load_started),
+            session.request.clone(),
+            session.storage.clone(),
+        )
+    };
+    let loading = Arc::clone(&model);
     tauri::async_runtime::spawn_blocking(move || {
-        load_if_pending(&model, &load_started, &request, &storage, &|stage| {
+        load_if_pending(&loading, &load_started, &request, &storage, &|stage| {
             let _ = on_stage.send(stage.to_owned());
         });
     })
     .await
     .expect("the load task should not panic");
 
-    let guard = lock(&session.model);
+    let guard = lock(&model);
     match guard.phase() {
         SessionPhase::Ready(review) => Ok(dto::project_snapshot(review.session())),
         SessionPhase::Failed(failure) => Err(failure.into()),
@@ -563,37 +577,158 @@ pub fn toggle_repositories_footer(state: tauri::State<'_, AppRoot>) -> dto::Home
     dto::project_home(&lock(&state.home.model))
 }
 
-/// Which screen the binary was launched into, asked once before anything is
-/// rendered.
+/// Which screen the window shows, and the Session it is holding.
 ///
-/// A Session carries its request's own description, which is all the loading
+/// Asked once before anything is rendered, and again after every navigation. A
+/// Session carries its request's own description, which is all the loading
 /// screen can say before the load reaches the pull request itself.
 #[tauri::command]
 #[specta::specta]
 #[allow(clippy::needless_pass_by_value)]
-pub fn describe_launch(state: tauri::State<'_, AppRoot>) -> dto::LaunchDto {
-    describe_launch_on_root(&state)
+pub fn describe_window(state: tauri::State<'_, AppRoot>) -> dto::WindowDto {
+    describe_window_on_root(&state)
 }
 
-fn describe_launch_on_root(root: &AppRoot) -> dto::LaunchDto {
-    match &root.session {
-        Some(session) => dto::LaunchDto::Session {
-            description: session.request.description(),
+fn describe_window_on_root(root: &AppRoot) -> dto::WindowDto {
+    describe(&lock(&root.window))
+}
+
+/// What the window shows now, from a window already locked.
+fn describe(window: &Window) -> dto::WindowDto {
+    let session = window.session.as_ref().map(|session| dto::OpenSessionDto {
+        description: session.request.description(),
+        row_identity: window
+            .slot
+            .session()
+            .and_then(app::OpenSession::row_identity),
+    });
+    match window.slot.showing() {
+        Showing::Home => dto::WindowDto::Home { alive: session },
+        Showing::Session => dto::WindowDto::Session {
+            session: session.expect("a window showing a Session is holding one"),
         },
-        None => dto::LaunchDto::Home,
     }
 }
 
-/// The Session behind the commands that need one.
+/// Opens the pull request a Home row names, replacing whatever Session was
+/// alive.
 ///
-/// Absent on a Home launch, where the frontend never calls them, so a call that
-/// arrives anyway is answered rather than assumed away.
-fn session<'a>(
-    state: &'a tauri::State<'_, AppRoot>,
-) -> Result<&'a ManagedSession, dto::SessionFailureDto> {
-    state
+/// # Errors
+///
+/// Returns a failure when no configured clone resolves to `repository`, which
+/// leaves the Session that was alive exactly as it was.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn open_row(
+    state: tauri::State<'_, AppRoot>,
+    repository: String,
+    number: u32,
+) -> Result<dto::WindowDto, dto::SessionFailureDto> {
+    open_row_on_root(&state, &repository, u64::from(number))
+}
+
+fn open_row_on_root(
+    root: &AppRoot,
+    repository: &str,
+    number: u64,
+) -> Result<dto::WindowDto, dto::SessionFailureDto> {
+    // Looked up before the window is touched, so a row that cannot be opened
+    // costs the reviewer nothing of the Session they were reading.
+    let clone_root = configured_clone(&root.home, repository)?;
+    let mut window = lock(&root.window);
+    window.open(
+        PullRequestId {
+            repository: repository.to_owned(),
+            number,
+        },
+        clone_root,
+    );
+    Ok(describe(&window))
+}
+
+/// The clone to open a row's pull request out of.
+///
+/// The first in settings order whose remote names `repository`, because two
+/// checkouts of one repository reach the same pull request either way.
+fn configured_clone(
+    home: &ManagedHome,
+    repository: &str,
+) -> Result<PathBuf, dto::SessionFailureDto> {
+    lock(&home.model)
+        .repositories()
+        .iter()
+        .find_map(|entry| match &entry.outcome {
+            RepositoryOutcome::Valid { root, slug } => {
+                slug.eq_ignore_ascii_case(repository).then(|| root.clone())
+            }
+            RepositoryOutcome::Failed { .. } => None,
+        })
+        .ok_or_else(|| {
+            dto::command_failure(format!("Home has no configured clone of {repository}"))
+        })
+}
+
+/// Shows Home again, leaving the Session alive behind it.
+///
+/// # Errors
+///
+/// Returns a failure for a Session the command line opened, which has no Home
+/// behind it to go back to.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn return_to_home(
+    state: tauri::State<'_, AppRoot>,
+) -> Result<dto::WindowDto, dto::SessionFailureDto> {
+    return_to_home_on_root(&state)
+}
+
+fn return_to_home_on_root(root: &AppRoot) -> Result<dto::WindowDto, dto::SessionFailureDto> {
+    let mut window = lock(&root.window);
+    if !window.slot.back_to_home() {
+        return Err(dto::command_failure(
+            "this session has no Home to go back to",
+        ));
+    }
+    Ok(describe(&window))
+}
+
+/// Shows the Session alive behind Home again, exactly as it was left.
+///
+/// # Errors
+///
+/// Returns a failure when no Session is alive, which the header slot's own
+/// absence already keeps a reviewer from asking for.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn return_to_session(
+    state: tauri::State<'_, AppRoot>,
+) -> Result<dto::WindowDto, dto::SessionFailureDto> {
+    return_to_session_on_root(&state)
+}
+
+fn return_to_session_on_root(root: &AppRoot) -> Result<dto::WindowDto, dto::SessionFailureDto> {
+    let mut window = lock(&root.window);
+    if !window.slot.return_to_session() {
+        return Err(dto::command_failure("no session is open"));
+    }
+    Ok(describe(&window))
+}
+
+/// The model of the Session this window holds, for the commands that need one.
+///
+/// Absent before a row has been opened, where the frontend never calls them, so
+/// a call that arrives anyway is answered rather than assumed away. Handed out
+/// as its own handle so no command holds the window's lock while it works.
+fn session_model(
+    state: &tauri::State<'_, AppRoot>,
+) -> Result<Arc<Mutex<app::SessionModel>>, dto::SessionFailureDto> {
+    lock(&state.window)
         .session
         .as_ref()
+        .map(|session| Arc::clone(&session.model))
         .ok_or_else(|| dto::command_failure("no session is open"))
 }
 
@@ -609,7 +744,8 @@ pub async fn select_file(
     state: tauri::State<'_, AppRoot>,
     index: u32,
 ) -> Result<dto::FileDetailDto, dto::SessionFailureDto> {
-    select_file_on_model(&session(&state)?.model, index as usize)
+    let model = session_model(&state)?;
+    select_file_on_model(&model, index as usize)
 }
 
 /// Marks the selected file viewed, or unmarks it, and returns the fresh sidebar.
@@ -623,7 +759,8 @@ pub async fn select_file(
 pub fn toggle_viewed(
     state: tauri::State<'_, AppRoot>,
 ) -> Result<dto::SidebarDto, dto::SessionFailureDto> {
-    toggle_viewed_on_model(&session(&state)?.model)
+    let model = session_model(&state)?;
+    toggle_viewed_on_model(&model)
 }
 
 /// Edits the draft over rows `start..=end` of `file_index`. Persists the new
@@ -645,8 +782,9 @@ pub fn edit_draft(
     end: u32,
     body: String,
 ) -> Result<dto::DraftEditOutcomeDto, dto::SessionFailureDto> {
+    let model = session_model(&state)?;
     edit_draft_on_model(
-        &session(&state)?.model,
+        &model,
         file_index as usize,
         start as usize,
         end as usize,
@@ -667,7 +805,8 @@ pub fn discard_draft(
     file_index: u32,
     row: u32,
 ) -> Result<dto::DraftsDto, dto::SessionFailureDto> {
-    discard_draft_on_model(&session(&state)?.model, file_index as usize, row as usize)
+    let model = session_model(&state)?;
+    discard_draft_on_model(&model, file_index as usize, row as usize)
 }
 
 /// Moves a stale draft, named by the position it was written against, onto
@@ -688,8 +827,9 @@ pub fn reanchor_draft(
     line: u32,
     row: u32,
 ) -> Result<dto::DraftsDto, dto::SessionFailureDto> {
+    let model = session_model(&state)?;
     reanchor_draft_on_model(
-        &session(&state)?.model,
+        &model,
         file_index as usize,
         &path,
         side.into(),
@@ -944,34 +1084,251 @@ mod tests {
             base: "main".to_owned(),
             head: "feature".to_owned(),
         };
-        let root = AppRoot {
-            home: ManagedHome::new(github::GithubClient::default()),
-            session: Some(ManagedSession {
-                model: Arc::new(Mutex::new(app::SessionModel::loading(
-                    request.description(),
-                ))),
-                request: request.clone(),
-                storage: ReviewStorage::Disabled,
-                load_started: Arc::new(AtomicBool::new(false)),
-            }),
-        };
+        let root = command_line_root(request.clone());
 
         assert_eq!(
-            describe_launch_on_root(&root),
-            dto::LaunchDto::Session {
-                description: request.description(),
+            describe_window_on_root(&root),
+            dto::WindowDto::Session {
+                session: dto::OpenSessionDto {
+                    description: request.description(),
+                    row_identity: None,
+                },
             },
         );
     }
 
     #[test]
     fn a_launch_with_no_session_is_described_as_home() {
-        let root = AppRoot {
-            home: ManagedHome::new(github::GithubClient::default()),
-            session: None,
-        };
+        let root = home_root(ManagedHome::new(github::GithubClient::default()));
 
-        assert_eq!(describe_launch_on_root(&root), dto::LaunchDto::Home);
+        assert_eq!(
+            describe_window_on_root(&root),
+            dto::WindowDto::Home { alive: None },
+        );
+    }
+
+    /// A window opened on Home, listing whatever `home` was configured with.
+    fn home_root(home: ManagedHome) -> AppRoot {
+        AppRoot {
+            home,
+            window: Mutex::new(Window::home()),
+        }
+    }
+
+    /// A window the command line opened straight into `request`'s Session.
+    fn command_line_root(request: SessionRequest) -> AppRoot {
+        AppRoot {
+            home: ManagedHome::new(github::GithubClient::default()),
+            window: Mutex::new(Window::command_line(request, ReviewStorage::Disabled)),
+        }
+    }
+
+    /// A window on Home with `clone` configured, ready to open a row from it.
+    ///
+    /// Configured through Add rather than a refresh, because opening a row asks
+    /// nothing of GitHub. The load itself is deferred until `open_session`.
+    fn home_root_listing(clone: &TempDir, settings_path: &Path) -> AppRoot {
+        let home = home_model();
+        add_repositories_on_model(&home, settings_path, &[clone.path().to_path_buf()]);
+        home_root(home)
+    }
+
+    /// Which `SessionModel` the window is holding, so a test can tell the one
+    /// that was kept alive from one loaded in its place.
+    fn session_identity(root: &AppRoot) -> *const Mutex<app::SessionModel> {
+        Arc::as_ptr(
+            &lock(&root.window)
+                .session
+                .as_ref()
+                .expect("a session is open")
+                .model,
+        )
+    }
+
+    /// What the window is holding, as the request it was opened with.
+    fn open_request(root: &AppRoot) -> SessionRequest {
+        lock(&root.window)
+            .session
+            .as_ref()
+            .expect("a session is open")
+            .request
+            .clone()
+    }
+
+    #[test]
+    fn opening_a_row_opens_its_pull_request_out_of_the_clone_it_is_configured_in() {
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = directory.path().join("settings.toml");
+        let root = home_root_listing(&clone, &settings_path);
+
+        let shown = open_row_on_root(&root, "acme/widgets", 412).expect("the clone is configured");
+
+        assert_eq!(
+            shown,
+            dto::WindowDto::Session {
+                session: dto::OpenSessionDto {
+                    description: "pull request #412".to_owned(),
+                    row_identity: Some("acme/widgets#412".to_owned()),
+                },
+            },
+        );
+        assert_eq!(
+            open_request(&root),
+            SessionRequest::PullRequest {
+                repository: clone.path().canonicalize().unwrap(),
+                selector: github::PullRequestSelector::Number(412),
+            },
+        );
+        assert_eq!(
+            lock(&root.window)
+                .session
+                .as_ref()
+                .expect("a session is open")
+                .storage,
+            ReviewStorage::Default,
+            "a row's drafts are kept, so it opens on the default storage",
+        );
+    }
+
+    /// The whole point of keeping one Session alive. Coming back to it costs no
+    /// load at all.
+    #[test]
+    fn opening_the_row_already_alive_shows_the_same_session_again() {
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = directory.path().join("settings.toml");
+        let root = home_root_listing(&clone, &settings_path);
+        open_row_on_root(&root, "acme/widgets", 412).expect("the clone is configured");
+        let alive = session_identity(&root);
+        return_to_home_on_root(&root).expect("there is a Home behind it");
+
+        open_row_on_root(&root, "acme/widgets", 412).expect("the clone is configured");
+
+        assert_eq!(session_identity(&root), alive);
+    }
+
+    #[test]
+    fn opening_another_row_replaces_the_session_that_was_alive() {
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = directory.path().join("settings.toml");
+        let root = home_root_listing(&clone, &settings_path);
+        open_row_on_root(&root, "acme/widgets", 412).expect("the clone is configured");
+        let dropped = session_identity(&root);
+
+        open_row_on_root(&root, "acme/widgets", 398).expect("the clone is configured");
+
+        assert_ne!(session_identity(&root), dropped);
+        assert_eq!(
+            open_request(&root),
+            SessionRequest::PullRequest {
+                repository: clone.path().canonicalize().unwrap(),
+                selector: github::PullRequestSelector::Number(398),
+            },
+        );
+    }
+
+    #[test]
+    fn going_back_shows_home_and_reports_the_session_still_alive_behind_it() {
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = directory.path().join("settings.toml");
+        let root = home_root_listing(&clone, &settings_path);
+        open_row_on_root(&root, "acme/widgets", 412).expect("the clone is configured");
+        let alive = session_identity(&root);
+
+        let shown = return_to_home_on_root(&root).expect("there is a Home behind it");
+
+        assert_eq!(
+            shown,
+            dto::WindowDto::Home {
+                alive: Some(dto::OpenSessionDto {
+                    description: "pull request #412".to_owned(),
+                    row_identity: Some("acme/widgets#412".to_owned()),
+                }),
+            },
+        );
+        assert_eq!(session_identity(&root), alive, "back is not a close");
+        assert_eq!(describe_window_on_root(&root), shown);
+    }
+
+    /// The header slot is the way back to a Session whose pull request has no
+    /// row in the list at all.
+    #[test]
+    fn the_header_slot_shows_the_session_alive_behind_home_again() {
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = directory.path().join("settings.toml");
+        let root = home_root_listing(&clone, &settings_path);
+        let opened = open_row_on_root(&root, "acme/widgets", 412).expect("the clone is configured");
+        return_to_home_on_root(&root).expect("there is a Home behind it");
+
+        let shown = return_to_session_on_root(&root).expect("a session is alive");
+
+        assert_eq!(shown, opened);
+    }
+
+    #[test]
+    fn returning_to_a_session_before_any_row_was_opened_says_there_is_none() {
+        let root = home_root(home_model());
+
+        let refused = return_to_session_on_root(&root).expect_err("no session is alive");
+
+        assert_eq!(refused.summary, "no session is open");
+    }
+
+    #[test]
+    fn a_session_the_command_line_opened_has_no_home_to_go_back_to() {
+        let root = command_line_root(SessionRequest::Demo);
+
+        let refused = return_to_home_on_root(&root).expect_err("there is no Home behind it");
+
+        assert_eq!(refused.summary, "this session has no Home to go back to");
+    }
+
+    /// The row's repository can be dropped from the settings file between the
+    /// refresh that listed it and the Enter that opens it.
+    #[test]
+    fn opening_a_row_of_a_repository_no_longer_configured_says_which_one() {
+        let root = home_root(home_model());
+
+        let refused =
+            open_row_on_root(&root, "acme/widgets", 412).expect_err("nothing is configured");
+
+        assert_eq!(
+            refused.summary,
+            "Home has no configured clone of acme/widgets"
+        );
+        assert!(
+            lock(&root.window).session.is_none(),
+            "a row that could not be opened drops nothing",
+        );
+    }
+
+    /// A refusal must not cost the reviewer the Session they were reading.
+    #[test]
+    fn a_row_that_could_not_be_opened_leaves_the_session_alive() {
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = directory.path().join("settings.toml");
+        let root = home_root_listing(&clone, &settings_path);
+        open_row_on_root(&root, "acme/widgets", 412).expect("the clone is configured");
+        let alive = session_identity(&root);
+        return_to_home_on_root(&root).expect("there is a Home behind it");
+
+        open_row_on_root(&root, "acme/billing", 7).expect_err("that clone is not configured");
+
+        assert_eq!(session_identity(&root), alive);
+        assert_eq!(
+            describe_window_on_root(&root),
+            dto::WindowDto::Home {
+                alive: Some(dto::OpenSessionDto {
+                    description: "pull request #412".to_owned(),
+                    row_identity: Some("acme/widgets#412".to_owned()),
+                }),
+            },
+        );
     }
 
     /// A clone whose `origin` points at GitHub, which is what Home configures.

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1445,7 +1445,12 @@ mod tests {
         let directory = TempDir::new().unwrap();
         let settings_path = settings_listing(&directory, &[&clone]);
         let root = home_root(home_with(&gh));
-        refresh_home_on_model(&root, &settings_path, &|_progress| {});
+        refresh_home_on_model(
+            &root,
+            &settings_path,
+            &no_drafts_database(),
+            &|_progress| {},
+        );
         assert!(
             shown_home(&root).groups[0]
                 .rows
@@ -1561,7 +1566,12 @@ mod tests {
 
     /// A refresh with nothing listening to its progress.
     fn refresh(home: &ManagedHome, settings_path: &Path) {
-        refresh_home_on_model(&home_root(home.clone()), settings_path, &no_drafts_database(), &|_progress| {});
+        refresh_home_on_model(
+            &home_root(home.clone()),
+            settings_path,
+            &no_drafts_database(),
+            &|_progress| {},
+        );
     }
 
     /// A settings file listing `clones`.
@@ -1642,9 +1652,14 @@ mod tests {
     /// Everything a refresh reported, in the order it said it.
     fn reported_by(home: &ManagedHome, settings_path: &Path) -> Vec<dto::HomeSnapshotDto> {
         let reported = Mutex::new(Vec::new());
-        refresh_home_on_model(&home_root(home.clone()), settings_path, &no_drafts_database(), &|shown| {
-            reported.lock().unwrap().push(shown);
-        });
+        refresh_home_on_model(
+            &home_root(home.clone()),
+            settings_path,
+            &no_drafts_database(),
+            &|shown| {
+                reported.lock().unwrap().push(shown);
+            },
+        );
         reported.into_inner().unwrap()
     }
 
@@ -1743,12 +1758,17 @@ mod tests {
         let reports = std::sync::atomic::AtomicUsize::new(0);
 
         let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            refresh_home_on_model(&home_root(home.clone()), &settings_path, &no_drafts_database(), &|_shown| {
-                assert!(
-                    reports.fetch_add(1, Ordering::AcqRel) < 2,
-                    "the refresh gave up here"
-                );
-            });
+            refresh_home_on_model(
+                &home_root(home.clone()),
+                &settings_path,
+                &no_drafts_database(),
+                &|_shown| {
+                    assert!(
+                        reports.fetch_add(1, Ordering::AcqRel) < 2,
+                        "the refresh gave up here"
+                    );
+                },
+            );
         }));
 
         assert!(panicked.is_err(), "the refresh was stopped by a panic");
@@ -1770,9 +1790,12 @@ mod tests {
         let settings_path = settings_listing(&directory, &[&clone]);
         let home = home_with(&gh);
         let _panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            refresh_home_on_model(&home_root(home.clone()), &settings_path, &no_drafts_database(), &|_shown| {
-                panic!("gave up")
-            });
+            refresh_home_on_model(
+                &home_root(home.clone()),
+                &settings_path,
+                &no_drafts_database(),
+                &|_shown| panic!("gave up"),
+            );
         }));
 
         refresh(&home, &settings_path);

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -8,7 +8,9 @@ use std::{
     },
 };
 
-use app::{PullRequestId, RepositoryOutcome, SessionPhase, SettingsWrite, Showing, lock, try_lock};
+use app::{
+    Opened, PullRequestId, RepositoryOutcome, SessionPhase, SettingsWrite, Showing, lock, try_lock,
+};
 use domain::DiffSide;
 use session::{ReviewStorage, SessionRequest};
 use tauri::ipc::Channel;
@@ -51,11 +53,12 @@ pub fn specta_builder() -> tauri_specta::Builder<tauri::Wry> {
 /// Takes the reporter as a plain callback so it can be tested without a Tauri
 /// channel, as `run_load` does.
 fn refresh_home_on_model(
-    home: &ManagedHome,
+    root: &AppRoot,
     settings_path: &Path,
     database_path: &Path,
     report: &dyn Fn(dto::HomeSnapshotDto),
 ) {
+    let home = &root.home;
     let Some(_ordered) = try_lock(&home.settings_action) else {
         return;
     };
@@ -63,13 +66,13 @@ fn refresh_home_on_model(
     // Every way out from here says how the refresh went, except a panic, which
     // would otherwise leave the stamp counting repositories off for ever.
     let _abandoned = AbandonedRefresh { home };
-    report_home(home, report);
+    report_home(root, report);
 
     read_into_model(home, settings_path);
     // Only the settings file can have failed by here, whatever stopped the last
     // refresh having gone with the trigger that started this one.
     if lock(&home.model).failure().is_some() {
-        report_home(home, report);
+        report_home(root, report);
         return;
     }
     let (slugs, preflight_in) = to_fetch(&lock(&home.model));
@@ -77,22 +80,22 @@ fn refresh_home_on_model(
         && let Err(failure) = pull_requests::preflight(&home.client, &clone)
     {
         lock(&home.model).preflight_failed(failure);
-        report_home(home, report);
+        report_home(root, report);
         return;
     }
 
     lock(&home.model).fetching(slugs.len());
-    report_home(home, report);
+    report_home(root, report);
     pull_requests::fetch(&home.client, &slugs, &|batch| {
         lock(&home.model).batch_fetched(batch);
-        report_home(home, report);
+        report_home(root, report);
     });
     // Evaluated before the lock is taken, so the store open and query never
     // hold the model mutex against every other command waiting on it.
     let drafts_result = drafts::read(database_path);
     lock(&home.model).drafts_read(drafts_result);
     lock(&home.model).finish_refresh(now_ms());
-    report_home(home, report);
+    report_home(root, report);
 }
 
 /// Ends a refresh that stopped without finishing.
@@ -111,9 +114,25 @@ impl Drop for AbandonedRefresh<'_> {
 }
 
 /// Hands the reporter everything Home now shows, so a list fills in as it loads.
-fn report_home(home: &ManagedHome, report: &dyn Fn(dto::HomeSnapshotDto)) {
-    let shown = dto::project_home(&lock(&home.model));
-    report(shown);
+fn report_home(root: &AppRoot, report: &dyn Fn(dto::HomeSnapshotDto)) {
+    report(shown_home(root));
+}
+
+/// Everything Home now shows, with the row of the Session behind it marked.
+fn shown_home(root: &AppRoot) -> dto::HomeSnapshotDto {
+    // Read out and released before Home's own lock is taken, so the two are
+    // never held at once and so can never be taken in two orders.
+    let alive = alive_pull_request(root);
+    dto::project_home(&lock(&root.home.model), alive.as_ref())
+}
+
+/// The pull request the Session behind Home is open on, when one is.
+fn alive_pull_request(root: &AppRoot) -> Option<PullRequestId> {
+    lock(&root.window)
+        .slot
+        .session()
+        .and_then(app::OpenSession::pull_request)
+        .cloned()
 }
 
 /// The repositories a refresh will ask about, and the clone to preflight in.
@@ -149,16 +168,12 @@ fn now_ms() -> i64 {
     i64::try_from(since_epoch.as_millis()).expect("the system clock is set before the year 292M")
 }
 
-fn move_home_cursor_on_model(
-    home: &ManagedHome,
-    move_to: dto::CursorMoveDto,
-) -> dto::HomeSnapshotDto {
-    let mut guard = lock(&home.model);
+fn move_home_cursor_on_model(root: &AppRoot, move_to: dto::CursorMoveDto) -> dto::HomeSnapshotDto {
     match move_to {
-        dto::CursorMoveDto::Down => guard.move_cursor_down(),
-        dto::CursorMoveDto::Up => guard.move_cursor_up(),
+        dto::CursorMoveDto::Down => lock(&root.home.model).move_cursor_down(),
+        dto::CursorMoveDto::Up => lock(&root.home.model).move_cursor_up(),
     }
-    dto::project_home(&guard)
+    shown_home(root)
 }
 
 /// Adds the folders a reviewer picked, then leaves Home showing the file.
@@ -199,15 +214,12 @@ fn write_then_read(home: &ManagedHome, settings_path: &Path, write: Option<Setti
 ///
 /// A machine with no home directory has nowhere to keep the file, which is a
 /// whole-Home failure rather than something an action can work around.
-fn on_settings_file(
-    home: &ManagedHome,
-    action: impl FnOnce(&ManagedHome, &Path),
-) -> dto::HomeSnapshotDto {
+fn on_settings_file(root: &AppRoot, action: impl FnOnce(&AppRoot, &Path)) -> dto::HomeSnapshotDto {
     match repositories::settings_path() {
-        Ok(path) => action(home, &path),
-        Err(failure) => lock(&home.model).refreshed(Err(failure)),
+        Ok(path) => action(root, &path),
+        Err(failure) => lock(&root.home.model).refreshed(Err(failure)),
     }
-    dto::project_home(&lock(&home.model))
+    shown_home(root)
 }
 
 /// Runs Home's file and Git work away from the UI thread.
@@ -224,6 +236,14 @@ async fn off_the_ui_thread(
         })
 }
 
+/// Held for the whole of one Session load, so no two ever run at once.
+///
+/// Opening a different row drops the Session that was loading, but not the load
+/// itself, which runs on until it finishes. A load runs Git and `gh` against a
+/// clone, and the load that replaces it usually reaches the same clone, so the
+/// new one waits here rather than fetching over the old one.
+static SESSION_LOAD: Mutex<()> = Mutex::new(());
+
 /// Loads `request` into `model`, reporting each stage's label to `report`.
 ///
 /// Takes the reporter as a plain callback so it can be tested without a Tauri channel.
@@ -233,6 +253,7 @@ fn run_load(
     storage: &ReviewStorage,
     report: &dyn Fn(&str),
 ) {
+    let _ordered = lock(&SESSION_LOAD);
     let result = session::load(request, storage, &|stage| {
         let _ = lock(model).set_stage(stage.label());
         report(stage.label());
@@ -491,12 +512,12 @@ pub async fn refresh_home(
     state: tauri::State<'_, AppRoot>,
     on_progress: Channel<dto::HomeSnapshotDto>,
 ) -> Result<dto::HomeSnapshotDto, dto::SessionFailureDto> {
-    let home = state.home.clone();
+    let root = state.inner().clone();
     off_the_ui_thread(move || {
-        on_settings_file(&home, |home, settings_path| {
+        on_settings_file(&root, |root, settings_path| {
             let database_path = store::default_database_path()
                 .expect("HOME is set, since the settings path just resolved from it");
-            refresh_home_on_model(home, settings_path, &database_path, &|shown| {
+            refresh_home_on_model(root, settings_path, &database_path, &|shown| {
                 let _ = on_progress.send(shown);
             });
         })
@@ -512,7 +533,7 @@ pub fn move_home_cursor(
     state: tauri::State<'_, AppRoot>,
     move_to: dto::CursorMoveDto,
 ) -> dto::HomeSnapshotDto {
-    move_home_cursor_on_model(&state.home, move_to)
+    move_home_cursor_on_model(&state, move_to)
 }
 
 /// Adds the folders the reviewer picked, writing the file once and reading it
@@ -533,11 +554,11 @@ pub async fn add_repositories(
     state: tauri::State<'_, AppRoot>,
     folders: Vec<String>,
 ) -> Result<dto::HomeSnapshotDto, dto::SessionFailureDto> {
-    let home = state.home.clone();
+    let root = state.inner().clone();
     let folders = folders.into_iter().map(PathBuf::from).collect::<Vec<_>>();
     off_the_ui_thread(move || {
-        on_settings_file(&home, |home, path| {
-            add_repositories_on_model(home, path, &folders);
+        on_settings_file(&root, |root, path| {
+            add_repositories_on_model(&root.home, path, &folders);
         })
     })
     .await
@@ -558,11 +579,11 @@ pub async fn remove_repository(
     state: tauri::State<'_, AppRoot>,
     path: String,
 ) -> Result<dto::HomeSnapshotDto, dto::SessionFailureDto> {
-    let home = state.home.clone();
+    let root = state.inner().clone();
     let path = PathBuf::from(path);
     off_the_ui_thread(move || {
-        on_settings_file(&home, |home, settings_path| {
-            remove_repository_on_model(home, settings_path, &path);
+        on_settings_file(&root, |root, settings_path| {
+            remove_repository_on_model(&root.home, settings_path, &path);
         })
     })
     .await
@@ -574,7 +595,7 @@ pub async fn remove_repository(
 #[allow(clippy::needless_pass_by_value)]
 pub fn toggle_repositories_footer(state: tauri::State<'_, AppRoot>) -> dto::HomeSnapshotDto {
     lock(&state.home.model).toggle_footer();
-    dto::project_home(&lock(&state.home.model))
+    shown_home(&state)
 }
 
 /// Which screen the window shows, and the Session it is holding.
@@ -586,11 +607,7 @@ pub fn toggle_repositories_footer(state: tauri::State<'_, AppRoot>) -> dto::Home
 #[specta::specta]
 #[allow(clippy::needless_pass_by_value)]
 pub fn describe_window(state: tauri::State<'_, AppRoot>) -> dto::WindowDto {
-    describe_window_on_root(&state)
-}
-
-fn describe_window_on_root(root: &AppRoot) -> dto::WindowDto {
-    describe(&lock(&root.window))
+    describe(&lock(&state.window))
 }
 
 /// What the window shows now, from a window already locked.
@@ -637,14 +654,16 @@ fn open_row_on_root(
     // costs the reviewer nothing of the Session they were reading.
     let clone_root = configured_clone(&root.home, repository)?;
     let mut window = lock(&root.window);
-    window.open(
-        PullRequestId {
-            repository: repository.to_owned(),
-            number,
-        },
-        clone_root,
-    );
-    Ok(describe(&window))
+    let pull_request = PullRequestId {
+        repository: repository.to_owned(),
+        number,
+    };
+    match window.open(pull_request, clone_root) {
+        Opened::Returned | Opened::Loading => Ok(describe(&window)),
+        Opened::Refused => Err(dto::command_failure(
+            "this window has no Home to open a row from",
+        )),
+    }
 }
 
 /// The clone to open a row's pull request out of.
@@ -951,6 +970,42 @@ mod tests {
         assert!(matches!(lock(&model).phase(), SessionPhase::Ready(_)));
     }
 
+    /// A Session dropped mid-load leaves its loader running, and the load that
+    /// replaces it reaches the same clone. Two `git fetch` runs in one clone
+    /// with nothing between them is what the guard exists to stop.
+    #[test]
+    fn two_session_loads_run_one_after_the_other() {
+        let running = std::sync::atomic::AtomicUsize::new(0);
+        let overlapped = AtomicBool::new(false);
+
+        thread::scope(|scope| {
+            for _ in 0..2 {
+                let running = &running;
+                let overlapped = &overlapped;
+                scope.spawn(move || {
+                    let model = Mutex::new(app::SessionModel::loading("test"));
+                    run_load(
+                        &model,
+                        &SessionRequest::Demo,
+                        &ReviewStorage::Disabled,
+                        &|_stage| {
+                            if running.fetch_add(1, Ordering::AcqRel) > 0 {
+                                overlapped.store(true, Ordering::Release);
+                            }
+                            thread::sleep(std::time::Duration::from_millis(25));
+                            running.fetch_sub(1, Ordering::AcqRel);
+                        },
+                    );
+                });
+            }
+        });
+
+        assert!(
+            !overlapped.load(Ordering::Acquire),
+            "two loads were in flight at once",
+        );
+    }
+
     #[test]
     fn load_if_pending_does_not_reload_a_ready_model() {
         let model = loaded_model();
@@ -1087,7 +1142,7 @@ mod tests {
         let root = command_line_root(request.clone());
 
         assert_eq!(
-            describe_window_on_root(&root),
+            describe(&lock(&root.window)),
             dto::WindowDto::Session {
                 session: dto::OpenSessionDto {
                     description: request.description(),
@@ -1102,7 +1157,7 @@ mod tests {
         let root = home_root(ManagedHome::new(github::GithubClient::default()));
 
         assert_eq!(
-            describe_window_on_root(&root),
+            describe(&lock(&root.window)),
             dto::WindowDto::Home { alive: None },
         );
     }
@@ -1111,7 +1166,7 @@ mod tests {
     fn home_root(home: ManagedHome) -> AppRoot {
         AppRoot {
             home,
-            window: Mutex::new(Window::home()),
+            window: Arc::new(Mutex::new(Window::home())),
         }
     }
 
@@ -1119,7 +1174,10 @@ mod tests {
     fn command_line_root(request: SessionRequest) -> AppRoot {
         AppRoot {
             home: ManagedHome::new(github::GithubClient::default()),
-            window: Mutex::new(Window::command_line(request, ReviewStorage::Disabled)),
+            window: Arc::new(Mutex::new(Window::command_line(
+                request,
+                ReviewStorage::Disabled,
+            ))),
         }
     }
 
@@ -1133,16 +1191,31 @@ mod tests {
         home_root(home)
     }
 
-    /// Which `SessionModel` the window is holding, so a test can tell the one
-    /// that was kept alive from one loaded in its place.
-    fn session_identity(root: &AppRoot) -> *const Mutex<app::SessionModel> {
-        Arc::as_ptr(
-            &lock(&root.window)
-                .session
-                .as_ref()
-                .expect("a session is open")
-                .model,
-        )
+    /// Writes `stage` on the Session the window holds.
+    ///
+    /// A Session kept alive keeps whatever it had reached; one loaded in its
+    /// place starts over, which is how a test tells the two apart without
+    /// running a load.
+    fn mark_session(root: &AppRoot, stage: &str) {
+        let window = lock(&root.window);
+        let session = window.session.as_ref().expect("a session is open");
+        assert!(
+            lock(&session.model).set_stage(stage),
+            "the mark should take"
+        );
+    }
+
+    /// How far the Session the window holds has got.
+    fn session_stage(root: &AppRoot) -> String {
+        let window = lock(&root.window);
+        let session = window.session.as_ref().expect("a session is open");
+        let guard = lock(&session.model);
+        match guard.phase() {
+            SessionPhase::Loading { stage, .. } => stage.clone(),
+            SessionPhase::Ready(_) | SessionPhase::Failed(_) => {
+                panic!("a row's load is deferred until open_session")
+            }
+        }
     }
 
     /// What the window is holding, as the request it was opened with.
@@ -1200,12 +1273,12 @@ mod tests {
         let settings_path = directory.path().join("settings.toml");
         let root = home_root_listing(&clone, &settings_path);
         open_row_on_root(&root, "acme/widgets", 412).expect("the clone is configured");
-        let alive = session_identity(&root);
+        mark_session(&root, "half way through");
         return_to_home_on_root(&root).expect("there is a Home behind it");
 
         open_row_on_root(&root, "acme/widgets", 412).expect("the clone is configured");
 
-        assert_eq!(session_identity(&root), alive);
+        assert_eq!(session_stage(&root), "half way through");
     }
 
     #[test]
@@ -1215,11 +1288,15 @@ mod tests {
         let settings_path = directory.path().join("settings.toml");
         let root = home_root_listing(&clone, &settings_path);
         open_row_on_root(&root, "acme/widgets", 412).expect("the clone is configured");
-        let dropped = session_identity(&root);
+        mark_session(&root, "half way through");
 
         open_row_on_root(&root, "acme/widgets", 398).expect("the clone is configured");
 
-        assert_ne!(session_identity(&root), dropped);
+        assert_eq!(
+            session_stage(&root),
+            "Starting",
+            "the Session that was alive was dropped, not carried over",
+        );
         assert_eq!(
             open_request(&root),
             SessionRequest::PullRequest {
@@ -1236,7 +1313,7 @@ mod tests {
         let settings_path = directory.path().join("settings.toml");
         let root = home_root_listing(&clone, &settings_path);
         open_row_on_root(&root, "acme/widgets", 412).expect("the clone is configured");
-        let alive = session_identity(&root);
+        mark_session(&root, "half way through");
 
         let shown = return_to_home_on_root(&root).expect("there is a Home behind it");
 
@@ -1249,8 +1326,12 @@ mod tests {
                 }),
             },
         );
-        assert_eq!(session_identity(&root), alive, "back is not a close");
-        assert_eq!(describe_window_on_root(&root), shown);
+        assert_eq!(
+            session_stage(&root),
+            "half way through",
+            "back is not a close",
+        );
+        assert_eq!(describe(&lock(&root.window)), shown);
     }
 
     /// The header slot is the way back to a Session whose pull request has no
@@ -1276,6 +1357,113 @@ mod tests {
         let refused = return_to_session_on_root(&root).expect_err("no session is alive");
 
         assert_eq!(refused.summary, "no session is open");
+    }
+
+    /// Only Home lists a row, and a window the command line opened never shows
+    /// one, so a row arriving here is answered rather than acted on.
+    #[test]
+    fn a_window_the_command_line_opened_refuses_to_open_a_row() {
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = directory.path().join("settings.toml");
+        let root = command_line_root(SessionRequest::Demo);
+        add_repositories_on_model(&root.home, &settings_path, &[clone.path().to_path_buf()]);
+
+        let refused =
+            open_row_on_root(&root, "acme/widgets", 412).expect_err("there is no Home here");
+
+        assert_eq!(
+            refused.summary,
+            "this window has no Home to open a row from"
+        );
+        assert_eq!(
+            describe(&lock(&root.window)),
+            dto::WindowDto::Session {
+                session: dto::OpenSessionDto {
+                    description: SessionRequest::Demo.description(),
+                    row_identity: None,
+                },
+            },
+            "the Session it was opened with is still the one it holds",
+        );
+    }
+
+    /// Two checkouts of one repository reach the same pull request, so the row
+    /// opens out of whichever the reviewer configured first.
+    #[test]
+    fn a_row_opens_out_of_the_first_clone_of_its_repository_in_settings_order() {
+        let first = clone_of("acme/widgets");
+        let second = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = directory.path().join("settings.toml");
+        let home = home_model();
+        add_repositories_on_model(
+            &home,
+            &settings_path,
+            &[first.path().to_path_buf(), second.path().to_path_buf()],
+        );
+        let root = home_root(home);
+
+        open_row_on_root(&root, "acme/widgets", 412).expect("both clones are configured");
+
+        assert_eq!(
+            open_request(&root),
+            SessionRequest::PullRequest {
+                repository: first.path().canonicalize().unwrap(),
+                selector: github::PullRequestSelector::Number(412),
+            },
+        );
+    }
+
+    /// GitHub compares two repository names without regard to case, so a row
+    /// that came back cased differently still finds its clone.
+    #[test]
+    fn a_row_cased_differently_from_its_clone_still_opens() {
+        let clone = clone_of("ACME/Widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = directory.path().join("settings.toml");
+        let root = home_root_listing(&clone, &settings_path);
+
+        open_row_on_root(&root, "acme/widgets", 412).expect("the clone is configured");
+
+        assert_eq!(
+            open_request(&root),
+            SessionRequest::PullRequest {
+                repository: clone.path().canonicalize().unwrap(),
+                selector: github::PullRequestSelector::Number(412),
+            },
+        );
+    }
+
+    /// The mark is the only thing on a row that says which Session is alive, so
+    /// it is decided where two repository names are compared properly.
+    #[test]
+    fn the_row_of_the_alive_session_comes_back_marked_however_it_is_cased() {
+        let gh = FakeGh::new();
+        gh.answer_graphql(&recorded_search("acme/widgets"));
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = settings_listing(&directory, &[&clone]);
+        let root = home_root(home_with(&gh));
+        refresh_home_on_model(&root, &settings_path, &|_progress| {});
+        assert!(
+            shown_home(&root).groups[0]
+                .rows
+                .iter()
+                .all(|row| !row.is_alive),
+            "nothing is alive before a row is opened",
+        );
+
+        open_row_on_root(&root, "ACME/Widgets", 412).expect("the clone is configured");
+        return_to_home_on_root(&root).expect("there is a Home behind it");
+
+        let marked = shown_home(&root).groups[0]
+            .rows
+            .iter()
+            .filter(|row| row.is_alive)
+            .map(|row| row.identity.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(marked, ["acme/widgets#412"]);
     }
 
     #[test]
@@ -1314,14 +1502,14 @@ mod tests {
         let settings_path = directory.path().join("settings.toml");
         let root = home_root_listing(&clone, &settings_path);
         open_row_on_root(&root, "acme/widgets", 412).expect("the clone is configured");
-        let alive = session_identity(&root);
+        mark_session(&root, "half way through");
         return_to_home_on_root(&root).expect("there is a Home behind it");
 
         open_row_on_root(&root, "acme/billing", 7).expect_err("that clone is not configured");
 
-        assert_eq!(session_identity(&root), alive);
+        assert_eq!(session_stage(&root), "half way through");
         assert_eq!(
-            describe_window_on_root(&root),
+            describe(&lock(&root.window)),
             dto::WindowDto::Home {
                 alive: Some(dto::OpenSessionDto {
                     description: "pull request #412".to_owned(),
@@ -1353,8 +1541,11 @@ mod tests {
     }
 
     /// What Home shows once an action has finished.
+    ///
+    /// Wrapped in a window of its own, because these tests exercise the list
+    /// rather than the Session that can be alive behind it.
     fn snapshot(home: &ManagedHome) -> dto::HomeSnapshotDto {
-        dto::project_home(&lock(&home.model))
+        shown_home(&home_root(home.clone()))
     }
 
     /// The repository paths the settings file now holds.
@@ -1370,7 +1561,7 @@ mod tests {
 
     /// A refresh with nothing listening to its progress.
     fn refresh(home: &ManagedHome, settings_path: &Path) {
-        refresh_home_on_model(home, settings_path, &no_drafts_database(), &|_progress| {});
+        refresh_home_on_model(&home_root(home.clone()), settings_path, &no_drafts_database(), &|_progress| {});
     }
 
     /// A settings file listing `clones`.
@@ -1451,7 +1642,7 @@ mod tests {
     /// Everything a refresh reported, in the order it said it.
     fn reported_by(home: &ManagedHome, settings_path: &Path) -> Vec<dto::HomeSnapshotDto> {
         let reported = Mutex::new(Vec::new());
-        refresh_home_on_model(home, settings_path, &no_drafts_database(), &|shown| {
+        refresh_home_on_model(&home_root(home.clone()), settings_path, &no_drafts_database(), &|shown| {
             reported.lock().unwrap().push(shown);
         });
         reported.into_inner().unwrap()
@@ -1525,8 +1716,8 @@ mod tests {
         let settled = snapshot(&home);
 
         let held = lock(&home.settings_action);
-        let ignored = on_settings_file(&home, |home, settings_path| {
-            refresh(home, settings_path);
+        let ignored = on_settings_file(&home_root(home.clone()), |root, settings_path| {
+            refresh(&root.home, settings_path);
         });
         drop(held);
 
@@ -1552,7 +1743,7 @@ mod tests {
         let reports = std::sync::atomic::AtomicUsize::new(0);
 
         let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            refresh_home_on_model(&home, &settings_path, &no_drafts_database(), &|_shown| {
+            refresh_home_on_model(&home_root(home.clone()), &settings_path, &no_drafts_database(), &|_shown| {
                 assert!(
                     reports.fetch_add(1, Ordering::AcqRel) < 2,
                     "the refresh gave up here"
@@ -1579,7 +1770,7 @@ mod tests {
         let settings_path = settings_listing(&directory, &[&clone]);
         let home = home_with(&gh);
         let _panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            refresh_home_on_model(&home, &settings_path, &no_drafts_database(), &|_shown| {
+            refresh_home_on_model(&home_root(home.clone()), &settings_path, &no_drafts_database(), &|_shown| {
                 panic!("gave up")
             });
         }));
@@ -1678,11 +1869,11 @@ mod tests {
         assert_eq!(snapshot(&home).cursor, 0);
 
         assert_eq!(
-            move_home_cursor_on_model(&home, dto::CursorMoveDto::Down).cursor,
+            move_home_cursor_on_model(&home_root(home.clone()), dto::CursorMoveDto::Down).cursor,
             1,
         );
         assert_eq!(
-            move_home_cursor_on_model(&home, dto::CursorMoveDto::Up).cursor,
+            move_home_cursor_on_model(&home_root(home.clone()), dto::CursorMoveDto::Up).cursor,
             0
         );
     }

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -987,7 +987,7 @@ mod tests {
             3,
         )])));
 
-        let snapshot = project_home(&home);
+        let snapshot = project_home(&home, None);
 
         let by_identity = |identity: &str| {
             snapshot.groups[0]
@@ -1008,7 +1008,7 @@ mod tests {
         let mut home = app::HomeModel::new();
         home.drafts_read(Err(SessionFailure::new("Drafts could not be read")));
 
-        let snapshot = project_home(&home);
+        let snapshot = project_home(&home, None);
 
         assert_eq!(
             snapshot

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -54,11 +54,27 @@ impl From<DiffLineKind> for DiffLineKindDto {
     }
 }
 
-/// Which screen the binary was launched into.
+/// The one Session the window holds, in front of Home or alive behind it.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, specta::Type)]
-pub enum LaunchDto {
-    Home,
-    Session { description: String },
+pub struct OpenSessionDto {
+    /// What is being opened, which is all the loading screen can say before the
+    /// load reaches the pull request itself.
+    pub description: String,
+    /// `owner/name#number` of the row this Session was opened from, which the
+    /// header slot reads and Home marks that row by. Absent for a Session the
+    /// command line opened, and its absence is what says there is no Home to go
+    /// back to.
+    pub row_identity: Option<String>,
+}
+
+/// Which screen the window shows, and the Session it is holding.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, specta::Type)]
+pub enum WindowDto {
+    /// Home, with the Session alive behind it when there is one. That Session's
+    /// tree stays mounted and hidden, which is what makes returning instant.
+    Home { alive: Option<OpenSessionDto> },
+    /// The Session, in front of Home or with no Home behind it at all.
+    Session { session: OpenSessionDto },
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, specta::Type)]
@@ -261,6 +277,9 @@ pub struct HomeRowDto {
     pub index: u32,
     pub title: String,
     pub url: String,
+    /// `owner/name`, which opening this row names its pull request by.
+    pub repository: String,
+    pub number: u32,
     /// `owner/name#number`.
     pub identity: String,
     /// Absent once GitHub has forgotten the account.
@@ -443,6 +462,8 @@ fn project_home_row(row: &app::HomeRow, index: u32) -> HomeRowDto {
         index,
         title: row.title.clone(),
         url: row.url.clone(),
+        repository: row.repository.clone(),
+        number: u32::try_from(row.number).expect("a pull request number fits comfortably in a u32"),
         identity: row.identity(),
         author: row.author_login.clone(),
         updated_at_ms: row.updated_at_ms,

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -4,6 +4,7 @@
 //! `&SessionFailure`) and returns a value, which is what keeps them testable
 //! without a running app.
 
+use app::PullRequestId;
 use domain::{
     DiffFile, DiffLineKind, DiffSide, EmptyDiffReason, FileStatus, ReviewSession, SessionFailure,
     SessionSource,
@@ -292,6 +293,9 @@ pub struct HomeRowDto {
     pub check_status: Option<RowStatusDto>,
     /// "1 draft" or "N drafts", absent for a blank cell.
     pub drafts_label: Option<String>,
+    /// Whether the Session alive behind Home is open on this row's pull
+    /// request, which is what the row's accent mark says.
+    pub is_alive: bool,
 }
 
 /// One of Home's three groups, always rendered whether or not it has rows.
@@ -395,8 +399,11 @@ pub struct HomeSnapshotDto {
 }
 
 /// Everything Home shows, from the model that decided it.
+///
+/// `alive` is the pull request the Session behind Home is open on, when one is,
+/// so the row listing it comes back marked.
 #[must_use]
-pub fn project_home(home: &app::HomeModel) -> HomeSnapshotDto {
+pub fn project_home(home: &app::HomeModel, alive: Option<&PullRequestId>) -> HomeSnapshotDto {
     // Walked in the model's own order, so a row's index is where the cursor
     // finds it rather than something counted twice and hoped to agree.
     let mut index = 0_u32;
@@ -405,7 +412,7 @@ pub fn project_home(home: &app::HomeModel) -> HomeSnapshotDto {
         let rows = home
             .rows_in(group)
             .map(|row| {
-                let projected = project_home_row(row, index);
+                let projected = project_home_row(row, index, alive);
                 index += 1;
                 projected
             })
@@ -457,9 +464,10 @@ pub fn project_home(home: &app::HomeModel) -> HomeSnapshotDto {
     }
 }
 
-fn project_home_row(row: &app::HomeRow, index: u32) -> HomeRowDto {
+fn project_home_row(row: &app::HomeRow, index: u32, alive: Option<&PullRequestId>) -> HomeRowDto {
     HomeRowDto {
         index,
+        is_alive: alive.is_some_and(|pull_request| row.is_on(pull_request)),
         title: row.title.clone(),
         url: row.url.clone(),
         repository: row.repository.clone(),
@@ -875,7 +883,7 @@ mod tests {
 
     #[test]
     fn home_projects_the_three_groups_in_order_with_their_empty_copy() {
-        let snapshot = project_home(&app::HomeModel::new());
+        let snapshot = project_home(&app::HomeModel::new(), None);
 
         let titles = snapshot
             .groups
@@ -889,7 +897,7 @@ mod tests {
 
     #[test]
     fn home_projects_each_repository_with_its_slug_or_its_reason() {
-        let snapshot = project_home(&home_with_one_failed_repository());
+        let snapshot = project_home(&home_with_one_failed_repository(), None);
 
         assert_eq!(snapshot.repositories[0].path, "/Developer/zreview");
         assert_eq!(
@@ -916,7 +924,7 @@ mod tests {
             "Home could not read your settings",
         )));
 
-        let snapshot = project_home(&home);
+        let snapshot = project_home(&home, None);
 
         assert_eq!(
             snapshot

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -114,11 +114,13 @@ impl Window {
     ///
     /// The Session already alive on this pull request is shown again rather
     /// than loaded a second time, which is what makes coming back instant. Any
-    /// other Session is dropped, silently, because Drafts already persist.
-    pub(crate) fn open(&mut self, pull_request: PullRequestId, clone_root: PathBuf) {
+    /// other Session is dropped, silently, because Drafts already persist. A
+    /// window with no Home refuses the row and keeps what it holds.
+    pub(crate) fn open(&mut self, pull_request: PullRequestId, clone_root: PathBuf) -> Opened {
         let number = pull_request.number;
-        match self.slot.open(pull_request) {
-            Opened::Returned => {}
+        let opened = self.slot.open(pull_request);
+        match opened {
+            Opened::Returned | Opened::Refused => {}
             Opened::Loading => {
                 self.session = Some(ManagedSession::new(
                     SessionRequest::PullRequest {
@@ -129,16 +131,20 @@ impl Window {
                 ));
             }
         }
+        opened
     }
 }
 
 /// Everything the window holds, shared with every command.
 ///
 /// Home and at most one Session, which Home opens a row into and comes back
-/// from, leaving it alive behind Home.
+/// from, leaving it alive behind Home. Cloned into whatever thread a Home
+/// action runs on, so a refresh reporting from off the UI thread can still say
+/// which row the alive Session was opened from.
+#[derive(Clone)]
 pub(crate) struct AppRoot {
     pub(crate) home: ManagedHome,
-    pub(crate) window: Mutex<Window>,
+    pub(crate) window: Arc<Mutex<Window>>,
 }
 
 /// Builds the window and runs the application until it closes.
@@ -154,7 +160,7 @@ pub fn run(launch: Launch) {
     };
     let root = AppRoot {
         home: ManagedHome::new(GithubClient::default()),
-        window: Mutex::new(window),
+        window: Arc::new(Mutex::new(window)),
     };
     let specta_builder = commands::specta_builder();
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,9 +1,12 @@
 //! The Tauri shell: wires the framework-free `app` crate to a window.
 
-use std::sync::{Arc, Mutex, atomic::AtomicBool};
+use std::{
+    path::PathBuf,
+    sync::{Arc, Mutex, atomic::AtomicBool},
+};
 
-use app::{HomeModel, SessionModel};
-use github::GithubClient;
+use app::{HomeModel, Opened, PullRequestId, SessionModel, SessionSlot};
+use github::{GithubClient, PullRequestSelector};
 use session::{ReviewStorage, SessionRequest};
 
 mod commands;
@@ -40,6 +43,18 @@ pub(crate) struct ManagedSession {
     pub(crate) load_started: Arc<AtomicBool>,
 }
 
+impl ManagedSession {
+    /// A Session for `request`, with nothing loaded into it yet.
+    fn new(request: SessionRequest, storage: ReviewStorage) -> Self {
+        Self {
+            model: Arc::new(Mutex::new(SessionModel::loading(request.description()))),
+            request,
+            storage,
+            load_started: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
 /// Home's state and the guard that orders the actions on its settings file.
 ///
 /// Cloned into whatever thread an action runs on, so both halves travel
@@ -68,13 +83,62 @@ impl ManagedHome {
     }
 }
 
+/// Which screen the window shows, and the one loaded Session it holds.
+///
+/// [`SessionSlot`] decides what opening a row does to the Session already
+/// alive; this pairs that decision with the Session it is about, so the two can
+/// never disagree about whether there is one.
+pub(crate) struct Window {
+    pub(crate) slot: SessionSlot,
+    pub(crate) session: Option<ManagedSession>,
+}
+
+impl Window {
+    /// A window that opened on Home, holding no Session yet.
+    fn home() -> Self {
+        Self {
+            slot: SessionSlot::home(),
+            session: None,
+        }
+    }
+
+    /// A window the command line opened straight into a Session.
+    fn command_line(request: SessionRequest, storage: ReviewStorage) -> Self {
+        Self {
+            slot: SessionSlot::command_line(),
+            session: Some(ManagedSession::new(request, storage)),
+        }
+    }
+
+    /// Opens `pull_request` from a Home row, out of the clone at `clone_root`.
+    ///
+    /// The Session already alive on this pull request is shown again rather
+    /// than loaded a second time, which is what makes coming back instant. Any
+    /// other Session is dropped, silently, because Drafts already persist.
+    pub(crate) fn open(&mut self, pull_request: PullRequestId, clone_root: PathBuf) {
+        let number = pull_request.number;
+        match self.slot.open(pull_request) {
+            Opened::Returned => {}
+            Opened::Loading => {
+                self.session = Some(ManagedSession::new(
+                    SessionRequest::PullRequest {
+                        repository: clone_root,
+                        selector: PullRequestSelector::Number(number),
+                    },
+                    ReviewStorage::Default,
+                ));
+            }
+        }
+    }
+}
+
 /// Everything the window holds, shared with every command.
 ///
-/// Home and at most one Session. For now a Session is here only when the binary
-/// was launched straight into one; Home does not open Sessions yet.
+/// Home and at most one Session, which Home opens a row into and comes back
+/// from, leaving it alive behind Home.
 pub(crate) struct AppRoot {
     pub(crate) home: ManagedHome,
-    pub(crate) session: Option<ManagedSession>,
+    pub(crate) window: Mutex<Window>,
 }
 
 /// Builds the window and runs the application until it closes.
@@ -84,18 +148,13 @@ pub(crate) struct AppRoot {
 /// Panics if the Tauri application fails to start, or if bindings export fails
 /// in a debug build.
 pub fn run(launch: Launch) {
-    let session = match launch {
-        Launch::Home => None,
-        Launch::Session { request, storage } => Some(ManagedSession {
-            model: Arc::new(Mutex::new(SessionModel::loading(request.description()))),
-            request,
-            storage,
-            load_started: Arc::new(AtomicBool::new(false)),
-        }),
+    let window = match launch {
+        Launch::Home => Window::home(),
+        Launch::Session { request, storage } => Window::command_line(request, storage),
     };
     let root = AppRoot {
         home: ManagedHome::new(GithubClient::default()),
-        session,
+        window: Mutex::new(window),
     };
     let specta_builder = commands::specta_builder();
 

--- a/apps/desktop/src/App.css
+++ b/apps/desktop/src/App.css
@@ -1,0 +1,5 @@
+/* The Session, in front of Home or hidden behind it. The hidden attribute is
+   what takes it off screen, so its tree is never torn down and rebuilt. */
+.app__session {
+  height: 100%;
+}

--- a/apps/desktop/src/App.css
+++ b/apps/desktop/src/App.css
@@ -1,5 +1,7 @@
-/* The Session, in front of Home or hidden behind it. The hidden attribute is
-   what takes it off screen, so its tree is never torn down and rebuilt. */
+/* Home and the Session share one window. Whichever is behind is hidden rather
+   than unmounted, so its state, its scroll, and any work still in flight for it
+   all survive being stepped away from. */
+.app__home,
 .app__session {
   height: 100%;
 }

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -5,7 +5,7 @@ import type { Channel } from "@tauri-apps/api/core";
 import App from "./App";
 import { makeFile, makeFileSummary, makeRow, makeSidebar, makeSnapshot } from "./test/fixtures";
 
-const describeLaunch = vi.fn();
+const describeWindow = vi.fn();
 const openSession = vi.fn();
 const selectFile = vi.fn();
 const toggleViewed = vi.fn();
@@ -15,7 +15,7 @@ const reanchorDraft = vi.fn();
 
 vi.mock("./bindings", () => ({
   commands: {
-    describeLaunch: () => describeLaunch(),
+    describeWindow: () => describeWindow(),
     openSession: (channel: unknown) => openSession(channel),
     selectFile: (index: unknown) => selectFile(index),
     toggleViewed: () => toggleViewed(),
@@ -31,8 +31,10 @@ vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
 }));
 
 beforeEach(() => {
-  describeLaunch.mockReset();
-  describeLaunch.mockResolvedValue({ Session: { description: "the generated fixture" } });
+  describeWindow.mockReset();
+  describeWindow.mockResolvedValue({
+    Session: { session: { description: "the generated fixture", row_identity: null } },
+  });
   openSession.mockReset();
   selectFile.mockReset();
   toggleViewed.mockReset();
@@ -110,8 +112,8 @@ describe("App", () => {
   });
 
   it("shows the failure screen when the launch call rejects", async () => {
-    describeLaunch.mockReset();
-    describeLaunch.mockRejectedValue(new Error("the launch could not be described"));
+    describeWindow.mockReset();
+    describeWindow.mockRejectedValue(new Error("the launch could not be described"));
 
     render(<App />);
 

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,32 +1,110 @@
-import { useEffect, useState } from "react";
-import type { LaunchDto, SessionFailureDto } from "./bindings";
+import { useCallback, useEffect, useState } from "react";
+import type { OpenSessionDto, SessionFailureDto, WindowDto } from "./bindings";
 import { commands } from "./bindings";
 import { FailureScreen } from "./components/FailureScreen";
 import { HomeScreen } from "./components/HomeScreen";
 import { toFailure } from "./lib/failure";
 import { SessionApp } from "./SessionApp";
+import "./App.css";
+
+/** What a navigation command answers with. */
+type WindowResult =
+  | { status: "ok"; data: WindowDto }
+  | { status: "error"; error: SessionFailureDto };
+
+/** Which screen is in front, and the Session the window holds either way. */
+function screens(shown: WindowDto): { isShowingHome: boolean; session: OpenSessionDto | null } {
+  if ("Home" in shown && shown.Home !== undefined) {
+    return { isShowingHome: true, session: shown.Home.alive };
+  }
+  return { isShowingHome: false, session: shown.Session.session };
+}
 
 export default function App() {
-  const [launch, setLaunch] = useState<LaunchDto | null>(null);
+  const [shown, setShown] = useState<WindowDto | null>(null);
   const [failure, setFailure] = useState<SessionFailureDto | null>(null);
 
   useEffect(() => {
     commands
-      .describeLaunch()
-      .then(setLaunch)
+      .describeWindow()
+      .then(setShown)
       .catch((error: unknown) => setFailure(toFailure(error)));
   }, []);
 
-  // A launch that never answers would otherwise leave the window blank.
+  /** Takes what a navigation answered, so a refusal is shown rather than swallowed. */
+  const navigate = useCallback((call: Promise<WindowResult>) => {
+    call
+      .then((result) => {
+        if (result.status === "error") {
+          setFailure(toFailure(result.error));
+          return;
+        }
+        setShown(result.data);
+      })
+      .catch((error: unknown) => setFailure(toFailure(error)));
+  }, []);
+
+  const openRow = useCallback(
+    (repository: string, number: number) => navigate(commands.openRow(repository, number)),
+    [navigate],
+  );
+  const returnToSession = useCallback(
+    () => navigate(commands.returnToSession()),
+    [navigate],
+  );
+  const returnToHome = useCallback(() => navigate(commands.returnToHome()), [navigate]);
+
+  const { isShowingHome, session } =
+    shown === null ? { isShowingHome: true, session: null } : screens(shown);
+  // Only a Session opened from a row has a Home behind it to go back to.
+  const canGoBack = !isShowingHome && session !== null && session.row_identity !== null;
+
+  useEffect(() => {
+    if (!canGoBack) {
+      return;
+    }
+    function handleKeydown(event: KeyboardEvent) {
+      // Escape stays reserved for dismissing composers and panels, so back
+      // never eats a dismissal.
+      if (event.metaKey && event.key === "[") {
+        event.preventDefault();
+        returnToHome();
+      }
+    }
+    window.addEventListener("keydown", handleKeydown);
+    return () => window.removeEventListener("keydown", handleKeydown);
+  }, [canGoBack, returnToHome]);
+
+  // A window that never said what it holds would otherwise be blank for ever.
   if (failure !== null) {
     return <FailureScreen failure={failure} />;
   }
   // Nothing is rendered until the answer arrives, so neither screen flashes first.
-  if (launch === null) {
+  if (shown === null) {
     return null;
   }
-  if (launch === "Home") {
-    return <HomeScreen />;
-  }
-  return <SessionApp description={launch.Session.description} />;
+
+  return (
+    <>
+      {isShowingHome && (
+        <HomeScreen
+          aliveIdentity={session?.row_identity ?? null}
+          onOpenRow={openRow}
+          onReturnToSession={returnToSession}
+        />
+      )}
+      {session !== null && (
+        // Kept mounted while Home shows, so the file, cursor, and unsent
+        // composer text of the Session behind it survive exactly.
+        <div className="app__session" hidden={isShowingHome}>
+          <SessionApp
+            key={session.row_identity ?? "the command line"}
+            description={session.description}
+            isShowing={!isShowingHome}
+            onBack={canGoBack ? returnToHome : null}
+          />
+        </div>
+      )}
+    </>
+  );
 }

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -48,10 +48,7 @@ export default function App() {
     (repository: string, number: number) => navigate(commands.openRow(repository, number)),
     [navigate],
   );
-  const returnToSession = useCallback(
-    () => navigate(commands.returnToSession()),
-    [navigate],
-  );
+  const returnToSession = useCallback(() => navigate(commands.returnToSession()), [navigate]);
   const returnToHome = useCallback(() => navigate(commands.returnToHome()), [navigate]);
 
   const { isShowingHome, session } =
@@ -59,13 +56,13 @@ export default function App() {
   // Only a Session opened from a row has a Home behind it to go back to.
   const canGoBack = !isShowingHome && session !== null && session.row_identity !== null;
 
+  // Cmd-[ is the only binding that goes back. Escape stays reserved for
+  // dismissing composers and panels, so back never eats a dismissal.
   useEffect(() => {
     if (!canGoBack) {
       return;
     }
     function handleKeydown(event: KeyboardEvent) {
-      // Escape stays reserved for dismissing composers and panels, so back
-      // never eats a dismissal.
       if (event.metaKey && event.key === "[") {
         event.preventDefault();
         returnToHome();

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -12,12 +12,19 @@ type WindowResult =
   | { status: "ok"; data: WindowDto }
   | { status: "error"; error: SessionFailureDto };
 
-/** Which screen is in front, and the Session the window holds either way. */
-function screens(shown: WindowDto): { isShowingHome: boolean; session: OpenSessionDto | null } {
+/** Which screen the window shows, and the Session it holds either way. */
+type Screen = { isShowingHome: boolean; session: OpenSessionDto | null };
+
+function currentScreen(shown: WindowDto): Screen {
   if ("Home" in shown && shown.Home !== undefined) {
     return { isShowingHome: true, session: shown.Home.alive };
   }
-  return { isShowingHome: false, session: shown.Session.session };
+  if ("Session" in shown && shown.Session !== undefined) {
+    return { isShowingHome: false, session: shown.Session.session };
+  }
+  // A window the backend grew a third screen for, which nothing here can draw.
+  const unknown: never = shown;
+  throw new Error(`the window is showing something unknown ${JSON.stringify(unknown)}`);
 }
 
 export default function App() {
@@ -31,17 +38,22 @@ export default function App() {
       .catch((error: unknown) => setFailure(toFailure(error)));
   }, []);
 
-  /** Takes what a navigation answered, so a refusal is shown rather than swallowed. */
+  /**
+   * Navigates, answering with the refusal when the window would not.
+   *
+   * A refusal is handed back rather than shown here, because the screen that
+   * asked is still on and is where the reviewer can act on it.
+   */
   const navigate = useCallback((call: Promise<WindowResult>) => {
-    call
+    return call
       .then((result) => {
         if (result.status === "error") {
-          setFailure(toFailure(result.error));
-          return;
+          return toFailure(result.error);
         }
         setShown(result.data);
+        return null;
       })
-      .catch((error: unknown) => setFailure(toFailure(error)));
+      .catch((error: unknown) => toFailure(error));
   }, []);
 
   const openRow = useCallback(
@@ -49,12 +61,20 @@ export default function App() {
     [navigate],
   );
   const returnToSession = useCallback(() => navigate(commands.returnToSession()), [navigate]);
-  const returnToHome = useCallback(() => navigate(commands.returnToHome()), [navigate]);
+  const returnToHome = useCallback(() => {
+    navigate(commands.returnToHome()).then((refused) => {
+      if (refused !== null) {
+        setFailure(refused);
+      }
+    });
+  }, [navigate]);
 
   const { isShowingHome, session } =
-    shown === null ? { isShowingHome: true, session: null } : screens(shown);
+    shown === null ? { isShowingHome: true, session: null } : currentScreen(shown);
   // Only a Session opened from a row has a Home behind it to go back to.
   const canGoBack = !isShowingHome && session !== null && session.row_identity !== null;
+  // A window the command line opened straight into a Session has no Home at all.
+  const hasHome = shown !== null && (isShowingHome || canGoBack);
 
   // Cmd-[ is the only binding that goes back. Escape stays reserved for
   // dismissing composers and panels, so back never eats a dismissal.
@@ -83,12 +103,17 @@ export default function App() {
 
   return (
     <>
-      {isShowingHome && (
-        <HomeScreen
-          aliveIdentity={session?.row_identity ?? null}
-          onOpenRow={openRow}
-          onReturnToSession={returnToSession}
-        />
+      {hasHome && (
+        // Kept mounted behind the Session, so a refresh still running when a
+        // row was opened has somewhere to land and settles the screen on return.
+        <div className="app__home" hidden={!isShowingHome}>
+          <HomeScreen
+            isShowing={isShowingHome}
+            aliveIdentity={session?.row_identity ?? null}
+            onOpenRow={openRow}
+            onReturnToSession={returnToSession}
+          />
+        </div>
       )}
       {session !== null && (
         // Kept mounted while Home shows, so the file, cursor, and unsent

--- a/apps/desktop/src/Home.test.tsx
+++ b/apps/desktop/src/Home.test.tsx
@@ -10,7 +10,7 @@ import {
   makeHomeSnapshot,
 } from "./test/fixtures";
 
-const describeLaunch = vi.fn();
+const describeWindow = vi.fn();
 const refreshHome = vi.fn();
 const addRepositories = vi.fn();
 const removeRepository = vi.fn();
@@ -20,7 +20,7 @@ const moveHomeCursor = vi.fn();
 
 vi.mock("./bindings", () => ({
   commands: {
-    describeLaunch: () => describeLaunch(),
+    describeWindow: () => describeWindow(),
     refreshHome: (onProgress: unknown) => refreshHome(onProgress),
     moveHomeCursor: (moveTo: unknown) => moveHomeCursor(moveTo),
     addRepositories: (folders: unknown) => addRepositories(folders),
@@ -32,6 +32,10 @@ vi.mock("./bindings", () => ({
 const open = vi.fn();
 vi.mock("@tauri-apps/plugin-dialog", () => ({
   open: (options: unknown) => open(options),
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({ onFocusChanged: () => Promise.resolve(() => {}) }),
 }));
 
 // The commands that touch the settings file answer with a result, as the bindings do.
@@ -71,8 +75,8 @@ function selectedIdentity() {
 }
 
 beforeEach(() => {
-  describeLaunch.mockReset();
-  describeLaunch.mockResolvedValue("Home");
+  describeWindow.mockReset();
+  describeWindow.mockResolvedValue({ Home: { alive: null } });
   refreshHome.mockReset();
   refreshHome.mockResolvedValue(ok(makeHomeSnapshot()));
   addRepositories.mockReset();

--- a/apps/desktop/src/Navigation.test.tsx
+++ b/apps/desktop/src/Navigation.test.tsx
@@ -1,0 +1,411 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { HomeSnapshotDto, OpenSessionDto, WindowDto } from "./bindings";
+import App from "./App";
+import {
+  makeAnchoredDraft,
+  makeDrafts,
+  makeFile,
+  makeFileSummary,
+  makeHomeGroups,
+  makeHomeRepository,
+  makeHomeRow,
+  makeHomeSnapshot,
+  makeRow,
+  makeSidebar,
+  makeSnapshot,
+} from "./test/fixtures";
+
+const describeWindow = vi.fn();
+const openRow = vi.fn();
+const returnToHome = vi.fn();
+const returnToSession = vi.fn();
+const refreshHome = vi.fn();
+const moveHomeCursor = vi.fn();
+const toggleRepositoriesFooter = vi.fn();
+const addRepositories = vi.fn();
+const removeRepository = vi.fn();
+const openSession = vi.fn();
+const selectFile = vi.fn();
+const toggleViewed = vi.fn();
+const editDraft = vi.fn();
+const discardDraft = vi.fn();
+const reanchorDraft = vi.fn();
+
+vi.mock("./bindings", () => ({
+  commands: {
+    describeWindow: () => describeWindow(),
+    openRow: (repository: unknown, number: unknown) => openRow(repository, number),
+    returnToHome: () => returnToHome(),
+    returnToSession: () => returnToSession(),
+    refreshHome: (onProgress: unknown) => refreshHome(onProgress),
+    moveHomeCursor: (moveTo: unknown) => moveHomeCursor(moveTo),
+    toggleRepositoriesFooter: () => toggleRepositoriesFooter(),
+    addRepositories: (folders: unknown) => addRepositories(folders),
+    removeRepository: (path: unknown) => removeRepository(path),
+    openSession: (channel: unknown) => openSession(channel),
+    selectFile: (index: unknown) => selectFile(index),
+    toggleViewed: () => toggleViewed(),
+    editDraft: (...args: unknown[]) => editDraft(...args),
+    discardDraft: (...args: unknown[]) => discardDraft(...args),
+    reanchorDraft: (...args: unknown[]) => reanchorDraft(...args),
+  },
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: () => Promise.resolve(null) }));
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({ writeText: () => Promise.resolve() }));
+
+/** The handler the screen gave Tauri's window focus event, once it is listening. */
+let focusChanged: ((event: { payload: boolean }) => void) | null = null;
+const stopListening = vi.fn();
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    onFocusChanged: (handler: (event: { payload: boolean }) => void) => {
+      focusChanged = handler;
+      return Promise.resolve(stopListening);
+    },
+  }),
+}));
+
+function ok<T>(data: T) {
+  return { status: "ok", data };
+}
+
+/** The Session opened from `acme/widgets#412`, as the window describes it. */
+function alive(identity = "acme/widgets#412"): OpenSessionDto {
+  return { description: "pull request #412", row_identity: identity };
+}
+
+function showingHome(session: OpenSessionDto | null = null): WindowDto {
+  return { Home: { alive: session } };
+}
+
+function showingSession(session: OpenSessionDto = alive()): WindowDto {
+  return { Session: { session } };
+}
+
+/** Two rows to review, one of which the alive Session was opened from. */
+function listed(): HomeSnapshotDto {
+  return makeHomeSnapshot({
+    count_line: "2 pull requests across 1 repository",
+    groups: makeHomeGroups([
+      [
+        makeHomeRow({
+          index: 0,
+          repository: "acme/widgets",
+          number: 412,
+          identity: "acme/widgets#412",
+          title: "Retry webhook deliveries",
+        }),
+        makeHomeRow({
+          index: 1,
+          repository: "acme/widgets",
+          number: 398,
+          identity: "acme/widgets#398",
+          title: "Split the invoice renderer",
+        }),
+      ],
+      [],
+      [],
+    ]),
+    repositories: [makeHomeRepository()],
+    footer_summary: "1 repository",
+    refresh: { Refreshed: { at_ms: Date.now() } },
+  });
+}
+
+/** Every row on screen, in the order the ledger renders them. */
+function rows() {
+  return screen.getAllByRole("listitem");
+}
+
+/** The row whose identity cell reads `identity`. */
+function rowFor(identity: string) {
+  const found = rows().find(
+    (row) => row.querySelector(".home__cell--identity")?.textContent === identity,
+  );
+  if (!found) {
+    throw new Error(`no row for ${identity}`);
+  }
+  return found;
+}
+
+beforeEach(() => {
+  focusChanged = null;
+  stopListening.mockReset();
+  describeWindow.mockReset();
+  describeWindow.mockResolvedValue(showingHome());
+  openRow.mockReset();
+  openRow.mockResolvedValue(ok(showingSession()));
+  returnToHome.mockReset();
+  returnToHome.mockResolvedValue(ok(showingHome(alive())));
+  returnToSession.mockReset();
+  returnToSession.mockResolvedValue(ok(showingSession()));
+  refreshHome.mockReset();
+  refreshHome.mockResolvedValue(ok(listed()));
+  moveHomeCursor.mockReset();
+  moveHomeCursor.mockResolvedValue({ ...listed(), cursor: 1 });
+  toggleRepositoriesFooter.mockReset();
+  addRepositories.mockReset();
+  removeRepository.mockReset();
+  openSession.mockReset();
+  openSession.mockResolvedValue(
+    ok(makeSnapshot({ sidebar: makeSidebar([makeFileSummary({ index: 0 }), makeFileSummary({ index: 1 })]) })),
+  );
+  selectFile.mockReset();
+  selectFile.mockResolvedValue(
+    ok(makeFile({ rows: [makeRow({ text: "first" }), makeRow({ text: "second" })] })),
+  );
+  toggleViewed.mockReset();
+  editDraft.mockReset();
+  discardDraft.mockReset();
+  reanchorDraft.mockReset();
+});
+
+/** Home, listed and settled, with the cursor on its first row. */
+async function openHome() {
+  render(<App />);
+  await waitFor(() => expect(screen.getByText("Retry webhook deliveries")).toBeTruthy());
+}
+
+/** The Session the cursor row opens into, loaded and showing its first file. */
+async function openTheCursorRow() {
+  await openHome();
+  fireEvent.keyDown(window, { key: "Enter" });
+  await waitFor(() => expect(screen.getByText("first")).toBeTruthy());
+}
+
+describe("opening a row", () => {
+  it("opens the row under the cursor on Enter", async () => {
+    await openTheCursorRow();
+
+    expect(openRow).toHaveBeenCalledWith("acme/widgets", 412);
+    expect(screen.queryByText("Retry webhook deliveries")).toBeNull();
+  });
+
+  it("opens the row a click lands on", async () => {
+    const user = userEvent.setup();
+    await openHome();
+
+    await user.click(screen.getByText("Split the invoice renderer"));
+
+    await waitFor(() => expect(openRow).toHaveBeenCalledWith("acme/widgets", 398));
+  });
+
+  it("shows the failure when the row could not be opened", async () => {
+    openRow.mockResolvedValue({
+      status: "error",
+      error: {
+        summary: "Home has no configured clone of acme/widgets",
+        detail: null,
+        remediation: null,
+      },
+    });
+    await openHome();
+
+    fireEvent.keyDown(window, { key: "Enter" });
+
+    await waitFor(() =>
+      expect(screen.getByText("Home has no configured clone of acme/widgets")).toBeTruthy(),
+    );
+  });
+});
+
+describe("coming back", () => {
+  it("returns to Home on the back chevron and refreshes it", async () => {
+    const user = userEvent.setup();
+    await openTheCursorRow();
+    refreshHome.mockClear();
+
+    await user.click(screen.getByRole("button", { name: "Back to Home" }));
+
+    await waitFor(() => expect(screen.getByText("Retry webhook deliveries")).toBeTruthy());
+    expect(refreshHome).toHaveBeenCalled();
+  });
+
+  it("returns to Home on cmd-[", async () => {
+    await openTheCursorRow();
+
+    fireEvent.keyDown(window, { key: "[", metaKey: true });
+
+    await waitFor(() => expect(returnToHome).toHaveBeenCalled());
+  });
+
+  it("leaves the Session showing on Escape", async () => {
+    await openTheCursorRow();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(returnToHome).not.toHaveBeenCalled();
+    expect(screen.getByText("first")).toBeTruthy();
+  });
+
+  it("offers neither chevron nor cmd-[ to a Session the command line opened", async () => {
+    describeWindow.mockResolvedValue(
+      showingSession({ description: "the generated fixture", row_identity: null }),
+    );
+
+    render(<App />);
+    await waitFor(() => expect(screen.getByText("first")).toBeTruthy());
+
+    expect(screen.queryByRole("button", { name: "Back to Home" })).toBeNull();
+    fireEvent.keyDown(window, { key: "[", metaKey: true });
+    expect(returnToHome).not.toHaveBeenCalled();
+  });
+});
+
+describe("the Session kept alive behind Home", () => {
+  it("keeps its tree mounted and hidden, with its file, cursor, and composer intact", async () => {
+    const user = userEvent.setup();
+    selectFile.mockResolvedValue(
+      ok(
+        makeFile({
+          index: 1,
+          rows: [makeRow({ text: "first" }), makeRow({ text: "second" })],
+          drafts: makeDrafts({
+            file_index: 1,
+            anchored: [makeAnchoredDraft({ row: 1, body: "worth keeping" })],
+          }),
+        }),
+      ),
+    );
+    await openTheCursorRow();
+    await user.keyboard("j");
+    await user.keyboard("c");
+    const composer = await waitFor(() => {
+      const element = document.querySelector("[data-composer] .cm-content");
+      if (!element) {
+        throw new Error("composer editor not mounted yet");
+      }
+      return element;
+    });
+    expect(composer.textContent).toContain("worth keeping");
+
+    fireEvent.keyDown(window, { key: "[", metaKey: true });
+    await waitFor(() => expect(screen.getByText("Retry webhook deliveries")).toBeTruthy());
+
+    // Hidden rather than unmounted, which is what makes returning free.
+    expect(document.querySelector(".app__session")?.hasAttribute("hidden")).toBe(true);
+    expect(document.querySelector("[data-composer] .cm-content")).toBe(composer);
+    await user.click(screen.getByRole("button", { name: /acme\/widgets#412/ }));
+
+    await waitFor(() => expect(screen.getByText("first")).toBeTruthy());
+    expect(document.querySelector("[data-composer] .cm-content")).toBe(composer);
+    expect(composer.textContent).toContain("worth keeping");
+    expect(screen.getByText("second").closest(".diff-row")?.className).toContain(
+      "diff-row--selected",
+    );
+  });
+
+  it("leaves the hidden Session's keys alone while Home has them", async () => {
+    const user = userEvent.setup();
+    await openTheCursorRow();
+    fireEvent.keyDown(window, { key: "[", metaKey: true });
+    await waitFor(() => expect(screen.getByText("Retry webhook deliveries")).toBeTruthy());
+
+    await user.keyboard("j");
+
+    expect(moveHomeCursor).toHaveBeenCalledWith("Down");
+    expect(screen.getByText("first").closest(".diff-row")?.className).toContain(
+      "diff-row--selected",
+    );
+  });
+
+  it("shows the header slot with the alive Session's identity and its keycap", async () => {
+    describeWindow.mockResolvedValue(showingHome(alive()));
+
+    await openHome();
+
+    const slot = screen.getByRole("button", { name: /acme\/widgets#412/ });
+    expect(slot.textContent).toContain("acme/widgets#412");
+    expect(slot.textContent).toContain("cmd-[");
+  });
+
+  it("shows no header slot when no Session is alive", async () => {
+    await openHome();
+
+    expect(screen.queryByText("acme/widgets#412", { selector: ".home__slot-identity" })).toBeNull();
+  });
+
+  it("marks the alive Session's row and leaves every other row unmarked", async () => {
+    describeWindow.mockResolvedValue(showingHome(alive()));
+
+    await openHome();
+
+    expect(rowFor("acme/widgets#412").querySelector(".home__alive-mark")).toBeTruthy();
+    expect(rowFor("acme/widgets#398").querySelector(".home__alive-mark")).toBeNull();
+  });
+
+  it("returns to the alive Session rather than reloading it when its row is opened", async () => {
+    describeWindow.mockResolvedValue(showingHome(alive()));
+    await openHome();
+
+    fireEvent.keyDown(window, { key: "Enter" });
+
+    await waitFor(() => expect(returnToSession).toHaveBeenCalled());
+    expect(openRow).not.toHaveBeenCalled();
+  });
+
+  it("still opens a different row while a Session is alive", async () => {
+    const user = userEvent.setup();
+    describeWindow.mockResolvedValue(showingHome(alive()));
+    await openHome();
+
+    await user.click(screen.getByText("Split the invoice renderer"));
+
+    await waitFor(() => expect(openRow).toHaveBeenCalledWith("acme/widgets", 398));
+    expect(returnToSession).not.toHaveBeenCalled();
+  });
+
+  it("reaches a Session whose pull request has no row through the slot alone", async () => {
+    describeWindow.mockResolvedValue(showingHome(alive("acme/billing#7")));
+    const user = userEvent.setup();
+    await openHome();
+
+    expect(rows().some((row) => row.querySelector(".home__alive-mark"))).toBe(false);
+    await user.click(screen.getByRole("button", { name: /acme\/billing#7/ }));
+
+    await waitFor(() => expect(returnToSession).toHaveBeenCalled());
+  });
+});
+
+describe("refreshing on focus", () => {
+  it("refreshes Home when the window regains focus", async () => {
+    await openHome();
+    refreshHome.mockClear();
+
+    focusChanged?.({ payload: true });
+
+    await waitFor(() => expect(refreshHome).toHaveBeenCalledTimes(1));
+  });
+
+  it("refreshes nothing when the window loses focus", async () => {
+    await openHome();
+    refreshHome.mockClear();
+
+    focusChanged?.({ payload: false });
+
+    expect(refreshHome).not.toHaveBeenCalled();
+  });
+
+  it("stops listening once the Session replaces Home", async () => {
+    await openTheCursorRow();
+
+    expect(stopListening).toHaveBeenCalled();
+  });
+
+  it("refreshes on no timer at all", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      await openHome();
+      refreshHome.mockClear();
+
+      await vi.advanceTimersByTimeAsync(10 * 60_000);
+
+      expect(refreshHome).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/desktop/src/Navigation.test.tsx
+++ b/apps/desktop/src/Navigation.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { HomeSnapshotDto, OpenSessionDto, WindowDto } from "./bindings";
 import App from "./App";
@@ -58,12 +58,16 @@ vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({ writeText: () => Promis
 
 /** The handler the screen gave Tauri's window focus event, once it is listening. */
 let focusChanged: ((event: { payload: boolean }) => void) | null = null;
-const stopListening = vi.fn();
 vi.mock("@tauri-apps/api/window", () => ({
   getCurrentWindow: () => ({
     onFocusChanged: (handler: (event: { payload: boolean }) => void) => {
       focusChanged = handler;
-      return Promise.resolve(stopListening);
+      // Unlistening stops delivery, exactly as it does through Tauri.
+      return Promise.resolve(() => {
+        if (focusChanged === handler) {
+          focusChanged = null;
+        }
+      });
     },
   }),
 }));
@@ -115,6 +119,13 @@ function listed(): HomeSnapshotDto {
   });
 }
 
+/** The same list, with the first row marked as the alive Session's own. */
+function withAliveRow(): HomeSnapshotDto {
+  const shown = listed();
+  shown.groups[0].rows[0] = { ...shown.groups[0].rows[0], is_alive: true };
+  return shown;
+}
+
 /** Every row on screen, in the order the ledger renders them. */
 function rows() {
   return screen.getAllByRole("listitem");
@@ -133,7 +144,6 @@ function rowFor(identity: string) {
 
 beforeEach(() => {
   focusChanged = null;
-  stopListening.mockReset();
   describeWindow.mockReset();
   describeWindow.mockResolvedValue(showingHome());
   openRow.mockReset();
@@ -181,7 +191,8 @@ describe("opening a row", () => {
     await openTheCursorRow();
 
     expect(openRow).toHaveBeenCalledWith("acme/widgets", 412);
-    expect(screen.queryByText("Retry webhook deliveries")).toBeNull();
+    // The Session is in front, which is the only screen offering a way back.
+    expect(screen.getByRole("button", { name: "Back to Home" })).toBeTruthy();
   });
 
   it("opens the row a click lands on", async () => {
@@ -193,7 +204,8 @@ describe("opening a row", () => {
     await waitFor(() => expect(openRow).toHaveBeenCalledWith("acme/widgets", 398));
   });
 
-  it("shows the failure when the row could not be opened", async () => {
+  it("shows a refused open inside Home, leaving its header and footer up", async () => {
+    describeWindow.mockResolvedValue(showingHome(alive("acme/billing#7")));
     openRow.mockResolvedValue({
       status: "error",
       error: {
@@ -209,6 +221,26 @@ describe("opening a row", () => {
     await waitFor(() =>
       expect(screen.getByText("Home has no configured clone of acme/widgets")).toBeTruthy(),
     );
+    expect(screen.getByText("Home")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /acme\/billing#7/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Add..." })).toBeTruthy();
+  });
+
+  it("clears a refused open on the next refresh", async () => {
+    openRow.mockResolvedValue({
+      status: "error",
+      error: { summary: "Home has no configured clone of acme/widgets", detail: null, remediation: null },
+    });
+    await openHome();
+    fireEvent.keyDown(window, { key: "Enter" });
+    await waitFor(() =>
+      expect(screen.getByText("Home has no configured clone of acme/widgets")).toBeTruthy(),
+    );
+
+    fireEvent.keyDown(window, { key: "r" });
+
+    await waitFor(() => expect(screen.getByText("Retry webhook deliveries")).toBeTruthy());
+    expect(screen.queryByText("Home has no configured clone of acme/widgets")).toBeNull();
   });
 });
 
@@ -273,29 +305,24 @@ describe("the Session kept alive behind Home", () => {
     await openTheCursorRow();
     await user.keyboard("j");
     await user.keyboard("c");
-    const composer = await waitFor(() => {
-      const element = document.querySelector("[data-composer] .cm-content");
-      if (!element) {
-        throw new Error("composer editor not mounted yet");
-      }
-      return element;
-    });
-    expect(composer.textContent).toContain("worth keeping");
+    await waitFor(() =>
+      expect(document.querySelector("[data-composer] .cm-content")?.textContent).toContain(
+        "worth keeping",
+      ),
+    );
 
     fireEvent.keyDown(window, { key: "[", metaKey: true });
     await waitFor(() => expect(screen.getByText("Retry webhook deliveries")).toBeTruthy());
-
-    // Hidden rather than unmounted, which is what makes returning free.
-    expect(document.querySelector(".app__session")?.hasAttribute("hidden")).toBe(true);
-    expect(document.querySelector("[data-composer] .cm-content")).toBe(composer);
     await user.click(screen.getByRole("button", { name: /acme\/widgets#412/ }));
 
     await waitFor(() => expect(screen.getByText("first")).toBeTruthy());
-    expect(document.querySelector("[data-composer] .cm-content")).toBe(composer);
-    expect(composer.textContent).toContain("worth keeping");
+    expect(document.querySelector("[data-composer] .cm-content")?.textContent).toContain(
+      "worth keeping",
+    );
     expect(screen.getByText("second").closest(".diff-row")?.className).toContain(
       "diff-row--selected",
     );
+    expect(openSession).toHaveBeenCalledTimes(1);
   });
 
   it("leaves the hidden Session's keys alone while Home has them", async () => {
@@ -330,6 +357,7 @@ describe("the Session kept alive behind Home", () => {
 
   it("marks the alive Session's row and leaves every other row unmarked", async () => {
     describeWindow.mockResolvedValue(showingHome(alive()));
+    refreshHome.mockResolvedValue(ok(withAliveRow()));
 
     await openHome();
 
@@ -339,6 +367,7 @@ describe("the Session kept alive behind Home", () => {
 
   it("returns to the alive Session rather than reloading it when its row is opened", async () => {
     describeWindow.mockResolvedValue(showingHome(alive()));
+    refreshHome.mockResolvedValue(ok(withAliveRow()));
     await openHome();
 
     fireEvent.keyDown(window, { key: "Enter" });
@@ -350,6 +379,7 @@ describe("the Session kept alive behind Home", () => {
   it("still opens a different row while a Session is alive", async () => {
     const user = userEvent.setup();
     describeWindow.mockResolvedValue(showingHome(alive()));
+    refreshHome.mockResolvedValue(ok(withAliveRow()));
     await openHome();
 
     await user.click(screen.getByText("Split the invoice renderer"));
@@ -389,10 +419,43 @@ describe("refreshing on focus", () => {
     expect(refreshHome).not.toHaveBeenCalled();
   });
 
-  it("stops listening once the Session replaces Home", async () => {
+  it("refreshes nothing on focus once the Session is showing", async () => {
     await openTheCursorRow();
+    refreshHome.mockClear();
 
-    expect(stopListening).toHaveBeenCalled();
+    focusChanged?.({ payload: true });
+
+    expect(refreshHome).not.toHaveBeenCalled();
+  });
+
+  /// A refresh running when a row is opened has nowhere to report to if Home
+  /// goes, and the return would then wait on a refresh that never settles.
+  it("lands the snapshot of a refresh still running when the row was opened", async () => {
+    let settle: ((snapshot: unknown) => void) | null = null;
+    let progress: ((shown: unknown) => void) | null = null;
+    refreshHome.mockImplementation((onProgress: { onmessage: (shown: unknown) => void }) => {
+      progress = (shown: unknown) => onProgress.onmessage(shown);
+      return new Promise((resolve) => {
+        settle = resolve;
+      });
+    });
+    render(<App />);
+    await waitFor(() => expect(progress).not.toBeNull());
+    act(() => progress?.({ ...listed(), refresh: { Refreshing: { done: 1, total: 3 } } }));
+    await waitFor(() => expect(screen.getByText("Refreshing 1 of 3")).toBeTruthy());
+
+    fireEvent.keyDown(window, { key: "Enter" });
+    await waitFor(() => expect(screen.getByText("first")).toBeTruthy());
+    fireEvent.keyDown(window, { key: "[", metaKey: true });
+    await waitFor(() => expect(screen.getByText("Retry webhook deliveries")).toBeTruthy());
+    // The refresh already running answers the return; a second never starts.
+    expect(refreshHome).toHaveBeenCalledTimes(1);
+
+    act(() =>
+      settle?.(ok({ ...listed(), refresh: { Refreshed: { at_ms: Date.now() - 150_000 } } })),
+    );
+
+    await waitFor(() => expect(screen.getByText("Refreshed 2 min ago")).toBeTruthy());
   });
 
   it("refreshes on no timer at all", async () => {

--- a/apps/desktop/src/SessionApp.tsx
+++ b/apps/desktop/src/SessionApp.tsx
@@ -3,7 +3,17 @@ import { LoadingScreen } from "./components/LoadingScreen";
 import { SessionShell } from "./components/SessionShell";
 import { useSession } from "./hooks/useSession";
 
-export function SessionApp({ description }: { description: string }) {
+export function SessionApp({
+  description,
+  isShowing,
+  onBack,
+}: {
+  description: string;
+  /** False while Home is in front, which is when this Session yields the keyboard. */
+  isShowing: boolean;
+  /** Absent for a Session with no Home behind it, which offers no way back. */
+  onBack: (() => void) | null;
+}) {
   const {
     state,
     selectFile,
@@ -13,7 +23,7 @@ export function SessionApp({ description }: { description: string }) {
     composerChange,
     composerDiscard,
     reanchorDraft,
-  } = useSession(description);
+  } = useSession(description, isShowing);
 
   switch (state.status) {
     case "loading":
@@ -24,6 +34,7 @@ export function SessionApp({ description }: { description: string }) {
       return (
         <SessionShell
           state={state}
+          onBack={onBack}
           onSelectFile={selectFile}
           onRowClick={clickRow}
           onOpenComposer={openComposer}

--- a/apps/desktop/src/SessionApp.tsx
+++ b/apps/desktop/src/SessionApp.tsx
@@ -34,6 +34,7 @@ export function SessionApp({
       return (
         <SessionShell
           state={state}
+          isShowing={isShowing}
           onBack={onBack}
           onSelectFile={selectFile}
           onRowClick={clickRow}

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -5,13 +5,13 @@ import { invoke as __TAURI_INVOKE, Channel } from "@tauri-apps/api/core";
 /** Commands */
 export const commands = {
 	/**
-	 *  Which screen the binary was launched into, asked once before anything is
-	 *  rendered.
+	 *  Which screen the window shows, and the Session it is holding.
 	 * 
-	 *  A Session carries its request's own description, which is all the loading
+	 *  Asked once before anything is rendered, and again after every navigation. A
+	 *  Session carries its request's own description, which is all the loading
 	 *  screen can say before the load reaches the pull request itself.
 	 */
-	describeLaunch: () => __TAURI_INVOKE<LaunchDto>("describe_launch"),
+	describeWindow: () => __TAURI_INVOKE<WindowDto>("describe_window"),
 	/**
 	 *  Re-reads the settings file, then fetches what every clone it lists has open.
 	 * 
@@ -58,6 +58,34 @@ export const commands = {
 	removeRepository: (path: string) => typedError<HomeSnapshotDto, SessionFailureDto>(__TAURI_INVOKE("remove_repository", { path })),
 	/**  Opens or closes the Repositories footer. */
 	toggleRepositoriesFooter: () => __TAURI_INVOKE<HomeSnapshotDto>("toggle_repositories_footer"),
+	/**
+	 *  Opens the pull request a Home row names, replacing whatever Session was
+	 *  alive.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns a failure when no configured clone resolves to `repository`, which
+	 *  leaves the Session that was alive exactly as it was.
+	 */
+	openRow: (repository: string, number: number) => typedError<WindowDto, SessionFailureDto>(__TAURI_INVOKE("open_row", { repository, number })),
+	/**
+	 *  Shows Home again, leaving the Session alive behind it.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns a failure for a Session the command line opened, which has no Home
+	 *  behind it to go back to.
+	 */
+	returnToHome: () => typedError<WindowDto, SessionFailureDto>(__TAURI_INVOKE("return_to_home")),
+	/**
+	 *  Shows the Session alive behind Home again, exactly as it was left.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns a failure when no Session is alive, which the header slot's own
+	 *  absence already keeps a reviewer from asking for.
+	 */
+	returnToSession: () => typedError<WindowDto, SessionFailureDto>(__TAURI_INVOKE("return_to_session")),
 	/**
 	 *  Loads the review session the window was opened with, reporting each stage on
 	 *  `on_stage` as it goes.
@@ -209,6 +237,9 @@ export type HomeRowDto = {
 	index: number,
 	title: string,
 	url: string,
+	/**  `owner/name`, which opening this row names its pull request by. */
+	repository: string,
+	number: number,
 	/**  `owner/name#number`. */
 	identity: string,
 	/**  Absent once GitHub has forgotten the account. */
@@ -256,10 +287,21 @@ export type HomeSnapshotDto = {
 	drafts_failure: SessionFailureDto | null,
 };
 
-/**  Which screen the binary was launched into. */
-export type LaunchDto = "Home" | { Session: {
+/**  The one Session the window holds, in front of Home or alive behind it. */
+export type OpenSessionDto = {
+	/**
+	 *  What is being opened, which is all the loading screen can say before the
+	 *  load reaches the pull request itself.
+	 */
 	description: string,
-} };
+	/**
+	 *  `owner/name#number` of the row this Session was opened from, which the
+	 *  header slot reads and Home marks that row by. Absent for a Session the
+	 *  command line opened, and its absence is what says there is no Home to go
+	 *  back to.
+	 */
+	row_identity: string | null,
+};
 
 /**  How current the list is, which the header stamp reads. */
 export type RefreshStateDto = 
@@ -337,6 +379,20 @@ export type StaleDraftDto = {
  *  sheet that owns them.
  */
 export type StatusToneDto = "Success" | "Error" | "Warning" | "Muted";
+
+/**  Which screen the window shows, and the Session it is holding. */
+export type WindowDto = 
+/**
+ *  Home, with the Session alive behind it when there is one. That Session's
+ *  tree stays mounted and hidden, which is what makes returning instant.
+ */
+({ Home: {
+	alive: OpenSessionDto | null,
+} }) & { Session?: never } | 
+/**  The Session, in front of Home or with no Home behind it at all. */
+({ Session: {
+	session: OpenSessionDto,
+} }) & { Home?: never };
 
 /* Tauri Specta runtime */
 async function typedError<T, E>(result: Promise<T>): Promise<{ status: "ok"; data: T } | { status: "error"; error: E }> {

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -253,6 +253,11 @@ export type HomeRowDto = {
 	check_status: RowStatusDto | null,
 	/**  "1 draft" or "N drafts", absent for a blank cell. */
 	drafts_label: string | null,
+	/**
+	 *  Whether the Session alive behind Home is open on this row's pull
+	 *  request, which is what the row's accent mark says.
+	 */
+	is_alive: boolean,
 };
 
 /**  Everything Home renders, from its header to its footer. */

--- a/apps/desktop/src/components/CommentComposer.tsx
+++ b/apps/desktop/src/components/CommentComposer.tsx
@@ -5,6 +5,7 @@ import "./CommentComposer.css";
 /** The comment editor over a frozen row span, pre-filled silently on mount and rebuilt only when `rows` changes identity. */
 export function CommentComposer({
   rows,
+  isShowing,
   prefill,
   notice,
   onChange,
@@ -12,6 +13,8 @@ export function CommentComposer({
   onDiscard,
 }: {
   rows: [number, number];
+  /** False while Home is in front, which is when nothing here can hold focus. */
+  isShowing: boolean;
   prefill: string;
   notice: string | null;
   onChange: (body: string) => void;
@@ -19,6 +22,7 @@ export function CommentComposer({
   onDiscard: () => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const editorRef = useRef<{ focus: () => void } | null>(null);
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
   const onCloseRef = useRef(onClose);
@@ -35,10 +39,22 @@ export function CommentComposer({
       onChange: (body) => onChangeRef.current(body),
       onClose: () => onCloseRef.current(),
     });
+    editorRef.current = handle;
     handle.focus();
-    return () => handle.destroy();
+    return () => {
+      editorRef.current = null;
+      handle.destroy();
+    };
     // Deliberately keyed on the span alone. Prefill only seeds the first mount.
   }, [rows[0], rows[1]]);
+
+  useEffect(() => {
+    // Focus goes nowhere while the Session is hidden, so the composer takes it
+    // back on return and the reviewer carries on typing where they stopped.
+    if (isShowing) {
+      editorRef.current?.focus();
+    }
+  }, [isShowing]);
 
   return (
     <div className="comment-composer" data-composer>

--- a/apps/desktop/src/components/DiffList.test.tsx
+++ b/apps/desktop/src/components/DiffList.test.tsx
@@ -19,6 +19,7 @@ function rows(): RowDto[] {
 /** Every prop DiffList needs beyond the ones a test wants to vary. */
 function baseProps() {
   return {
+    isShowing: true,
     fileIndex: 0,
     drafts: makeDrafts(),
     composer: null as ComposerState,

--- a/apps/desktop/src/components/DiffList.tsx
+++ b/apps/desktop/src/components/DiffList.tsx
@@ -11,6 +11,7 @@ import "./DiffList.css";
 
 export function DiffList({
   rows,
+  isShowing,
   fileIndex,
   cursor,
   selectionStart,
@@ -25,6 +26,8 @@ export function DiffList({
   onComposerDiscard,
 }: {
   rows: RowDto[];
+  /** False while Home is in front, which is when nothing here has a size. */
+  isShowing: boolean;
   fileIndex: number;
   cursor: number;
   selectionStart: number;
@@ -64,6 +67,17 @@ export function DiffList({
     virtualizer.scrollToIndex(cursor, { align: "auto" });
   }, [cursor, virtualizer]);
 
+  useEffect(() => {
+    // Nothing has a size while the Session is hidden, so what was measured
+    // then is worth nothing and the scroll it decided is gone. Measure again
+    // and put the cursor row back where the reviewer left it.
+    if (!isShowing || rows.length === 0) {
+      return;
+    }
+    virtualizer.measure();
+    virtualizer.scrollToIndex(cursor, { align: "auto" });
+  }, [isShowing]);
+
   return (
     <div ref={scrollRef} className="diff-list">
       <div className="diff-list__spacer" style={{ height: virtualizer.getTotalSize() }}>
@@ -96,6 +110,7 @@ export function DiffList({
               {composerOpenHere && composer && (
                 <CommentComposer
                   rows={composer.rows}
+                  isShowing={isShowing}
                   prefill={composerPrefill}
                   notice={composer.notice}
                   onChange={onComposerChange}

--- a/apps/desktop/src/components/FileSidebar.css
+++ b/apps/desktop/src/components/FileSidebar.css
@@ -15,7 +15,36 @@
   border-bottom: 1px solid var(--border-default);
 }
 
+.file-sidebar__identity {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+
+/* The way back to Home, bound to cmd-[, beside the pull request it names. */
+.file-sidebar__back {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: 0;
+  border-radius: 3px;
+  background: none;
+  font-family: var(--font-sans);
+  font-size: var(--size-body);
+  line-height: 1;
+  color: var(--text-tertiary);
+  cursor: pointer;
+}
+
+.file-sidebar__back:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
 .file-sidebar__label {
+  min-width: 0;
   color: var(--severity-info);
   font-size: var(--size-meta);
   overflow: hidden;

--- a/apps/desktop/src/components/FileSidebar.test.tsx
+++ b/apps/desktop/src/components/FileSidebar.test.tsx
@@ -8,6 +8,7 @@ import { FileSidebar } from "./FileSidebar";
 /** Every prop FileSidebar needs beyond the ones a test wants to vary. */
 function baseProps() {
   return {
+    onBack: null,
     title: "t",
     subtitle: "s",
     warnings: [],

--- a/apps/desktop/src/components/FileSidebar.tsx
+++ b/apps/desktop/src/components/FileSidebar.tsx
@@ -13,6 +13,7 @@ const STATUS_GLYPH: Record<FileStatusDto, { label: string; className: string }> 
 };
 
 export function FileSidebar({
+  onBack,
   title,
   subtitle,
   sidebar,
@@ -24,6 +25,8 @@ export function FileSidebar({
   onSelect,
   onReanchorDraft,
 }: {
+  /** Absent for a Session with no Home behind it, which offers no way back. */
+  onBack: (() => void) | null;
   title: string;
   subtitle: string;
   sidebar: SidebarDto;
@@ -43,7 +46,20 @@ export function FileSidebar({
   return (
     <div className="file-sidebar">
       <div className="file-sidebar__header">
-        <div className="file-sidebar__label">{title}</div>
+        <div className="file-sidebar__identity">
+          {onBack !== null && (
+            <button
+              type="button"
+              className="file-sidebar__back"
+              aria-label="Back to Home"
+              title="Back to Home (cmd-[)"
+              onClick={onBack}
+            >
+              &#8249;
+            </button>
+          )}
+          <div className="file-sidebar__label">{title}</div>
+        </div>
         <div className="file-sidebar__title">{subtitle}</div>
         <div className="file-sidebar__meta">
           {sidebar.files.length} files &middot; {sidebar.viewed_count} viewed &middot;{" "}

--- a/apps/desktop/src/components/HomeScreen.css
+++ b/apps/desktop/src/components/HomeScreen.css
@@ -199,6 +199,7 @@
 
 /* One dense line per pull request, on the file row's scale. */
 .home__row {
+  position: relative;
   height: var(--file-row-height);
   padding: 0 12px;
   display: flex;
@@ -253,19 +254,19 @@
   font-size: var(--size-label);
 }
 
-/* Wide enough for "you reviewed this head", the longest label it carries, so
-   the mark can sit in the gap before it without any clipping to fear. */
+/* Wide enough for "you reviewed this head", the longest label it carries. */
 .home__cell--review {
   width: 172px;
-  position: relative;
-  overflow: visible;
 }
 
-/* The alive Session's row, marked where its statuses begin. Out of the text
-   flow, so every other row's columns stay aligned with it. */
+/* The alive Session's row, marked in the gap where its statuses begin.
+   Positioned against the row rather than the cell it sits in, so it is out of
+   every other row's way and no cell has to give up hiding its overflow. Its
+   horizontal place is the one it would have had in the cell, shifted back into
+   the gap; its vertical place is the middle of the row. */
 .home__alive-mark {
   position: absolute;
-  left: -9px;
+  margin-left: -9px;
   top: 50%;
   width: 6px;
   height: 6px;

--- a/apps/desktop/src/components/HomeScreen.css
+++ b/apps/desktop/src/components/HomeScreen.css
@@ -36,6 +36,34 @@
   color: var(--text-tertiary);
 }
 
+.home__header-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+/* The Session alive behind Home, and the way back into it. */
+.home__slot {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 6px;
+  border: 1px solid var(--accent-base);
+  border-radius: 4px;
+  background: none;
+  cursor: pointer;
+}
+
+.home__slot:hover {
+  background: var(--surface-hover);
+}
+
+.home__slot-identity {
+  font-family: var(--font-mono);
+  font-size: var(--size-label);
+  color: var(--accent-text);
+}
+
 .home__stamp {
   display: flex;
   align-items: center;
@@ -178,6 +206,7 @@
   gap: 12px;
   border-radius: 4px;
   background: var(--surface-base);
+  cursor: pointer;
 }
 
 .home__row:hover {
@@ -224,9 +253,25 @@
   font-size: var(--size-label);
 }
 
-/* Wide enough for "you reviewed this head", the longest label it carries. */
+/* Wide enough for "you reviewed this head", the longest label it carries, so
+   the mark can sit in the gap before it without any clipping to fear. */
 .home__cell--review {
   width: 172px;
+  position: relative;
+  overflow: visible;
+}
+
+/* The alive Session's row, marked where its statuses begin. Out of the text
+   flow, so every other row's columns stay aligned with it. */
+.home__alive-mark {
+  position: absolute;
+  left: -9px;
+  top: 50%;
+  width: 6px;
+  height: 6px;
+  margin-top: -3px;
+  border-radius: 50%;
+  background: var(--accent-base);
 }
 
 .home__cell--checks {

--- a/apps/desktop/src/components/HomeScreen.tsx
+++ b/apps/desktop/src/components/HomeScreen.tsx
@@ -23,8 +23,18 @@ function stampText(refresh: RefreshStateDto, nowMs: number): string | null {
 }
 
 /** The screen ZReview opens on when no pull request has been named. */
-export function HomeScreen() {
-  const { snapshot, failure, toggleFooter, addRepositories, removeRepository } = useHome();
+export function HomeScreen({
+  aliveIdentity,
+  onOpenRow,
+  onReturnToSession,
+}: {
+  /** `owner/name#number` of the Session alive behind Home, if one is. */
+  aliveIdentity: string | null;
+  onOpenRow: (repository: string, number: number) => void;
+  onReturnToSession: () => void;
+}) {
+  const { snapshot, failure, toggleFooter, addRepositories, removeRepository, openRow, isAliveRow } =
+    useHome({ aliveIdentity, onOpenRow, onReturnToSession });
   const nowMs = useNow();
 
   // A command that never answered leaves nothing worth trusting on screen.
@@ -40,12 +50,19 @@ export function HomeScreen() {
 
   return (
     <div className="home">
-      <Header countLine={snapshot.count_line} stamp={stamp} />
+      <Header
+        countLine={snapshot.count_line}
+        stamp={stamp}
+        aliveIdentity={aliveIdentity}
+        onReturnToSession={onReturnToSession}
+      />
       <HomeBody
         snapshot={snapshot}
         nowMs={nowMs}
+        isAliveRow={isAliveRow}
         onAdd={addRepositories}
         onRemove={removeRepository}
+        onOpenRow={openRow}
       />
       <footer className="home__footer">
         <div className="home__footer-line">
@@ -82,19 +99,38 @@ export function HomeScreen() {
   );
 }
 
-function Header({ countLine, stamp }: { countLine: string | null; stamp: string | null }) {
+function Header({
+  countLine,
+  stamp,
+  aliveIdentity,
+  onReturnToSession,
+}: {
+  countLine: string | null;
+  stamp: string | null;
+  aliveIdentity: string | null;
+  onReturnToSession: () => void;
+}) {
   return (
     <header className="home__header">
       <div className="home__heading">
         <h1 className="home__title">Home</h1>
         {countLine !== null && <span className="home__count">{countLine}</span>}
       </div>
-      {stamp !== null && (
-        <div className="home__stamp">
-          <span className="home__stamp-text">{stamp}</span>
-          <span className="home__keycap">r</span>
-        </div>
-      )}
+      <div className="home__header-right">
+        {/* The way back to a Session whose pull request has no row at all. */}
+        {aliveIdentity !== null && (
+          <button className="home__slot" type="button" onClick={onReturnToSession}>
+            <span className="home__slot-identity">{aliveIdentity}</span>
+            <span className="home__keycap">cmd-[</span>
+          </button>
+        )}
+        {stamp !== null && (
+          <div className="home__stamp">
+            <span className="home__stamp-text">{stamp}</span>
+            <span className="home__keycap">r</span>
+          </div>
+        )}
+      </div>
     </header>
   );
 }
@@ -103,13 +139,17 @@ function Header({ countLine, stamp }: { countLine: string | null; stamp: string 
 function HomeBody({
   snapshot,
   nowMs,
+  isAliveRow,
   onAdd,
   onRemove,
+  onOpenRow,
 }: {
   snapshot: HomeSnapshotDto;
   nowMs: number;
+  isAliveRow: (row: HomeRowDto) => boolean;
   onAdd: () => void;
   onRemove: (path: string) => void;
+  onOpenRow: (row: HomeRowDto) => void;
 }) {
   if (snapshot.failure !== null) {
     return (
@@ -156,7 +196,14 @@ function HomeBody({
           {group.count > 0 && (
             <ul className="home__rows">
               {group.rows.map((row) => (
-                <Row key={row.identity} row={row} cursor={row.index === snapshot.cursor} nowMs={nowMs} />
+                <Row
+                  key={row.identity}
+                  row={row}
+                  cursor={row.index === snapshot.cursor}
+                  alive={isAliveRow(row)}
+                  nowMs={nowMs}
+                  onOpen={onOpenRow}
+                />
               ))}
             </ul>
           )}
@@ -188,7 +235,19 @@ function FailureLine({ failure }: { failure: SessionFailureDto | null }) {
 }
 
 /** One pull request on one line, its columns aligned whether or not they speak. */
-function Row({ row, cursor, nowMs }: { row: HomeRowDto; cursor: boolean; nowMs: number }) {
+function Row({
+  row,
+  cursor,
+  alive,
+  nowMs,
+  onOpen,
+}: {
+  row: HomeRowDto;
+  cursor: boolean;
+  alive: boolean;
+  nowMs: number;
+  onOpen: (row: HomeRowDto) => void;
+}) {
   const line = useRef<HTMLLIElement>(null);
 
   useEffect(() => {
@@ -202,6 +261,7 @@ function Row({ row, cursor, nowMs }: { row: HomeRowDto; cursor: boolean; nowMs: 
       ref={line}
       className={`home__row${cursor ? " home__row--cursor" : ""}`}
       aria-selected={cursor}
+      onClick={() => onOpen(row)}
     >
       <span className="home__row-title">{row.title}</span>
       <span className="home__cell home__cell--drafts">
@@ -210,6 +270,7 @@ function Row({ row, cursor, nowMs }: { row: HomeRowDto; cursor: boolean; nowMs: 
         )}
       </span>
       <span className="home__cell home__cell--review">
+        {alive && <span className="home__alive-mark" aria-hidden="true" />}
         {row.review_status !== null && (
           <span className={`home__status home__status--${row.review_status.tone.toLowerCase()}`}>
             {row.review_status.label}

--- a/apps/desktop/src/components/HomeScreen.tsx
+++ b/apps/desktop/src/components/HomeScreen.tsx
@@ -24,17 +24,20 @@ function stampText(refresh: RefreshStateDto, nowMs: number): string | null {
 
 /** The screen ZReview opens on when no pull request has been named. */
 export function HomeScreen({
+  isShowing,
   aliveIdentity,
   onOpenRow,
   onReturnToSession,
 }: {
+  /** False while a Session is in front, which is when Home goes quiet. */
+  isShowing: boolean;
   /** `owner/name#number` of the Session alive behind Home, if one is. */
   aliveIdentity: string | null;
-  onOpenRow: (repository: string, number: number) => void;
-  onReturnToSession: () => void;
+  onOpenRow: (repository: string, number: number) => Promise<SessionFailureDto | null>;
+  onReturnToSession: () => Promise<SessionFailureDto | null>;
 }) {
-  const { snapshot, failure, toggleFooter, addRepositories, removeRepository, openRow, isAliveRow } =
-    useHome({ aliveIdentity, onOpenRow, onReturnToSession });
+  const { snapshot, failure, openFailure, toggleFooter, addRepositories, removeRepository, openRow } =
+    useHome({ isShowing, onOpenRow, onReturnToSession });
   const nowMs = useNow();
 
   // A command that never answered leaves nothing worth trusting on screen.
@@ -58,8 +61,8 @@ export function HomeScreen({
       />
       <HomeBody
         snapshot={snapshot}
+        openFailure={openFailure}
         nowMs={nowMs}
-        isAliveRow={isAliveRow}
         onAdd={addRepositories}
         onRemove={removeRepository}
         onOpenRow={openRow}
@@ -138,23 +141,25 @@ function Header({
 /** The list area, which the empty state and a whole-Home failure each replace. */
 function HomeBody({
   snapshot,
+  openFailure,
   nowMs,
-  isAliveRow,
   onAdd,
   onRemove,
   onOpenRow,
 }: {
   snapshot: HomeSnapshotDto;
+  /** Why the last row would not open, until the next refresh asks again. */
+  openFailure: SessionFailureDto | null;
   nowMs: number;
-  isAliveRow: (row: HomeRowDto) => boolean;
   onAdd: () => void;
   onRemove: (path: string) => void;
   onOpenRow: (row: HomeRowDto) => void;
 }) {
-  if (snapshot.failure !== null) {
+  const blocked = snapshot.failure ?? openFailure;
+  if (blocked !== null) {
     return (
       <div className="home__body">
-        <FailureScreen failure={snapshot.failure} />
+        <FailureScreen failure={blocked} />
       </div>
     );
   }
@@ -200,7 +205,7 @@ function HomeBody({
                   key={row.identity}
                   row={row}
                   cursor={row.index === snapshot.cursor}
-                  alive={isAliveRow(row)}
+                  alive={row.is_alive}
                   nowMs={nowMs}
                   onOpen={onOpenRow}
                 />

--- a/apps/desktop/src/components/SessionShell.test.tsx
+++ b/apps/desktop/src/components/SessionShell.test.tsx
@@ -7,6 +7,7 @@ import { SessionShell } from "./SessionShell";
 /** Every prop SessionShell needs beyond the ones a test wants to vary. */
 function baseHandlers() {
   return {
+    onBack: null,
     onSelectFile: () => {},
     onRowClick: () => {},
     onOpenComposer: () => {},

--- a/apps/desktop/src/components/SessionShell.test.tsx
+++ b/apps/desktop/src/components/SessionShell.test.tsx
@@ -7,6 +7,7 @@ import { SessionShell } from "./SessionShell";
 /** Every prop SessionShell needs beyond the ones a test wants to vary. */
 function baseHandlers() {
   return {
+    isShowing: true,
     onBack: null,
     onSelectFile: () => {},
     onRowClick: () => {},

--- a/apps/desktop/src/components/SessionShell.tsx
+++ b/apps/desktop/src/components/SessionShell.tsx
@@ -8,6 +8,7 @@ import "./SessionShell.css";
 
 export function SessionShell({
   state,
+  onBack,
   onSelectFile,
   onRowClick,
   onOpenComposer,
@@ -17,6 +18,8 @@ export function SessionShell({
   onReanchorDraft,
 }: {
   state: ReadyState;
+  /** Absent for a Session with no Home behind it, which offers no way back. */
+  onBack: (() => void) | null;
   onSelectFile: (index: number) => void;
   onRowClick: (index: number) => void;
   onOpenComposer: (index: number) => void;
@@ -32,6 +35,7 @@ export function SessionShell({
   return (
     <div className="session-shell">
       <FileSidebar
+        onBack={onBack}
         title={state.snapshot.title}
         subtitle={state.snapshot.subtitle}
         sidebar={state.snapshot.sidebar}

--- a/apps/desktop/src/components/SessionShell.tsx
+++ b/apps/desktop/src/components/SessionShell.tsx
@@ -8,6 +8,7 @@ import "./SessionShell.css";
 
 export function SessionShell({
   state,
+  isShowing,
   onBack,
   onSelectFile,
   onRowClick,
@@ -18,6 +19,8 @@ export function SessionShell({
   onReanchorDraft,
 }: {
   state: ReadyState;
+  /** False while Home is in front, which is when this Session has no screen. */
+  isShowing: boolean;
   /** Absent for a Session with no Home behind it, which offers no way back. */
   onBack: (() => void) | null;
   onSelectFile: (index: number) => void;
@@ -55,6 +58,7 @@ export function SessionShell({
       ) : (
         <DiffList
           rows={rows}
+          isShowing={isShowing}
           fileIndex={state.file.index}
           cursor={state.cursor}
           selectionStart={selectionStart}

--- a/apps/desktop/src/hooks/useHome.ts
+++ b/apps/desktop/src/hooks/useHome.ts
@@ -19,20 +19,24 @@ function isTyping(target: EventTarget | null): boolean {
   return target.isContentEditable || target.closest("input, textarea") !== null;
 }
 
-/** Reads Home's pull requests and exposes every action the screen can take on them. */
+/**
+ * Reads Home's pull requests and exposes every action the screen can take.
+ *
+ * Home stays mounted behind a Session, so `isShowing` is what decides whether
+ * it answers the keyboard, listens for focus, and refreshes.
+ */
 export function useHome({
-  aliveIdentity,
+  isShowing,
   onOpenRow,
   onReturnToSession,
 }: {
-  /** `owner/name#number` of the Session alive behind Home, if one is. */
-  aliveIdentity: string | null;
-  onOpenRow: (repository: string, number: number) => void;
-  onReturnToSession: () => void;
+  isShowing: boolean;
+  onOpenRow: (repository: string, number: number) => Promise<SessionFailureDto | null>;
+  onReturnToSession: () => Promise<SessionFailureDto | null>;
 }) {
   const [snapshot, setSnapshot] = useState<HomeSnapshotDto | null>(null);
   const [failure, setFailure] = useState<SessionFailureDto | null>(null);
-  const hasOpened = useRef(false);
+  const [openFailure, setOpenFailure] = useState<SessionFailureDto | null>(null);
   const refreshing = useRef(false);
   // Read by the key handler, which is attached once and must still see the
   // list as it stands rather than as it was when it was attached.
@@ -69,6 +73,7 @@ export function useHome({
       return;
     }
     refreshing.current = true;
+    setOpenFailure(null);
     // Every batch carries what Home shows by then, so the list fills in as it loads.
     const channel = new Channel<HomeSnapshotDto>();
     channel.onmessage = (shown) => {
@@ -80,20 +85,29 @@ export function useHome({
     });
   }, [apply]);
 
+  // Home refreshes when it appears, which is the first time it is drawn and
+  // every return from a Session. What it last showed is what decides, so
+  // StrictMode's double mount effect refreshes once and a refresh already
+  // running is left to settle the screen itself.
+  const showed = useRef(false);
   useEffect(() => {
-    // Guarded so StrictMode's double mount effect does not refresh twice.
-    if (hasOpened.current) {
+    if (showed.current === isShowing) {
       return;
     }
-    hasOpened.current = true;
-    refresh();
-  }, [refresh]);
+    showed.current = isShowing;
+    if (isShowing) {
+      refresh();
+    }
+  }, [isShowing, refresh]);
 
   // Coming back from the browser shows the current state. Nothing polls, so
   // this and `r` are all that ever ask GitHub anything while Home is up. The
   // listener goes with the screen, so a Session in front of Home refreshes
   // nothing.
   useEffect(() => {
+    if (!isShowing) {
+      return;
+    }
     let listening = true;
     let stopListening: (() => void) | null = null;
     getCurrentWindow()
@@ -114,7 +128,7 @@ export function useHome({
       listening = false;
       stopListening?.();
     };
-  }, [refresh]);
+  }, [isShowing, refresh]);
 
   const toggleFooter = useCallback(() => {
     commands
@@ -172,30 +186,19 @@ export function useHome({
       .catch((error: unknown) => setFailure(toFailure(error)));
   }, []);
 
-  /** Whether this row's pull request is the one the alive Session is open on. */
-  const isAliveRow = useCallback(
-    (row: HomeRowDto) =>
-      // GitHub compares two repository names without regard to case, so a row
-      // that came back cased differently is still the alive Session's own.
-      aliveIdentity !== null && row.identity.toLowerCase() === aliveIdentity.toLowerCase(),
-    [aliveIdentity],
-  );
-
   /**
    * Opens `row`'s pull request, or returns to it when its Session is the one
    * alive behind Home.
    *
    * Returning never reloads, which is what keeps a half-finished review whole.
+   * A refusal stays on Home, which is where the reviewer can act on it.
    */
   const openRow = useCallback(
     (row: HomeRowDto) => {
-      if (isAliveRow(row)) {
-        onReturnToSession();
-        return;
-      }
-      onOpenRow(row.repository, row.number);
+      const navigated = row.is_alive ? onReturnToSession() : onOpenRow(row.repository, row.number);
+      navigated.then(setOpenFailure);
     },
-    [isAliveRow, onOpenRow, onReturnToSession],
+    [onOpenRow, onReturnToSession],
   );
 
   const openCursorRow = useCallback(() => {
@@ -215,6 +218,9 @@ export function useHome({
   // r refreshes, e opens or closes the Repositories footer, j and k walk the
   // rows, and Enter opens the one under the cursor.
   useEffect(() => {
+    if (!isShowing) {
+      return;
+    }
     function handleKeydown(event: KeyboardEvent) {
       if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
         return;
@@ -251,15 +257,15 @@ export function useHome({
 
     window.addEventListener("keydown", handleKeydown);
     return () => window.removeEventListener("keydown", handleKeydown);
-  }, [moveCursor, openCursorRow, refresh, toggleFooter]);
+  }, [isShowing, moveCursor, openCursorRow, refresh, toggleFooter]);
 
   return {
     snapshot,
     failure,
+    openFailure,
     toggleFooter,
     addRepositories,
     removeRepository,
     openRow,
-    isAliveRow,
   };
 }

--- a/apps/desktop/src/hooks/useHome.ts
+++ b/apps/desktop/src/hooks/useHome.ts
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Channel } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
-import type { CursorMoveDto, HomeSnapshotDto, SessionFailureDto } from "../bindings";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import type { CursorMoveDto, HomeRowDto, HomeSnapshotDto, SessionFailureDto } from "../bindings";
 import { commands } from "../bindings";
 import { toFailure } from "../lib/failure";
 
@@ -19,11 +20,24 @@ function isTyping(target: EventTarget | null): boolean {
 }
 
 /** Reads Home's pull requests and exposes every action the screen can take on them. */
-export function useHome() {
+export function useHome({
+  aliveIdentity,
+  onOpenRow,
+  onReturnToSession,
+}: {
+  /** `owner/name#number` of the Session alive behind Home, if one is. */
+  aliveIdentity: string | null;
+  onOpenRow: (repository: string, number: number) => void;
+  onReturnToSession: () => void;
+}) {
   const [snapshot, setSnapshot] = useState<HomeSnapshotDto | null>(null);
   const [failure, setFailure] = useState<SessionFailureDto | null>(null);
   const hasOpened = useRef(false);
   const refreshing = useRef(false);
+  // Read by the key handler, which is attached once and must still see the
+  // list as it stands rather than as it was when it was attached.
+  const shown = useRef<HomeSnapshotDto | null>(null);
+  shown.current = snapshot;
 
   /** Takes what a command answered, so a rejection is shown rather than swallowed. */
   const apply = useCallback((call: Promise<HomeResult>) => {
@@ -73,6 +87,33 @@ export function useHome() {
     }
     hasOpened.current = true;
     refresh();
+  }, [refresh]);
+
+  // Coming back from the browser shows the current state. Nothing polls, so
+  // this and `r` are all that ever ask GitHub anything while Home is up. The
+  // listener goes with the screen, so a Session in front of Home refreshes
+  // nothing.
+  useEffect(() => {
+    let listening = true;
+    let stopListening: (() => void) | null = null;
+    getCurrentWindow()
+      .onFocusChanged(({ payload: focused }) => {
+        if (focused) {
+          refresh();
+        }
+      })
+      .then((stop) => {
+        if (listening) {
+          stopListening = stop;
+        } else {
+          stop();
+        }
+      })
+      .catch((error: unknown) => setFailure(toFailure(error)));
+    return () => {
+      listening = false;
+      stopListening?.();
+    };
   }, [refresh]);
 
   const toggleFooter = useCallback(() => {
@@ -131,8 +172,48 @@ export function useHome() {
       .catch((error: unknown) => setFailure(toFailure(error)));
   }, []);
 
-  // r refreshes, e opens or closes the Repositories footer, and j and k walk the
-  // rows, as the layout prototype bound them.
+  /** Whether this row's pull request is the one the alive Session is open on. */
+  const isAliveRow = useCallback(
+    (row: HomeRowDto) =>
+      // GitHub compares two repository names without regard to case, so a row
+      // that came back cased differently is still the alive Session's own.
+      aliveIdentity !== null && row.identity.toLowerCase() === aliveIdentity.toLowerCase(),
+    [aliveIdentity],
+  );
+
+  /**
+   * Opens `row`'s pull request, or returns to it when its Session is the one
+   * alive behind Home.
+   *
+   * Returning never reloads, which is what keeps a half-finished review whole.
+   */
+  const openRow = useCallback(
+    (row: HomeRowDto) => {
+      if (isAliveRow(row)) {
+        onReturnToSession();
+        return;
+      }
+      onOpenRow(row.repository, row.number);
+    },
+    [isAliveRow, onOpenRow, onReturnToSession],
+  );
+
+  const openCursorRow = useCallback(() => {
+    const listed = shown.current;
+    if (listed === null) {
+      return;
+    }
+    const row = listed.groups
+      .flatMap((group) => group.rows)
+      .find((candidate) => candidate.index === listed.cursor);
+    if (row === undefined) {
+      return;
+    }
+    openRow(row);
+  }, [openRow]);
+
+  // r refreshes, e opens or closes the Repositories footer, j and k walk the
+  // rows, and Enter opens the one under the cursor.
   useEffect(() => {
     function handleKeydown(event: KeyboardEvent) {
       if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
@@ -142,6 +223,11 @@ export function useHome() {
         return;
       }
       const key = event.key.toLowerCase();
+      if (key === "enter") {
+        event.preventDefault();
+        openCursorRow();
+        return;
+      }
       if (key === "r") {
         event.preventDefault();
         refresh();
@@ -165,7 +251,15 @@ export function useHome() {
 
     window.addEventListener("keydown", handleKeydown);
     return () => window.removeEventListener("keydown", handleKeydown);
-  }, [moveCursor, refresh, toggleFooter]);
+  }, [moveCursor, openCursorRow, refresh, toggleFooter]);
 
-  return { snapshot, failure, toggleFooter, addRepositories, removeRepository };
+  return {
+    snapshot,
+    failure,
+    toggleFooter,
+    addRepositories,
+    removeRepository,
+    openRow,
+    isAliveRow,
+  };
 }

--- a/apps/desktop/src/hooks/useSession.ts
+++ b/apps/desktop/src/hooks/useSession.ts
@@ -8,8 +8,13 @@ import { toFailure } from "../lib/failure";
 import { initialState, selectionRange, sessionReducer } from "./sessionReducer";
 import { useDraftQueue } from "./useDraftQueue";
 
-/** Loads the session the window was launched into and exposes every action the UI can take on it. */
-export function useSession(description: string) {
+/**
+ * Loads one session and exposes every action the UI can take on it.
+ *
+ * `isShowing` is false while Home is in front of this session, which keeps its
+ * hidden tree from answering keystrokes meant for the list.
+ */
+export function useSession(description: string, isShowing: boolean) {
   const [state, dispatch] = useReducer(sessionReducer, initialState);
   const stateRef = useRef(state);
   stateRef.current = state;
@@ -108,7 +113,7 @@ export function useSession(description: string) {
   );
 
   useEffect(() => {
-    if (state.status !== "ready") {
+    if (state.status !== "ready" || !isShowing) {
       return;
     }
 
@@ -169,7 +174,7 @@ export function useSession(description: string) {
 
     window.addEventListener("keydown", handleKeydown);
     return () => window.removeEventListener("keydown", handleKeydown);
-  }, [state.status, selectFile, toggleViewed]);
+  }, [state.status, isShowing, selectFile, toggleViewed]);
 
   return {
     state,

--- a/apps/desktop/src/test/fixtures.ts
+++ b/apps/desktop/src/test/fixtures.ts
@@ -123,6 +123,7 @@ export function makeHomeRow(overrides: Partial<HomeRowDto> = {}): HomeRowDto {
     review_status: null,
     check_status: null,
     drafts_label: null,
+    is_alive: false,
     ...overrides,
   };
 }

--- a/apps/desktop/src/test/fixtures.ts
+++ b/apps/desktop/src/test/fixtures.ts
@@ -115,6 +115,8 @@ export function makeHomeRow(overrides: Partial<HomeRowDto> = {}): HomeRowDto {
     index: 0,
     title: "Retry webhook deliveries with jittered backoff",
     url: "https://github.com/acme/widgets/pull/412",
+    repository: "acme/widgets",
+    number: 412,
     identity: "acme/widgets#412",
     author: "mlee",
     updated_at_ms: 1_788_266_096_000,

--- a/crates/app/src/home.rs
+++ b/crates/app/src/home.rs
@@ -12,6 +12,8 @@ use std::{
 
 use domain::SessionFailure;
 
+use crate::window::PullRequestId;
+
 /// What resolving one clone found.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RepositoryOutcome {
@@ -235,10 +237,26 @@ pub struct HomeRow {
 }
 
 impl HomeRow {
+    /// Which pull request this row lists.
+    #[must_use]
+    pub fn pull_request(&self) -> PullRequestId {
+        PullRequestId {
+            repository: self.repository.clone(),
+            number: self.number,
+        }
+    }
+
     /// `owner/name#number`, which is how a row names its pull request.
     #[must_use]
     pub fn identity(&self) -> String {
-        format!("{}#{}", self.repository, self.number)
+        self.pull_request().identity()
+    }
+
+    /// Whether this row lists `pull_request`, which is how the row of the
+    /// Session alive behind Home is found.
+    #[must_use]
+    pub fn is_on(&self, pull_request: &PullRequestId) -> bool {
+        self.pull_request().is_same_pull_request(pull_request)
     }
 
     /// The scope this row's Drafts are stored under.
@@ -945,6 +963,41 @@ mod tests {
                 reason: reason.to_owned(),
             },
         }
+    }
+
+    /// The row a listed pull request becomes, for asking what it names.
+    fn row(repository: &str, number: u64) -> HomeRow {
+        HomeRow {
+            group: HomeGroup::ToReview,
+            repository: repository.to_owned(),
+            number,
+            title: "Retry webhook deliveries".to_owned(),
+            url: String::new(),
+            author_login: None,
+            updated_at_ms: 0,
+            review_status: None,
+            check_status: None,
+        }
+    }
+
+    /// GitHub compares two repository names without regard to case, so a row
+    /// that came back cased differently still names the same pull request.
+    #[test]
+    fn a_row_cased_differently_is_still_on_the_same_pull_request() {
+        let listed = row("ACME/Widgets", 412);
+
+        assert!(listed.is_on(&PullRequestId {
+            repository: "acme/widgets".to_owned(),
+            number: 412,
+        }));
+        assert!(!listed.is_on(&PullRequestId {
+            repository: "acme/widgets".to_owned(),
+            number: 398,
+        }));
+        assert!(!listed.is_on(&PullRequestId {
+            repository: "acme/billing".to_owned(),
+            number: 412,
+        }));
     }
 
     /// One fetched pull request, with nothing standing between it and its group.

--- a/crates/app/src/home.rs
+++ b/crates/app/src/home.rs
@@ -977,6 +977,7 @@ mod tests {
             updated_at_ms: 0,
             review_status: None,
             check_status: None,
+            draft_count: None,
         }
     }
 

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -17,6 +17,7 @@ mod handoff;
 mod home;
 mod review;
 mod session;
+mod window;
 
 pub use handoff::Handoff;
 pub use home::{
@@ -26,6 +27,7 @@ pub use home::{
 };
 pub use review::{FindingDisposition, ReviewModel, ReviewRunState};
 pub use session::{PendingSend, SessionModel, SessionPhase, SubmissionState};
+pub use window::{OpenSession, Opened, PullRequestId, SessionSlot, Showing};
 
 /// Takes a model's lock, recovering from poisoning. The guarded state stays
 /// consistent, and refusing to use it would be worse than the panic that

--- a/crates/app/src/window.rs
+++ b/crates/app/src/window.rs
@@ -1,0 +1,292 @@
+//! Which screen the window shows, and the one Session it holds.
+
+/// Which pull request a Session is open on.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PullRequestId {
+    /// `owner/name`, as GitHub names the repository.
+    pub repository: String,
+    pub number: u64,
+}
+
+impl PullRequestId {
+    /// `owner/name#number`, which is how a row and the header slot name it.
+    #[must_use]
+    pub fn identity(&self) -> String {
+        format!("{}#{}", self.repository, self.number)
+    }
+
+    /// Whether both name one pull request, which GitHub decides without regard
+    /// to case, so nothing here may either.
+    fn is_same_pull_request(&self, other: &Self) -> bool {
+        self.number == other.number && self.repository.eq_ignore_ascii_case(&other.repository)
+    }
+}
+
+/// The one Session a window holds.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum OpenSession {
+    /// Opened from a Home row, which is what puts a Home behind it.
+    FromRow(PullRequestId),
+    /// Opened by the command line, with no Home behind it at all.
+    FromCommandLine,
+}
+
+impl OpenSession {
+    /// `owner/name#number` of the row this Session was opened from, absent for
+    /// one the command line opened on something Home never listed.
+    ///
+    /// Its presence is what says there is a Home behind this Session.
+    #[must_use]
+    pub fn row_identity(&self) -> Option<String> {
+        match self {
+            Self::FromRow(pull_request) => Some(pull_request.identity()),
+            Self::FromCommandLine => None,
+        }
+    }
+
+    /// Whether this Session is open on `pull_request`.
+    fn is_on(&self, pull_request: &PullRequestId) -> bool {
+        match self {
+            Self::FromRow(open) => open.is_same_pull_request(pull_request),
+            Self::FromCommandLine => false,
+        }
+    }
+}
+
+/// Which screen the window shows.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Showing {
+    Home,
+    Session,
+}
+
+/// What opening a row asked of the Session already alive.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[must_use]
+pub enum Opened {
+    /// The Session already alive is this pull request's own, so it is shown
+    /// again rather than loaded a second time.
+    Returned,
+    /// Nothing alive was this pull request's, so one is to be loaded.
+    Loading,
+}
+
+/// Which screen the window shows, and the one Session it holds.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SessionSlot {
+    session: Option<OpenSession>,
+    showing: Showing,
+}
+
+impl SessionSlot {
+    /// A window that opened on Home, holding no Session yet.
+    #[must_use]
+    pub const fn home() -> Self {
+        Self {
+            session: None,
+            showing: Showing::Home,
+        }
+    }
+
+    /// A window the command line opened straight into a Session.
+    ///
+    /// There is no Home behind it, so this window never shows one.
+    #[must_use]
+    pub const fn command_line() -> Self {
+        Self {
+            session: Some(OpenSession::FromCommandLine),
+            showing: Showing::Session,
+        }
+    }
+
+    #[must_use]
+    pub const fn showing(&self) -> Showing {
+        self.showing
+    }
+
+    /// The Session this window holds, in front of Home or alive behind it.
+    #[must_use]
+    pub const fn session(&self) -> Option<&OpenSession> {
+        self.session.as_ref()
+    }
+
+    /// Opens `pull_request` from a row, showing its Session.
+    ///
+    /// The Session already alive on this pull request is shown again rather
+    /// than loaded a second time. Any other is dropped, silently, because
+    /// Drafts already persist.
+    pub fn open(&mut self, pull_request: PullRequestId) -> Opened {
+        self.showing = Showing::Session;
+        if self
+            .session
+            .as_ref()
+            .is_some_and(|session| session.is_on(&pull_request))
+        {
+            return Opened::Returned;
+        }
+        self.session = Some(OpenSession::FromRow(pull_request));
+        Opened::Loading
+    }
+
+    /// Shows the Session alive behind Home again, exactly as it was left.
+    ///
+    /// Answers `false` when no Session is alive, which the header slot's own
+    /// absence already keeps a reviewer from asking for.
+    #[must_use]
+    pub fn return_to_session(&mut self) -> bool {
+        if self.session.is_none() {
+            return false;
+        }
+        self.showing = Showing::Session;
+        true
+    }
+
+    /// Shows Home again, leaving the Session alive behind it.
+    ///
+    /// Answers `false` for a Session the command line opened, which has no
+    /// Home behind it to go back to, and for a window already showing Home.
+    #[must_use]
+    pub fn back_to_home(&mut self) -> bool {
+        match &self.session {
+            Some(OpenSession::FromRow(_)) if self.showing == Showing::Session => {
+                self.showing = Showing::Home;
+                true
+            }
+            Some(OpenSession::FromRow(_) | OpenSession::FromCommandLine) | None => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pull_request(number: u64) -> PullRequestId {
+        PullRequestId {
+            repository: "acme/widgets".to_owned(),
+            number,
+        }
+    }
+
+    #[test]
+    fn a_window_that_opened_on_home_holds_no_session() {
+        let slot = SessionSlot::home();
+
+        assert_eq!(slot.showing(), Showing::Home);
+        assert_eq!(slot.session(), None);
+    }
+
+    #[test]
+    fn opening_a_row_shows_its_session_and_leaves_it_alive() {
+        let mut slot = SessionSlot::home();
+
+        assert_eq!(slot.open(pull_request(412)), Opened::Loading);
+
+        assert_eq!(slot.showing(), Showing::Session);
+        assert_eq!(
+            slot.session(),
+            Some(&OpenSession::FromRow(pull_request(412))),
+        );
+    }
+
+    /// Coming back to the pull request already open costs nothing, which is the
+    /// whole point of keeping it alive.
+    #[test]
+    fn opening_the_pull_request_already_alive_returns_to_it_unloaded() {
+        let mut slot = SessionSlot::home();
+        let _opened = slot.open(pull_request(412));
+        assert!(slot.back_to_home());
+
+        assert_eq!(slot.open(pull_request(412)), Opened::Returned);
+
+        assert_eq!(slot.showing(), Showing::Session);
+    }
+
+    /// GitHub compares two repository names without regard to case, so a row
+    /// that came back cased differently is still the same pull request.
+    #[test]
+    fn a_repository_cased_differently_still_names_the_session_already_alive() {
+        let mut slot = SessionSlot::home();
+        let _opened = slot.open(pull_request(412));
+
+        let differently_cased = PullRequestId {
+            repository: "ACME/Widgets".to_owned(),
+            number: 412,
+        };
+
+        assert_eq!(slot.open(differently_cased), Opened::Returned);
+    }
+
+    /// Drafts already persist, so the Session that goes is not carrying
+    /// anything the reviewer would have to be asked about.
+    #[test]
+    fn opening_a_different_pull_request_drops_the_one_that_was_alive() {
+        let mut slot = SessionSlot::home();
+        let _opened = slot.open(pull_request(412));
+
+        assert_eq!(slot.open(pull_request(398)), Opened::Loading);
+
+        assert_eq!(
+            slot.session(),
+            Some(&OpenSession::FromRow(pull_request(398))),
+            "only the pull request just opened is alive",
+        );
+    }
+
+    /// Back is a navigation rather than a close, which is what makes returning
+    /// to a half-finished review instant.
+    #[test]
+    fn back_shows_home_and_leaves_the_session_alive_behind_it() {
+        let mut slot = SessionSlot::home();
+        let _opened = slot.open(pull_request(412));
+
+        assert!(slot.back_to_home());
+
+        assert_eq!(slot.showing(), Showing::Home);
+        assert_eq!(
+            slot.session(),
+            Some(&OpenSession::FromRow(pull_request(412))),
+        );
+    }
+
+    #[test]
+    fn the_header_slot_returns_to_the_session_alive_behind_home() {
+        let mut slot = SessionSlot::home();
+        let _opened = slot.open(pull_request(412));
+        assert!(slot.back_to_home());
+
+        assert!(slot.return_to_session());
+
+        assert_eq!(slot.showing(), Showing::Session);
+    }
+
+    #[test]
+    fn returning_to_a_session_is_refused_when_none_is_alive() {
+        let mut slot = SessionSlot::home();
+
+        assert!(!slot.return_to_session());
+
+        assert_eq!(slot.showing(), Showing::Home);
+    }
+
+    #[test]
+    fn a_session_the_command_line_opened_has_no_home_to_go_back_to() {
+        let mut slot = SessionSlot::command_line();
+
+        assert_eq!(slot.showing(), Showing::Session);
+        assert_eq!(slot.session(), Some(&OpenSession::FromCommandLine));
+        assert!(!slot.back_to_home());
+        assert_eq!(slot.showing(), Showing::Session);
+    }
+
+    /// The identity is both what the header slot reads and what says there is a
+    /// Home behind the Session at all.
+    #[test]
+    fn only_a_session_opened_from_a_row_carries_the_identity_of_one() {
+        assert_eq!(
+            OpenSession::FromRow(pull_request(412)).row_identity(),
+            Some("acme/widgets#412".to_owned()),
+        );
+        assert_eq!(OpenSession::FromCommandLine.row_identity(), None);
+    }
+}

--- a/crates/app/src/window.rs
+++ b/crates/app/src/window.rs
@@ -10,14 +10,16 @@ pub struct PullRequestId {
 
 impl PullRequestId {
     /// `owner/name#number`, which is how a row and the header slot name it.
-    #[must_use]
-    pub fn identity(&self) -> String {
+    ///
+    /// The one place that format is written, so a row and the Session opened
+    /// from it can never name the same pull request differently.
+    pub(crate) fn identity(&self) -> String {
         format!("{}#{}", self.repository, self.number)
     }
 
     /// Whether both name one pull request, which GitHub decides without regard
     /// to case, so nothing here may either.
-    fn is_same_pull_request(&self, other: &Self) -> bool {
+    pub(crate) fn is_same_pull_request(&self, other: &Self) -> bool {
         self.number == other.number && self.repository.eq_ignore_ascii_case(&other.repository)
     }
 }
@@ -32,24 +34,22 @@ pub enum OpenSession {
 }
 
 impl OpenSession {
-    /// `owner/name#number` of the row this Session was opened from, absent for
-    /// one the command line opened on something Home never listed.
-    ///
-    /// Its presence is what says there is a Home behind this Session.
+    /// The pull request this Session is open on, absent for one the command
+    /// line opened on something Home never listed.
     #[must_use]
-    pub fn row_identity(&self) -> Option<String> {
+    pub const fn pull_request(&self) -> Option<&PullRequestId> {
         match self {
-            Self::FromRow(pull_request) => Some(pull_request.identity()),
+            Self::FromRow(pull_request) => Some(pull_request),
             Self::FromCommandLine => None,
         }
     }
 
-    /// Whether this Session is open on `pull_request`.
-    fn is_on(&self, pull_request: &PullRequestId) -> bool {
-        match self {
-            Self::FromRow(open) => open.is_same_pull_request(pull_request),
-            Self::FromCommandLine => false,
-        }
+    /// `owner/name#number` of the row this Session was opened from.
+    ///
+    /// Its presence is what says there is a Home behind this Session.
+    #[must_use]
+    pub fn row_identity(&self) -> Option<String> {
+        self.pull_request().map(PullRequestId::identity)
     }
 }
 
@@ -69,6 +69,9 @@ pub enum Opened {
     Returned,
     /// Nothing alive was this pull request's, so one is to be loaded.
     Loading,
+    /// This window has no Home to open a row from, so nothing was opened. Only
+    /// the command line opens such a window, and it never lists a row.
+    Refused,
 }
 
 /// Which screen the window shows, and the one Session it holds.
@@ -114,16 +117,18 @@ impl SessionSlot {
     ///
     /// The Session already alive on this pull request is shown again rather
     /// than loaded a second time. Any other is dropped, silently, because
-    /// Drafts already persist.
+    /// Drafts already persist. A window with no Home refuses the row instead,
+    /// rather than growing a Home it never had.
     pub fn open(&mut self, pull_request: PullRequestId) -> Opened {
-        self.showing = Showing::Session;
-        if self
-            .session
-            .as_ref()
-            .is_some_and(|session| session.is_on(&pull_request))
-        {
-            return Opened::Returned;
+        match &self.session {
+            Some(OpenSession::FromCommandLine) => return Opened::Refused,
+            Some(OpenSession::FromRow(open)) if open.is_same_pull_request(&pull_request) => {
+                self.showing = Showing::Session;
+                return Opened::Returned;
+            }
+            Some(OpenSession::FromRow(_)) | None => {}
         }
+        self.showing = Showing::Session;
         self.session = Some(OpenSession::FromRow(pull_request));
         Opened::Loading
     }
@@ -267,6 +272,18 @@ mod tests {
         assert!(!slot.return_to_session());
 
         assert_eq!(slot.showing(), Showing::Home);
+    }
+
+    /// Only Home lists a row, and a window the command line opened never shows
+    /// one, so a row arriving here is a mistake rather than a navigation.
+    #[test]
+    fn a_window_the_command_line_opened_refuses_to_open_a_row() {
+        let mut slot = SessionSlot::command_line();
+
+        assert_eq!(slot.open(pull_request(412)), Opened::Refused);
+
+        assert_eq!(slot.session(), Some(&OpenSession::FromCommandLine));
+        assert_eq!(slot.showing(), Showing::Session);
     }
 
     #[test]


### PR DESCRIPTION
Closes #18

Home listed pull requests but could not open one, and a Session had no way back. This connects the two screens and keeps one Session alive behind Home so returning to it is instant.

What changed:
- Enter on the cursor row or a click opens that pull request's Session in the same window, loaded from the first configured clone of its repository
- The Session header gains a back chevron bound to Cmd-[, shown only when there is a Home to go back to; Escape never navigates
- At most one Session stays alive behind Home, modelled as a small framework-free state machine in the app crate; opening the alive pull request returns to it without a reload, opening another drops it silently
- Both screens stay mounted while hidden, so file selection, cursor, composer text, and a running refresh survive a round trip; Home refreshes on return and on window focus, never on a timer
- Home's header shows the alive Session's identity with the keycap, and its row carries an accent mark
- Session loads are serialised so an abandoned load cannot fetch into a clone concurrently with a new one

Notes:
Start with the window module in the app crate, then the open, return, and describe commands. The chevron, the accent dot, and scroll restoration on return could not be seen from an agent session. This branch and the Drafts count branch both touch the row DTO and fixture, so whichever merges second needs a small rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189um4LrckqAAq5fgnixT1p
