### PR TITLE
Show Guidance and run a review in the desktop Session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,6 +1727,7 @@ dependencies = [
  "app",
  "domain",
  "github",
+ "review",
  "serde",
  "serde_json",
  "session",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -19,6 +19,7 @@ tauri-build = { version = "=2.6.3", features = [] }
 app.workspace = true
 domain.workspace = true
 github.workspace = true
+review.workspace = true
 session.workspace = true
 settings.workspace = true
 store.workspace = true

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -329,6 +329,14 @@ fn toggle_viewed_on_model(
     Ok(dto::project_sidebar(review.session()))
 }
 
+/// The Session's review panel, from an already-locked model.
+///
+/// Absent while the session is loading or failed, and for a snapshot with no
+/// commit behind it, which cannot be reviewed at all.
+fn panel_of(model: &app::SessionModel) -> Option<dto::ReviewPanelDto> {
+    model.review().and_then(dto::project_panel)
+}
+
 /// Projects the drafts on `file_index` from an already-locked, `Ready` model.
 ///
 /// # Panics
@@ -2396,5 +2404,91 @@ mod tests {
             1,
             "the late reanchor must not have moved it"
         );
+    }
+
+    /// The repository the review tests run against: two changed files, guidance
+    /// the panel can list, a candidate too large to send, and one file
+    /// configuration keeps out of the review.
+    fn guided_repository() -> TempDir {
+        let repository = temporary_repository();
+        let path = repository.path();
+        git(path, ["checkout", "--quiet", "feature"]);
+        std::fs::create_dir_all(path.join("vendor")).unwrap();
+        std::fs::write(path.join("vendor/lib.rs"), "generated\n").unwrap();
+        git(path, ["add", "."]);
+        git(path, ["commit", "--quiet", "-m", "vendor"]);
+        git(path, ["checkout", "--quiet", "main"]);
+        std::fs::write(path.join("AGENTS.md"), "Never use unwrap.\n").unwrap();
+        std::fs::write(path.join("CLAUDE.md"), "x".repeat(review::MAX_FILE_BYTES + 1)).unwrap();
+        std::fs::write(
+            path.join(".zreview.toml"),
+            "[review]\nexclude_files = [\"vendor/**\"]\n",
+        )
+        .unwrap();
+        repository
+    }
+
+    #[test]
+    fn the_panel_lists_the_guidance_a_run_would_be_held_to() {
+        let repository = guided_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+
+        let panel = panel_of(&lock(&model)).expect("a repository-backed session can be reviewed");
+
+        assert_eq!(panel.heading, "Review");
+        assert!(matches!(panel.run, dto::ReviewRunDto::Idle));
+        assert!(panel.footer.is_none());
+        let note = panel.note.expect("an idle panel says no review has been run");
+        assert_eq!(note.heading, "No review has been run.");
+
+        let dto::GuidanceDto::Discovered {
+            summary,
+            expanded,
+            entries,
+            skipped,
+            excluded,
+        } = panel.guidance
+        else {
+            panic!("guidance was discovered");
+        };
+        assert!(expanded, "open before the first run");
+        assert_eq!(summary, "1 guidance file \u{00B7} 0 KB");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].path, "AGENTS.md");
+        assert_eq!(entries[0].scope, "whole repository");
+        assert!(entries[0].included);
+        assert_eq!(skipped.len(), 1);
+        assert_eq!(skipped[0].path, "CLAUDE.md");
+        assert!(skipped[0].reason.contains("over the 65536-byte limit"));
+        assert_eq!(
+            excluded.as_deref(),
+            Some("1 file excluded from review by .zreview.toml")
+        );
+    }
+
+    /// "None found" must not look like "never looked".
+    #[test]
+    fn a_repository_that_states_no_conventions_says_so_rather_than_showing_nothing() {
+        let repository = temporary_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+
+        let panel = panel_of(&lock(&model)).expect("a repository-backed session can be reviewed");
+
+        let dto::GuidanceDto::NothingFound { note } = panel.guidance else {
+            panic!("nothing was discovered");
+        };
+        assert_eq!(
+            note,
+            "No guidance files found. The review will judge the diff alone."
+        );
+    }
+
+    /// The generated fixture has no commit, so there are no anchors to validate
+    /// findings against and nothing to put a panel on.
+    #[test]
+    fn the_generated_fixture_offers_no_panel() {
+        let model = loaded_model();
+
+        assert!(panel_of(&lock(&model)).is_none());
     }
 }

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -11,9 +11,7 @@ use std::{
 use app::{
     Opened, PullRequestId, RepositoryOutcome, SessionPhase, SettingsWrite, Showing, lock, try_lock,
 };
-use domain::{
-    DiffSide, ReviewBackend, ReviewEventSink, ReviewProgress, ReviewSession, SessionSource,
-};
+use domain::{DiffSide, ReviewBackend, ReviewError, ReviewEventSink, ReviewProgress};
 use review::{Agent, CodingAgent};
 use session::{ReviewStorage, SessionRequest};
 use tauri::ipc::Channel;
@@ -499,7 +497,7 @@ impl ReviewEventSink for RunEvents<'_> {
 /// can be tested without a coding agent or a Tauri channel.
 fn run_review_on_model(
     model: &Mutex<app::SessionModel>,
-    make_backend: impl FnOnce(&ReviewSession) -> Box<dyn ReviewBackend>,
+    make_backend: impl FnOnce(&Path) -> Box<dyn ReviewBackend>,
     report: &(dyn Fn(dto::ReviewPanelDto) + Sync),
 ) -> Option<dto::ReviewPanelDto> {
     let mut guard = lock(model);
@@ -515,7 +513,18 @@ fn run_review_on_model(
     // rather than after the first line the backend happens to send.
     report(started);
 
-    let backend = make_backend(&session);
+    let Some(root) = session::repository_root(session.source()) else {
+        // No repository means no anchors to validate findings against, which
+        // `run_review` refuses anyway. Refusing here keeps the backend from being
+        // handed a working directory nobody chose.
+        let mut guard = lock(model);
+        guard.review_failed(
+            ReviewError::NothingToReview.to_string(),
+            ReviewError::NothingToReview.remediation(),
+        );
+        return panel_of(&guard);
+    };
+    let backend = make_backend(root);
     let events = RunEvents {
         model,
         cancel,
@@ -534,29 +543,12 @@ fn run_review_on_model(
     panel_of(&guard)
 }
 
-/// The backend a run uses: the Claude coding agent, at the repository the session
-/// was opened from, which is what the GPUI binary runs.
-fn coding_agent(session: &ReviewSession) -> Box<dyn ReviewBackend> {
-    Box::new(CodingAgent::new(
-        Agent::ClaudeCode,
-        repository_root(session),
-    ))
-}
-
-/// Where the backend runs, so relative paths in the diff resolve.
+/// The backend a run uses, which is the Claude coding agent the GPUI binary runs.
 ///
-/// A session with no repository never reaches one: `run_review` refuses it,
-/// because there would be no anchors to validate findings against.
-fn repository_root(session: &ReviewSession) -> PathBuf {
-    match session.source() {
-        SessionSource::LocalComparison {
-            repository_root, ..
-        }
-        | SessionSource::GitHubPullRequest {
-            repository_root, ..
-        } => repository_root.clone(),
-        SessionSource::Demo => PathBuf::from("."),
-    }
+/// `root` is the clone the session was opened out of, so relative paths in the
+/// diff resolve. Nothing here may invent one.
+fn coding_agent(root: &Path) -> Box<dyn ReviewBackend> {
+    Box::new(CodingAgent::new(Agent::ClaudeCode, root))
 }
 
 /// Asks the running review to stop. It ends at the backend's next step.
@@ -2703,6 +2695,30 @@ mod tests {
         );
     }
 
+    /// Every panel-returning command answers with the whole panel, and they run
+    /// at once. The revision is how the frontend tells which answer is older.
+    #[test]
+    fn a_panel_carries_a_revision_that_only_ever_grows() {
+        let repository = guided_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+        let opened = panel_of(&lock(&model)).expect("the session can be reviewed");
+
+        let toggled = toggle_guidance_on_model(&model, "AGENTS.md")
+            .expect("AGENTS.md was discovered")
+            .expect("the session can be reviewed");
+        assert!(toggled.revision > opened.revision);
+
+        let (finished, reported) = run_with(&model, &FakeBackend::finding_free(vec!["Reading"]));
+        let panel = finished.expect("the session can be reviewed");
+        assert!(panel.revision > toggled.revision);
+        // Every report on the way there is older than the outcome it ends with.
+        assert!(
+            reported
+                .iter()
+                .all(|report| report.revision < panel.revision)
+        );
+    }
+
     /// "None found" must not look like "never looked".
     #[test]
     fn a_repository_that_states_no_conventions_says_so_rather_than_showing_nothing() {
@@ -2717,6 +2733,33 @@ mod tests {
         assert_eq!(
             note,
             "No guidance files found. The review will judge the diff alone."
+        );
+    }
+
+    /// The fixture has no repository, so a run the keyboard starts on it has
+    /// nowhere to launch a backend. It has to say so rather than run one in
+    /// whatever directory the app happens to have been started from.
+    #[test]
+    fn a_run_on_a_session_with_no_repository_refuses_before_it_reaches_a_backend() {
+        let model = loaded_model();
+
+        let panel = run_review_on_model(
+            &model,
+            |_root| panic!("a session with no repository must not reach a backend"),
+            &|_panel| {},
+        );
+
+        let dto::ReviewRunDto::Failed {
+            summary,
+            remediation,
+        } = panel.expect("a started run puts a panel on screen").run
+        else {
+            panic!("the run should have been refused");
+        };
+        assert_eq!(summary, "there is nothing to review");
+        assert_eq!(
+            remediation.as_deref(),
+            Some("Nothing in this snapshot is reviewable after exclusions.")
         );
     }
 
@@ -2803,7 +2846,7 @@ mod tests {
         backend: &FakeBackend,
     ) -> (Option<dto::ReviewPanelDto>, Vec<dto::ReviewPanelDto>) {
         let reported = Mutex::new(Vec::new());
-        let finished = run_review_on_model(model, |_session| Box::new(backend.clone()), &|panel| {
+        let finished = run_review_on_model(model, |_root| Box::new(backend.clone()), &|panel| {
             reported.lock().unwrap().push(panel);
         });
         (finished, reported.into_inner().unwrap())
@@ -2842,7 +2885,6 @@ mod tests {
             accepted,
             rejected,
             suppressed,
-            unreviewed,
         } = panel.run
         else {
             panic!("the run should have completed");
@@ -2850,7 +2892,6 @@ mod tests {
         assert_eq!(accepted, 0);
         assert_eq!(rejected, 0);
         assert_eq!(suppressed, 0);
-        assert_eq!(unreviewed, vec!["vendor/lib.rs".to_owned()]);
 
         let note = panel.note.expect("a run that found nothing says so");
         assert_eq!(note.heading, "Nothing to act on.");
@@ -2863,6 +2904,7 @@ mod tests {
             footer.not_reviewed.as_deref(),
             Some("1 file(s) not reviewed")
         );
+        assert_eq!(footer.unreviewed, vec!["vendor/lib.rs".to_owned()]);
         assert_eq!(footer.refused, None);
     }
 
@@ -2934,14 +2976,14 @@ mod tests {
 
         let finished = run_review_on_model(
             &model,
-            |_session| Box::new(FakeBackend::finding_free(vec!["Reading the diff"])),
+            |_root| Box::new(FakeBackend::finding_free(vec!["Reading the diff"])),
             &|panel| {
                 if progress_line(&panel) != Some("Reading the diff") {
                     return;
                 }
                 *second.lock().unwrap() = Some(run_review_on_model(
                     &model,
-                    |_session| panic!("a second run must not start a backend"),
+                    |_root| panic!("a second run must not start a backend"),
                     &|_panel| panic!("a second run must not report progress"),
                 ));
             },
@@ -2966,7 +3008,7 @@ mod tests {
 
         let finished = run_review_on_model(
             &model,
-            |_session| {
+            |_root| {
                 Box::new(FakeBackend::finding_free(vec![
                     "Reading the diff",
                     "Writing findings",
@@ -3006,7 +3048,7 @@ mod tests {
         let run = thread::spawn(move || {
             run_review_on_model(
                 &running,
-                |_session| Box::new(FakeBackend::finding_free(vec!["Reading the diff"])),
+                |_root| Box::new(FakeBackend::finding_free(vec!["Reading the diff"])),
                 &|_panel| {},
             )
         });

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -2991,6 +2991,34 @@ mod tests {
         assert_eq!(remediation, None, "cancelling was deliberate");
     }
 
+    /// Closing the window, or opening another row, drops the Session but not the
+    /// run. The run holds the only handle to the model by then and has to finish
+    /// into it rather than panic.
+    #[test]
+    fn a_run_whose_session_was_dropped_finishes_into_a_model_nobody_reads() {
+        let repository = guided_repository();
+        let model = Arc::new(local_model(
+            &local_request(&repository),
+            &ReviewStorage::Disabled,
+        ));
+        let running = Arc::clone(&model);
+
+        let run = thread::spawn(move || {
+            run_review_on_model(
+                &running,
+                |_session| Box::new(FakeBackend::finding_free(vec!["Reading the diff"])),
+                &|_panel| {},
+            )
+        });
+        drop(model);
+
+        let panel = run.join().expect("the run must not panic");
+        assert!(matches!(
+            panel.expect("the session can be reviewed").run,
+            dto::ReviewRunDto::Complete { .. }
+        ));
+    }
+
     #[test]
     fn a_backend_failure_shows_its_summary_and_remediation() {
         let repository = guided_repository();

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -11,7 +11,10 @@ use std::{
 use app::{
     Opened, PullRequestId, RepositoryOutcome, SessionPhase, SettingsWrite, Showing, lock, try_lock,
 };
-use domain::DiffSide;
+use domain::{
+    DiffSide, ReviewBackend, ReviewEventSink, ReviewProgress, ReviewSession, SessionSource,
+};
+use review::{Agent, CodingAgent};
 use session::{ReviewStorage, SessionRequest};
 use tauri::ipc::Channel;
 use tauri_specta::collect_commands;
@@ -37,6 +40,11 @@ pub fn specta_builder() -> tauri_specta::Builder<tauri::Wry> {
         edit_draft,
         discard_draft,
         reanchor_draft,
+        review_panel,
+        run_review,
+        cancel_review,
+        toggle_guidance_panel,
+        toggle_guidance,
     ])
 }
 
@@ -452,6 +460,134 @@ fn reanchor_draft_on_model(
     Ok(drafts_snapshot(&guard, selected))
 }
 
+/// Publishes a run's progress into the model and out to whoever asked for it, and
+/// tells the backend when the reviewer has abandoned the run.
+struct RunEvents<'a> {
+    model: &'a Mutex<app::SessionModel>,
+    /// Set by [`cancel_review_on_model`]. The backend polls it between steps, so
+    /// cancelling costs nothing until the backend next looks.
+    cancel: Arc<AtomicBool>,
+    report: &'a (dyn Fn(dto::ReviewPanelDto) + Sync),
+}
+
+impl ReviewEventSink for RunEvents<'_> {
+    fn progress(&self, progress: ReviewProgress) {
+        let moved = {
+            let mut guard = lock(self.model);
+            let moved = guard.review_progress(progress.to_string());
+            moved.then(|| panel_of(&guard).expect("a running review has a panel"))
+        };
+        // A line that has not moved is not worth a message to the frontend.
+        if let Some(panel) = moved {
+            (self.report)(panel);
+        }
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.cancel.load(Ordering::Relaxed)
+    }
+}
+
+/// Runs a review of the session in `model`, publishing the panel as it changes.
+///
+/// The session is cloned out from under the lock and the backend is built from
+/// that clone, so nothing holds the model while the backend runs, which takes
+/// minutes. A trigger that arrives while a run is in flight starts nothing and
+/// answers with the panel already on screen.
+///
+/// Takes the backend as a factory and the reporter as a plain callback, so both
+/// can be tested without a coding agent or a Tauri channel.
+fn run_review_on_model(
+    model: &Mutex<app::SessionModel>,
+    make_backend: impl FnOnce(&ReviewSession) -> Box<dyn ReviewBackend>,
+    report: &(dyn Fn(dto::ReviewPanelDto) + Sync),
+) -> Option<dto::ReviewPanelDto> {
+    let mut guard = lock(model);
+    let Some(session) = guard.review_request() else {
+        return panel_of(&guard);
+    };
+    let cancel = Arc::new(AtomicBool::new(false));
+    guard.review_started(Arc::clone(&cancel));
+    let started = panel_of(&guard).expect("a running review has a panel");
+    drop(guard);
+
+    // Reported before the work starts, so the panel shows a running review at once
+    // rather than after the first line the backend happens to send.
+    report(started);
+
+    let backend = make_backend(&session);
+    let events = RunEvents {
+        model,
+        cancel,
+        report,
+    };
+    let result = session::run_review(&session, backend.as_ref(), &events);
+
+    let mut guard = lock(model);
+    match result {
+        Ok(run) => guard.review_finished(
+            run.findings,
+            run.excluded.into_iter().chain(run.omitted).collect(),
+        ),
+        Err(error) => guard.review_failed(error.to_string(), error.remediation()),
+    }
+    panel_of(&guard)
+}
+
+/// The backend a run uses: the Claude coding agent, at the repository the session
+/// was opened from, which is what the GPUI binary runs.
+fn coding_agent(session: &ReviewSession) -> Box<dyn ReviewBackend> {
+    Box::new(CodingAgent::new(
+        Agent::ClaudeCode,
+        repository_root(session),
+    ))
+}
+
+/// Where the backend runs, so relative paths in the diff resolve.
+///
+/// A session with no repository never reaches one: `run_review` refuses it,
+/// because there would be no anchors to validate findings against.
+fn repository_root(session: &ReviewSession) -> PathBuf {
+    match session.source() {
+        SessionSource::LocalComparison {
+            repository_root, ..
+        }
+        | SessionSource::GitHubPullRequest {
+            repository_root, ..
+        } => repository_root.clone(),
+        SessionSource::Demo => PathBuf::from("."),
+    }
+}
+
+/// Asks the running review to stop. It ends at the backend's next step.
+fn cancel_review_on_model(model: &Mutex<app::SessionModel>) -> Option<dto::ReviewPanelDto> {
+    let guard = lock(model);
+    guard.cancel_review();
+    panel_of(&guard)
+}
+
+/// Opens or closes the guidance section.
+fn toggle_guidance_panel_on_model(model: &Mutex<app::SessionModel>) -> Option<dto::ReviewPanelDto> {
+    let mut guard = lock(model);
+    guard.toggle_guidance_panel();
+    panel_of(&guard)
+}
+
+/// Turns one guidance file on or off for the next run.
+///
+/// A path naming no discovered file is refused rather than answered with an
+/// unchanged panel, which would hide the mismatch.
+fn toggle_guidance_on_model(
+    model: &Mutex<app::SessionModel>,
+    path: &str,
+) -> Result<Option<dto::ReviewPanelDto>, dto::SessionFailureDto> {
+    let mut guard = lock(model);
+    if !guard.toggle_guidance(path) {
+        return Err(dto::command_failure(format!("no guidance file at {path}")));
+    }
+    Ok(panel_of(&guard))
+}
+
 /// Loads the review session the window was opened with, reporting each stage on
 /// `on_stage` as it goes.
 ///
@@ -863,6 +999,101 @@ pub fn reanchor_draft(
         line,
         row as usize,
     )
+}
+
+/// The Session's review panel, asked for once the session is ready.
+///
+/// `null` means this snapshot cannot be reviewed at all, which is the generated
+/// fixture, and the Session shows no panel.
+///
+/// # Errors
+///
+/// Returns a failure when no session is open.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn review_panel(
+    state: tauri::State<'_, AppRoot>,
+) -> Result<Option<dto::ReviewPanelDto>, dto::SessionFailureDto> {
+    let model = session_model(&state)?;
+    let panel = panel_of(&lock(&model));
+    Ok(panel)
+}
+
+/// Runs a review against the Claude coding agent at the repository root, on a
+/// background thread, reporting the panel to `on_progress` as the backend speaks.
+///
+/// A trigger that arrives while a run is in flight starts nothing and answers with
+/// the panel already on screen. The model is taken out of the window as its own
+/// handle, so a Session dropped or a window closed mid-run leaves the background
+/// work finishing into a model nobody reads rather than panicking.
+///
+/// # Errors
+///
+/// Returns a failure when no session is open, or when the task doing the review
+/// does not finish.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub async fn run_review(
+    state: tauri::State<'_, AppRoot>,
+    on_progress: Channel<dto::ReviewPanelDto>,
+) -> Result<Option<dto::ReviewPanelDto>, dto::SessionFailureDto> {
+    let model = session_model(&state)?;
+    tauri::async_runtime::spawn_blocking(move || {
+        run_review_on_model(&model, coding_agent, &|panel| {
+            let _ = on_progress.send(panel);
+        })
+    })
+    .await
+    .map_err(|error| dto::command_failure(format!("the review did not finish: {error}")))
+}
+
+/// Asks the running review to stop. It ends at the backend's next step.
+///
+/// # Errors
+///
+/// Returns a failure when no session is open.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn cancel_review(
+    state: tauri::State<'_, AppRoot>,
+) -> Result<Option<dto::ReviewPanelDto>, dto::SessionFailureDto> {
+    let model = session_model(&state)?;
+    Ok(cancel_review_on_model(&model))
+}
+
+/// Opens or closes the guidance section.
+///
+/// # Errors
+///
+/// Returns a failure when no session is open.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn toggle_guidance_panel(
+    state: tauri::State<'_, AppRoot>,
+) -> Result<Option<dto::ReviewPanelDto>, dto::SessionFailureDto> {
+    let model = session_model(&state)?;
+    Ok(toggle_guidance_panel_on_model(&model))
+}
+
+/// Turns one guidance file on or off for the next run.
+///
+/// # Errors
+///
+/// Returns a failure when no session is open, or when `path` names no guidance
+/// file the session discovered.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn toggle_guidance(
+    state: tauri::State<'_, AppRoot>,
+    path: String,
+) -> Result<Option<dto::ReviewPanelDto>, dto::SessionFailureDto> {
+    let model = session_model(&state)?;
+    toggle_guidance_on_model(&model, &path)
 }
 
 #[cfg(test)]
@@ -2419,7 +2650,11 @@ mod tests {
         git(path, ["commit", "--quiet", "-m", "vendor"]);
         git(path, ["checkout", "--quiet", "main"]);
         std::fs::write(path.join("AGENTS.md"), "Never use unwrap.\n").unwrap();
-        std::fs::write(path.join("CLAUDE.md"), "x".repeat(review::MAX_FILE_BYTES + 1)).unwrap();
+        std::fs::write(
+            path.join("CLAUDE.md"),
+            "x".repeat(review::MAX_FILE_BYTES + 1),
+        )
+        .unwrap();
         std::fs::write(
             path.join(".zreview.toml"),
             "[review]\nexclude_files = [\"vendor/**\"]\n",
@@ -2438,7 +2673,9 @@ mod tests {
         assert_eq!(panel.heading, "Review");
         assert!(matches!(panel.run, dto::ReviewRunDto::Idle));
         assert!(panel.footer.is_none());
-        let note = panel.note.expect("an idle panel says no review has been run");
+        let note = panel
+            .note
+            .expect("an idle panel says no review has been run");
         assert_eq!(note.heading, "No review has been run.");
 
         let dto::GuidanceDto::Discovered {
@@ -2490,5 +2727,300 @@ mod tests {
         let model = loaded_model();
 
         assert!(panel_of(&lock(&model)).is_none());
+    }
+
+    /// A backend that reports the lines it was built with, stops as soon as the
+    /// reviewer cancels, and then answers with the outcome it was built with.
+    ///
+    /// Cloned into the run, so the test keeps a handle on what was sent.
+    #[derive(Clone)]
+    struct FakeBackend {
+        lines: Vec<&'static str>,
+        outcome: Result<Vec<domain::RawFinding>, domain::ReviewError>,
+        seen: Arc<Mutex<Option<domain::ReviewRequest>>>,
+    }
+
+    impl FakeBackend {
+        fn new(
+            lines: Vec<&'static str>,
+            outcome: Result<Vec<domain::RawFinding>, domain::ReviewError>,
+        ) -> Self {
+            Self {
+                lines,
+                outcome,
+                seen: Arc::new(Mutex::new(None)),
+            }
+        }
+
+        fn finding_free(lines: Vec<&'static str>) -> Self {
+            Self::new(lines, Ok(Vec::new()))
+        }
+
+        /// The guidance the run actually sent, in order.
+        fn guidance_sent(&self) -> Vec<String> {
+            self.seen
+                .lock()
+                .unwrap()
+                .as_ref()
+                .expect("the backend was called")
+                .guidance
+                .iter()
+                .map(|excerpt| excerpt.path.to_string())
+                .collect()
+        }
+    }
+
+    impl domain::ReviewBackend for FakeBackend {
+        fn name(&self) -> Arc<str> {
+            Arc::from("fake")
+        }
+
+        fn review(
+            &self,
+            request: &domain::ReviewRequest,
+            events: &dyn domain::ReviewEventSink,
+        ) -> Result<Vec<domain::RawFinding>, domain::ReviewError> {
+            *self.seen.lock().unwrap() = Some(request.clone());
+            for line in &self.lines {
+                if events.is_cancelled() {
+                    return Err(domain::ReviewError::Cancelled);
+                }
+                events.progress(domain::ReviewProgress::Running {
+                    detail: Arc::from(*line),
+                });
+            }
+            if events.is_cancelled() {
+                return Err(domain::ReviewError::Cancelled);
+            }
+            self.outcome.clone()
+        }
+    }
+
+    /// Runs `backend` over the session in `model`, collecting every panel the run
+    /// reported on its way.
+    fn run_with(
+        model: &Mutex<app::SessionModel>,
+        backend: &FakeBackend,
+    ) -> (Option<dto::ReviewPanelDto>, Vec<dto::ReviewPanelDto>) {
+        let reported = Mutex::new(Vec::new());
+        let finished = run_review_on_model(model, |_session| Box::new(backend.clone()), &|panel| {
+            reported.lock().unwrap().push(panel);
+        });
+        (finished, reported.into_inner().unwrap())
+    }
+
+    /// The progress line the panel is showing, whatever else it says.
+    fn progress_line(panel: &dto::ReviewPanelDto) -> Option<&str> {
+        match &panel.run {
+            dto::ReviewRunDto::Running { detail } => Some(detail),
+            dto::ReviewRunDto::Idle
+            | dto::ReviewRunDto::Complete { .. }
+            | dto::ReviewRunDto::Failed { .. } => None,
+        }
+    }
+
+    #[test]
+    fn a_run_reports_its_progress_and_ends_with_what_it_did_not_see() {
+        let repository = guided_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+        let backend = FakeBackend::finding_free(vec!["Reading the diff", "Writing findings"]);
+
+        let (finished, reported) = run_with(&model, &backend);
+
+        // Told before the work starts, so the panel shows a running review at once
+        // rather than after the first line the backend happens to report.
+        assert_eq!(
+            reported
+                .iter()
+                .filter_map(progress_line)
+                .collect::<Vec<_>>(),
+            vec!["Starting...", "Reading the diff", "Writing findings"]
+        );
+
+        let panel = finished.expect("the session can be reviewed");
+        let dto::ReviewRunDto::Complete {
+            accepted,
+            rejected,
+            suppressed,
+            unreviewed,
+        } = panel.run
+        else {
+            panic!("the run should have completed");
+        };
+        assert_eq!(accepted, 0);
+        assert_eq!(rejected, 0);
+        assert_eq!(suppressed, 0);
+        assert_eq!(unreviewed, vec!["vendor/lib.rs".to_owned()]);
+
+        let note = panel.note.expect("a run that found nothing says so");
+        assert_eq!(note.heading, "Nothing to act on.");
+        assert_eq!(
+            note.detail.as_deref(),
+            Some("The review found no problems.")
+        );
+        let footer = panel.footer.expect("a partial review says it was partial");
+        assert_eq!(
+            footer.not_reviewed.as_deref(),
+            Some("1 file(s) not reviewed")
+        );
+        assert_eq!(footer.refused, None);
+    }
+
+    /// The guidance section is the disclosure notice for what leaves the machine,
+    /// so a file turned off must actually stop being sent.
+    #[test]
+    fn a_run_sends_only_the_guidance_the_reviewer_left_on() {
+        let repository = guided_repository();
+        std::fs::write(repository.path().join("CONTRIBUTING.md"), "Be kind.\n").unwrap();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+
+        let panel = toggle_guidance_on_model(&model, "AGENTS.md")
+            .expect("AGENTS.md was discovered")
+            .expect("the session can be reviewed");
+        let dto::GuidanceDto::Discovered {
+            summary, entries, ..
+        } = panel.guidance
+        else {
+            panic!("guidance was discovered");
+        };
+        assert_eq!(summary, "1 guidance file \u{00B7} 0 KB");
+        assert!(!entries[0].included, "AGENTS.md is off now");
+
+        let backend = FakeBackend::finding_free(Vec::new());
+        run_with(&model, &backend);
+
+        assert_eq!(backend.guidance_sent(), vec!["CONTRIBUTING.md".to_owned()]);
+    }
+
+    #[test]
+    fn toggling_a_path_that_names_no_guidance_file_is_refused() {
+        let repository = guided_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+
+        let error = toggle_guidance_on_model(&model, "NOWHERE.md").unwrap_err();
+
+        assert_eq!(error.summary, "no guidance file at NOWHERE.md");
+    }
+
+    /// The disclosure has served its purpose once a run has happened; the summary
+    /// line stays visible either way.
+    #[test]
+    fn the_guidance_section_collapses_once_a_run_has_happened() {
+        let repository = guided_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+
+        let (finished, _) = run_with(&model, &FakeBackend::finding_free(Vec::new()));
+
+        let panel = finished.expect("the session can be reviewed");
+        let dto::GuidanceDto::Discovered { expanded, .. } = panel.guidance else {
+            panic!("guidance was discovered");
+        };
+        assert!(!expanded);
+
+        let reopened = toggle_guidance_panel_on_model(&model).expect("the panel is showing");
+        let dto::GuidanceDto::Discovered { expanded, .. } = reopened.guidance else {
+            panic!("guidance was discovered");
+        };
+        assert!(expanded);
+    }
+
+    /// A run already in flight owns the session. A second trigger answers with
+    /// what is already on screen and reaches no backend at all.
+    #[test]
+    fn a_second_trigger_while_a_run_is_in_flight_starts_nothing() {
+        let repository = guided_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+        let second = Mutex::new(None);
+
+        let finished = run_review_on_model(
+            &model,
+            |_session| Box::new(FakeBackend::finding_free(vec!["Reading the diff"])),
+            &|panel| {
+                if progress_line(&panel) != Some("Reading the diff") {
+                    return;
+                }
+                *second.lock().unwrap() = Some(run_review_on_model(
+                    &model,
+                    |_session| panic!("a second run must not start a backend"),
+                    &|_panel| panic!("a second run must not report progress"),
+                ));
+            },
+        );
+
+        let refused = second
+            .into_inner()
+            .unwrap()
+            .expect("the second trigger answered")
+            .expect("the session can be reviewed");
+        assert_eq!(progress_line(&refused), Some("Reading the diff"));
+        assert!(matches!(
+            finished.expect("the session can be reviewed").run,
+            dto::ReviewRunDto::Complete { .. }
+        ));
+    }
+
+    #[test]
+    fn cancelling_ends_the_run_saying_so() {
+        let repository = guided_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+
+        let finished = run_review_on_model(
+            &model,
+            |_session| {
+                Box::new(FakeBackend::finding_free(vec![
+                    "Reading the diff",
+                    "Writing findings",
+                ]))
+            },
+            &|panel| {
+                if progress_line(&panel) == Some("Reading the diff") {
+                    cancel_review_on_model(&model);
+                }
+            },
+        );
+
+        let panel = finished.expect("the session can be reviewed");
+        let dto::ReviewRunDto::Failed {
+            summary,
+            remediation,
+        } = panel.run
+        else {
+            panic!("a cancelled run ends failed");
+        };
+        assert_eq!(summary, "the review was cancelled");
+        assert_eq!(remediation, None, "cancelling was deliberate");
+    }
+
+    #[test]
+    fn a_backend_failure_shows_its_summary_and_remediation() {
+        let repository = guided_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+        let backend = FakeBackend::new(
+            Vec::new(),
+            Err(domain::ReviewError::NotInstalled {
+                program: Arc::from("claude"),
+            }),
+        );
+
+        let (finished, _) = run_with(&model, &backend);
+
+        let panel = finished.expect("the session can be reviewed");
+        let dto::ReviewRunDto::Failed {
+            summary,
+            remediation,
+        } = panel.run
+        else {
+            panic!("the run should have failed");
+        };
+        assert_eq!(summary, "claude is not installed");
+        assert!(
+            remediation
+                .expect("a missing backend says how to get it")
+                .contains("PATH")
+        );
+        let note = panel
+            .note
+            .expect("the failure is what the panel has to say");
+        assert_eq!(note.heading, "claude is not installed");
     }
 }

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -233,7 +233,7 @@ pub struct GuidanceSkipDto {
 #[serde(tag = "kind")]
 pub enum GuidanceDto {
     /// Discovery ran and found nothing. Saying so is not the same as showing
-    /// nothing: a reviewer needs to tell "this repository states no conventions"
+    /// nothing. A reviewer needs to tell "this repository states no conventions"
     /// from "guidance was never looked for".
     NothingFound { note: String },
     Discovered {
@@ -261,8 +261,6 @@ pub enum ReviewRunDto {
         rejected: u32,
         /// Claims suppressed because the reviewer dismissed them before.
         suppressed: u32,
-        /// Files the run did not see.
-        unreviewed: Vec<String>,
     },
     Failed {
         summary: String,
@@ -287,12 +285,17 @@ pub struct PanelFooterDto {
     pub refused: Option<String>,
     /// Present when a completed run did not see the whole change.
     pub not_reviewed: Option<String>,
+    /// The files that run did not see, named under the count that describes them.
+    pub unreviewed: Vec<String>,
 }
 
 /// The Session's right-hand panel: what a review is held to, and how far the run
 /// that populates it has got.
 #[derive(Clone, Debug, Serialize, specta::Type)]
 pub struct ReviewPanelDto {
+    /// How many times the panel has changed, so a snapshot that was read before
+    /// a change can be told from one that carries it.
+    pub revision: u32,
     /// "Review" before there is anything to act on, otherwise the finding count.
     pub heading: String,
     pub guidance: GuidanceDto,
@@ -755,6 +758,7 @@ pub fn project_panel(review: &ReviewModel) -> Option<ReviewPanelDto> {
     let session = review.session();
     let run = review.run();
     Some(ReviewPanelDto {
+        revision: review.revision(),
         heading: match session.findings().len() {
             0 => "Review".to_owned(),
             1 => "1 finding".to_owned(),
@@ -828,12 +832,11 @@ fn project_run(run: &ReviewRunState) -> ReviewRunDto {
             accepted,
             rejected,
             suppressed,
-            unreviewed,
+            ..
         } => ReviewRunDto::Complete {
             accepted: as_u32(*accepted),
             rejected: as_u32(*rejected),
             suppressed: as_u32(*suppressed),
-            unreviewed: unreviewed.clone(),
         },
         ReviewRunState::Failed {
             summary,
@@ -895,6 +898,7 @@ fn project_footer(session: &ReviewSession, run: &ReviewRunState) -> Option<Panel
         return refused.map(|refused| PanelFooterDto {
             refused: Some(refused),
             not_reviewed: None,
+            unreviewed: Vec::new(),
         });
     };
     if rejected == 0 && unreviewed.is_empty() {
@@ -904,6 +908,7 @@ fn project_footer(session: &ReviewSession, run: &ReviewRunState) -> Option<Panel
         refused,
         not_reviewed: (!unreviewed.is_empty())
             .then(|| format!("{} file(s) not reviewed", unreviewed.len())),
+        unreviewed: unreviewed.clone(),
     })
 }
 

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -6,8 +6,8 @@
 
 use app::{PullRequestId, ReviewModel, ReviewRunState};
 use domain::{
-    DiffFile, DiffLineKind, DiffSide, EmptyDiffReason, FileStatus, GuidanceSelection, ReviewSession,
-    SessionFailure, SessionSource,
+    DiffFile, DiffLineKind, DiffSide, EmptyDiffReason, FileStatus, GuidanceSelection,
+    ReviewSession, SessionFailure, SessionSource,
 };
 use serde::{Deserialize, Serialize};
 

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -4,10 +4,10 @@
 //! `&SessionFailure`) and returns a value, which is what keeps them testable
 //! without a running app.
 
-use app::PullRequestId;
+use app::{PullRequestId, ReviewModel, ReviewRunState};
 use domain::{
-    DiffFile, DiffLineKind, DiffSide, EmptyDiffReason, FileStatus, ReviewSession, SessionFailure,
-    SessionSource,
+    DiffFile, DiffLineKind, DiffSide, EmptyDiffReason, FileStatus, GuidanceSelection, ReviewSession,
+    SessionFailure, SessionSource,
 };
 use serde::{Deserialize, Serialize};
 
@@ -207,6 +207,98 @@ pub struct FileDetailDto {
     pub rows: Vec<RowDto>,
     pub drafts: DraftsDto,
     pub empty_reason: Option<EmptyReasonDto>,
+}
+
+/// One guidance file discovery found, as the panel draws its row.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct GuidanceEntryDto {
+    /// Repository-relative path, which is also how a finding cites it.
+    pub path: String,
+    /// What it applies to, already rendered, e.g. "whole repository".
+    pub scope: String,
+    pub kilobytes: u32,
+    /// Whether the next run will send it.
+    pub included: bool,
+}
+
+/// Something discovery found and will not use, and why.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct GuidanceSkipDto {
+    pub path: String,
+    pub reason: String,
+}
+
+/// The guidance section at the top of the panel.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+#[serde(tag = "kind")]
+pub enum GuidanceDto {
+    /// Discovery ran and found nothing. Saying so is not the same as showing
+    /// nothing: a reviewer needs to tell "this repository states no conventions"
+    /// from "guidance was never looked for".
+    NothingFound { note: String },
+    Discovered {
+        /// The one line that stays on screen whether or not the section is open.
+        summary: String,
+        expanded: bool,
+        entries: Vec<GuidanceEntryDto>,
+        skipped: Vec<GuidanceSkipDto>,
+        /// What configuration keeps out of the review, when it keeps anything out.
+        excluded: Option<String>,
+    },
+}
+
+/// How far the current review run has got.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+#[serde(tag = "state")]
+pub enum ReviewRunDto {
+    Idle,
+    Running {
+        /// The backend's most recent progress line.
+        detail: String,
+    },
+    Complete {
+        accepted: u32,
+        rejected: u32,
+        /// Claims suppressed because the reviewer dismissed them before.
+        suppressed: u32,
+        /// Files the run did not see.
+        unreviewed: Vec<String>,
+    },
+    Failed {
+        summary: String,
+        remediation: Option<String>,
+    },
+}
+
+/// What the panel says when there is no finding to show.
+///
+/// Every run state has one. An empty panel with no explanation is the failure
+/// this projection exists to avoid.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct PanelNoteDto {
+    pub heading: String,
+    pub detail: Option<String>,
+}
+
+/// The caveats under the panel: what was refused, and what was never looked at.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct PanelFooterDto {
+    /// Claims that did not survive checking against the diff.
+    pub refused: Option<String>,
+    /// Present when a completed run did not see the whole change.
+    pub not_reviewed: Option<String>,
+}
+
+/// The Session's right-hand panel: what a review is held to, and how far the run
+/// that populates it has got.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct ReviewPanelDto {
+    /// "Review" before there is anything to act on, otherwise the finding count.
+    pub heading: String,
+    pub guidance: GuidanceDto,
+    pub run: ReviewRunDto,
+    pub note: Option<PanelNoteDto>,
+    pub footer: Option<PanelFooterDto>,
 }
 
 #[derive(Clone, Debug, Serialize, specta::Type)]
@@ -647,6 +739,172 @@ pub fn project_drafts(session: &ReviewSession, file_index: usize) -> DraftsDto {
         file_draft_count,
         write_failure: None,
     }
+}
+
+/// The Session's review panel, or `None` when this session has nothing to put one
+/// on.
+///
+/// Mirrors `crates/ui/src/findings.rs`, which is the parity target: the same copy
+/// in the same order, read off the same model. The findings list itself is not
+/// projected yet.
+#[must_use]
+pub fn project_panel(review: &ReviewModel) -> Option<ReviewPanelDto> {
+    if !review.findings_panel_visible() {
+        return None;
+    }
+    let session = review.session();
+    let run = review.run();
+    Some(ReviewPanelDto {
+        heading: match session.findings().len() {
+            0 => "Review".to_owned(),
+            1 => "1 finding".to_owned(),
+            many => format!("{many} findings"),
+        },
+        guidance: project_guidance(session.guidance(), review.guidance_expanded()),
+        run: project_run(run),
+        note: project_note(session, run),
+        footer: project_footer(session, run),
+    })
+}
+
+fn project_guidance(guidance: &GuidanceSelection, expanded: bool) -> GuidanceDto {
+    if guidance.is_empty() {
+        return GuidanceDto::NothingFound {
+            note: "No guidance files found. The review will judge the diff alone.".to_owned(),
+        };
+    }
+    let count = guidance.included_count();
+    let kilobytes = guidance.included_bytes() / 1024;
+    let excluded = guidance.excluded_paths().len();
+    GuidanceDto::Discovered {
+        summary: if count == 0 {
+            "No guidance will be sent".to_owned()
+        } else {
+            format!(
+                "{count} guidance file{} \u{00B7} {kilobytes} KB",
+                plural(count)
+            )
+        },
+        expanded,
+        entries: guidance
+            .entries()
+            .iter()
+            .map(|entry| GuidanceEntryDto {
+                path: entry.path().to_string(),
+                scope: entry.excerpt.scope.to_string(),
+                kilobytes: as_u32(entry.bytes() / 1024),
+                included: entry.included,
+            })
+            .collect(),
+        skipped: guidance
+            .skipped()
+            .iter()
+            .map(|skip| GuidanceSkipDto {
+                path: skip.path.to_string(),
+                reason: skip.reason.to_string(),
+            })
+            .collect(),
+        excluded: (excluded > 0).then(|| {
+            format!(
+                "{excluded} file{} excluded from review by .zreview.toml",
+                plural(excluded)
+            )
+        }),
+    }
+}
+
+/// The plural suffix for a count, so no line ever reads "1 files".
+const fn plural(count: usize) -> &'static str {
+    if count == 1 { "" } else { "s" }
+}
+
+fn project_run(run: &ReviewRunState) -> ReviewRunDto {
+    match run {
+        ReviewRunState::Idle => ReviewRunDto::Idle,
+        ReviewRunState::Running { detail, .. } => ReviewRunDto::Running {
+            detail: detail.clone(),
+        },
+        ReviewRunState::Complete {
+            accepted,
+            rejected,
+            suppressed,
+            unreviewed,
+        } => ReviewRunDto::Complete {
+            accepted: as_u32(*accepted),
+            rejected: as_u32(*rejected),
+            suppressed: as_u32(*suppressed),
+            unreviewed: unreviewed.clone(),
+        },
+        ReviewRunState::Failed {
+            summary,
+            remediation,
+        } => ReviewRunDto::Failed {
+            summary: summary.clone(),
+            remediation: remediation.clone(),
+        },
+    }
+}
+
+/// What to say when there is no finding to show.
+///
+/// Every run state says something. An empty panel with no explanation is the
+/// failure this projection exists to avoid.
+fn project_note(session: &ReviewSession, run: &ReviewRunState) -> Option<PanelNoteDto> {
+    if !session.findings().is_empty() {
+        return None;
+    }
+    let (heading, detail) = match run {
+        ReviewRunState::Idle => (
+            "No review has been run.".to_owned(),
+            Some("Press Review to check this change against the repository's guidance.".to_owned()),
+        ),
+        ReviewRunState::Running { .. } => ("Reviewing...".to_owned(), None),
+        ReviewRunState::Complete {
+            rejected,
+            suppressed,
+            ..
+        } => (
+            "Nothing to act on.".to_owned(),
+            Some(nothing_to_act_on(*rejected, *suppressed)),
+        ),
+        ReviewRunState::Failed {
+            summary,
+            remediation,
+        } => (summary.clone(), remediation.clone()),
+    };
+    Some(PanelNoteDto { heading, detail })
+}
+
+/// Why a completed run left nothing to act on.
+fn nothing_to_act_on(rejected: usize, suppressed: usize) -> String {
+    match (rejected, suppressed) {
+        (0, 0) => "The review found no problems.".to_owned(),
+        (rejected, 0) => format!("{rejected} claim(s) did not survive checking against the diff."),
+        (0, suppressed) => format!("{suppressed} previously dismissed claim(s) were hidden."),
+        (rejected, suppressed) => format!(
+            "{rejected} claim(s) did not check out and {suppressed} were previously dismissed."
+        ),
+    }
+}
+
+/// The caveats: what was refused, and what was never looked at.
+fn project_footer(session: &ReviewSession, run: &ReviewRunState) -> Option<PanelFooterDto> {
+    let rejected = session.findings().rejected().len();
+    let refused = (rejected > 0).then(|| format!("{rejected} claim(s) refused"));
+    let ReviewRunState::Complete { unreviewed, .. } = run else {
+        return refused.map(|refused| PanelFooterDto {
+            refused: Some(refused),
+            not_reviewed: None,
+        });
+    };
+    if rejected == 0 && unreviewed.is_empty() {
+        return None;
+    }
+    Some(PanelFooterDto {
+        refused,
+        not_reviewed: (!unreviewed.is_empty())
+            .then(|| format!("{} file(s) not reviewed", unreviewed.len())),
+    })
 }
 
 #[cfg(test)]

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -12,6 +12,7 @@ const toggleViewed = vi.fn();
 const editDraft = vi.fn();
 const discardDraft = vi.fn();
 const reanchorDraft = vi.fn();
+const reviewPanel = vi.fn();
 
 vi.mock("./bindings", () => ({
   commands: {
@@ -22,6 +23,7 @@ vi.mock("./bindings", () => ({
     editDraft: (...args: unknown[]) => editDraft(...args),
     discardDraft: (...args: unknown[]) => discardDraft(...args),
     reanchorDraft: (...args: unknown[]) => reanchorDraft(...args),
+    reviewPanel: () => reviewPanel(),
   },
 }));
 
@@ -41,6 +43,8 @@ beforeEach(() => {
   editDraft.mockReset();
   discardDraft.mockReset();
   reanchorDraft.mockReset();
+  reviewPanel.mockReset();
+  reviewPanel.mockResolvedValue({ status: "ok", data: null });
   writeText.mockReset();
 });
 

--- a/apps/desktop/src/Navigation.test.tsx
+++ b/apps/desktop/src/Navigation.test.tsx
@@ -32,6 +32,7 @@ const toggleViewed = vi.fn();
 const editDraft = vi.fn();
 const discardDraft = vi.fn();
 const reanchorDraft = vi.fn();
+const reviewPanel = vi.fn();
 
 vi.mock("./bindings", () => ({
   commands: {
@@ -50,6 +51,7 @@ vi.mock("./bindings", () => ({
     editDraft: (...args: unknown[]) => editDraft(...args),
     discardDraft: (...args: unknown[]) => discardDraft(...args),
     reanchorDraft: (...args: unknown[]) => reanchorDraft(...args),
+    reviewPanel: () => reviewPanel(),
   },
 }));
 
@@ -171,6 +173,8 @@ beforeEach(() => {
   editDraft.mockReset();
   discardDraft.mockReset();
   reanchorDraft.mockReset();
+  reviewPanel.mockReset();
+  reviewPanel.mockResolvedValue({ status: "ok", data: null });
 });
 
 /** Home, listed and settled, with the cursor on its first row. */

--- a/apps/desktop/src/Navigation.test.tsx
+++ b/apps/desktop/src/Navigation.test.tsx
@@ -14,6 +14,7 @@ import {
   makeHomeSnapshot,
   makeRow,
   makeSidebar,
+  makePanel,
   makeSnapshot,
 } from "./test/fixtures";
 
@@ -33,6 +34,7 @@ const editDraft = vi.fn();
 const discardDraft = vi.fn();
 const reanchorDraft = vi.fn();
 const reviewPanel = vi.fn();
+const runReview = vi.fn();
 
 vi.mock("./bindings", () => ({
   commands: {
@@ -52,6 +54,7 @@ vi.mock("./bindings", () => ({
     discardDraft: (...args: unknown[]) => discardDraft(...args),
     reanchorDraft: (...args: unknown[]) => reanchorDraft(...args),
     reviewPanel: () => reviewPanel(),
+    runReview: (channel: unknown) => runReview(channel),
   },
 }));
 
@@ -175,6 +178,7 @@ beforeEach(() => {
   reanchorDraft.mockReset();
   reviewPanel.mockReset();
   reviewPanel.mockResolvedValue({ status: "ok", data: null });
+  runReview.mockReset();
 });
 
 /** Home, listed and settled, with the cursor on its first row. */
@@ -292,6 +296,27 @@ describe("coming back", () => {
 });
 
 describe("the Session kept alive behind Home", () => {
+  /// A Session behind Home has no screen, so its bindings must not answer
+  /// keystrokes meant for the list.
+  it("starts no review on cmd-shift-R once Home is in front of the Session", async () => {
+    reviewPanel.mockResolvedValue(ok(makePanel()));
+    runReview.mockResolvedValue(ok(makePanel({ revision: 2, heading: "1 finding" })));
+    await openTheCursorRow();
+
+    // In front, the Session answers the binding and the run settles.
+    fireEvent.keyDown(window, { key: "r", metaKey: true, shiftKey: true });
+    await waitFor(() => expect(screen.getByText("1 finding")).toBeTruthy());
+    expect(runReview).toHaveBeenCalledOnce();
+
+    fireEvent.keyDown(window, { key: "[", metaKey: true });
+    await waitFor(() =>
+      expect(document.querySelector(".app__session")?.hasAttribute("hidden")).toBe(true),
+    );
+    fireEvent.keyDown(window, { key: "r", metaKey: true, shiftKey: true });
+
+    expect(runReview).toHaveBeenCalledOnce();
+  });
+
   it("keeps its tree mounted and hidden, with its file, cursor, and composer intact", async () => {
     const user = userEvent.setup();
     selectFile.mockResolvedValue(

--- a/apps/desktop/src/Review.test.tsx
+++ b/apps/desktop/src/Review.test.tsx
@@ -5,6 +5,8 @@ import type { Channel } from "@tauri-apps/api/core";
 import type { ReviewPanelDto } from "./bindings";
 import App from "./App";
 import {
+  makeAnchoredDraft,
+  makeDrafts,
   makeFile,
   makeFileSummary,
   makeGuidance,
@@ -48,8 +50,9 @@ vi.mock("./bindings", () => ({
 vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({ writeText: () => Promise.resolve() }));
 
 /** The panel the backend reports while a run is in flight. */
-function runningPanel(detail: string): ReviewPanelDto {
+function runningPanel(detail: string, revision = 2): ReviewPanelDto {
   return makePanel({
+    revision,
     run: { state: "Running", detail },
     note: { heading: "Reviewing...", detail: null },
   });
@@ -139,9 +142,112 @@ describe("the review panel in a Session", () => {
 
     await user.click(screen.getByRole("button", { name: /1 guidance file/ }));
 
-    expect(toggleGuidancePanel).toHaveBeenCalledOnce();
     await waitFor(() => expect(screen.queryByText("AGENTS.md")).toBeNull());
     expect(screen.getByText("1 guidance file · 2 KB")).toBeTruthy();
+  });
+
+  it("shows what a refused toggle said, leaving the diff and the composer alone", async () => {
+    const user = userEvent.setup();
+    selectFile.mockResolvedValue({
+      status: "ok",
+      data: makeFile({
+        rows: [makeRow({ text: "first" }), makeRow({ text: "second" })],
+        drafts: makeDrafts({ anchored: [makeAnchoredDraft({ row: 0, body: "worth keeping" })] }),
+      }),
+    });
+    toggleGuidance.mockResolvedValue({
+      status: "error",
+      error: { summary: "no guidance file at AGENTS.md", detail: null, remediation: null },
+    });
+    await openPanel();
+    await user.keyboard("c");
+    await waitFor(() =>
+      expect(document.querySelector("[data-composer] .cm-content")?.textContent).toContain(
+        "worth keeping",
+      ),
+    );
+
+    await user.click(screen.getByRole("button", { name: /AGENTS\.md/ }));
+
+    await waitFor(() => expect(screen.getByText("no guidance file at AGENTS.md")).toBeTruthy());
+    expect(screen.getByText("first")).toBeTruthy();
+    expect(document.querySelector("[data-composer] .cm-content")?.textContent).toContain(
+      "worth keeping",
+    );
+  });
+
+  it("shows a review command's transport rejection in the panel rather than losing the Session", async () => {
+    const user = userEvent.setup();
+    toggleGuidancePanel.mockRejectedValue(new Error("IPC is unavailable"));
+    await openPanel();
+
+    await user.click(screen.getByRole("button", { name: /1 guidance file/ }));
+
+    await waitFor(() => expect(screen.getByText("Error: IPC is unavailable")).toBeTruthy());
+    expect(screen.getByText("first")).toBeTruthy();
+  });
+
+  it("clears the notice once a command answers with a panel again", async () => {
+    const user = userEvent.setup();
+    toggleGuidance.mockResolvedValue({
+      status: "error",
+      error: { summary: "no guidance file at AGENTS.md", detail: null, remediation: null },
+    });
+    toggleGuidancePanel.mockResolvedValue({
+      status: "ok",
+      data: makePanel({ revision: 2, guidance: makeGuidance({ expanded: false }) }),
+    });
+    await openPanel();
+
+    await user.click(screen.getByRole("button", { name: /AGENTS\.md/ }));
+    await waitFor(() => expect(screen.getByText("no guidance file at AGENTS.md")).toBeTruthy());
+
+    await user.click(screen.getByRole("button", { name: /1 guidance file/ }));
+
+    await waitFor(() => expect(screen.queryByText("no guidance file at AGENTS.md")).toBeNull());
+  });
+
+  it("drops a command's answer that was read before the run had finished", async () => {
+    const user = userEvent.setup();
+    let channel: Channel<ReviewPanelDto> | undefined;
+    let settleRun: (outcome: unknown) => void = () => {};
+    let settleCancel: (outcome: unknown) => void = () => {};
+    runReview.mockImplementation((given: Channel<ReviewPanelDto>) => {
+      channel = given;
+      return new Promise((resolve) => {
+        settleRun = resolve;
+      });
+    });
+    cancelReview.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          settleCancel = resolve;
+        }),
+    );
+    await openPanel();
+
+    await user.click(screen.getByRole("button", { name: "Review" }));
+    act(() => channel?.onmessage(runningPanel("Reading the diff", 3)));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy());
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await act(async () => {
+      settleRun({
+        status: "ok",
+        data: makePanel({
+          revision: 9,
+          run: { state: "Complete", accepted: 0, rejected: 0, suppressed: 0 },
+          note: { heading: "Nothing to act on.", detail: "The review found no problems." },
+        }),
+      });
+    });
+    // Cancel read the model while the run was still going, and answers last.
+    await act(async () => {
+      settleCancel({ status: "ok", data: runningPanel("Reading the diff", 3) });
+    });
+
+    expect(screen.getByText("Nothing to act on.")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
   });
 
   it("starts one run when Review is pressed twice before the backend has answered", async () => {
@@ -239,6 +345,7 @@ describe("the review panel in a Session", () => {
       settle({
         status: "ok",
         data: makePanel({
+          revision: 4,
           run: { state: "Failed", summary: "the review was cancelled", remediation: null },
           note: { heading: "the review was cancelled", detail: null },
         }),
@@ -284,13 +391,16 @@ describe("the review panel in a Session", () => {
           accepted: 0,
           rejected: 2,
           suppressed: 1,
-          unreviewed: ["vendor/lib.rs"],
         },
         note: {
           heading: "Nothing to act on.",
           detail: "2 claim(s) did not check out and 1 were previously dismissed.",
         },
-        footer: { refused: "2 claim(s) refused", not_reviewed: "1 file(s) not reviewed" },
+        footer: {
+          refused: "2 claim(s) refused",
+          not_reviewed: "1 file(s) not reviewed",
+          unreviewed: ["vendor/lib.rs"],
+        },
       }),
     });
     await openPanel();

--- a/apps/desktop/src/Review.test.tsx
+++ b/apps/desktop/src/Review.test.tsx
@@ -1,0 +1,311 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Channel } from "@tauri-apps/api/core";
+import type { ReviewPanelDto } from "./bindings";
+import App from "./App";
+import {
+  makeFile,
+  makeFileSummary,
+  makeGuidance,
+  makeGuidanceEntry,
+  makePanel,
+  makeRow,
+  makeSidebar,
+  makeSnapshot,
+} from "./test/fixtures";
+
+const describeWindow = vi.fn();
+const openSession = vi.fn();
+const selectFile = vi.fn();
+const toggleViewed = vi.fn();
+const editDraft = vi.fn();
+const discardDraft = vi.fn();
+const reanchorDraft = vi.fn();
+const reviewPanel = vi.fn();
+const runReview = vi.fn();
+const cancelReview = vi.fn();
+const toggleGuidancePanel = vi.fn();
+const toggleGuidance = vi.fn();
+
+vi.mock("./bindings", () => ({
+  commands: {
+    describeWindow: () => describeWindow(),
+    openSession: (channel: unknown) => openSession(channel),
+    selectFile: (index: unknown) => selectFile(index),
+    toggleViewed: () => toggleViewed(),
+    editDraft: (...args: unknown[]) => editDraft(...args),
+    discardDraft: (...args: unknown[]) => discardDraft(...args),
+    reanchorDraft: (...args: unknown[]) => reanchorDraft(...args),
+    reviewPanel: () => reviewPanel(),
+    runReview: (channel: unknown) => runReview(channel),
+    cancelReview: () => cancelReview(),
+    toggleGuidancePanel: () => toggleGuidancePanel(),
+    toggleGuidance: (path: unknown) => toggleGuidance(path),
+  },
+}));
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({ writeText: () => Promise.resolve() }));
+
+/** The panel the backend reports while a run is in flight. */
+function runningPanel(detail: string): ReviewPanelDto {
+  return makePanel({
+    run: { state: "Running", detail },
+    note: { heading: "Reviewing...", detail: null },
+  });
+}
+
+beforeEach(() => {
+  describeWindow.mockReset();
+  describeWindow.mockResolvedValue({
+    Session: { session: { description: "the generated fixture", row_identity: null } },
+  });
+  openSession.mockReset();
+  openSession.mockResolvedValue({
+    status: "ok",
+    data: makeSnapshot({ sidebar: makeSidebar([makeFileSummary()]) }),
+  });
+  selectFile.mockReset();
+  selectFile.mockResolvedValue({
+    status: "ok",
+    data: makeFile({ rows: [makeRow({ text: "first" }), makeRow({ text: "second" })] }),
+  });
+  toggleViewed.mockReset();
+  editDraft.mockReset();
+  discardDraft.mockReset();
+  reanchorDraft.mockReset();
+  reviewPanel.mockReset();
+  reviewPanel.mockResolvedValue({ status: "ok", data: makePanel() });
+  runReview.mockReset();
+  runReview.mockReturnValue(new Promise(() => {}));
+  cancelReview.mockReset();
+  toggleGuidancePanel.mockReset();
+  toggleGuidance.mockReset();
+});
+
+/** Renders the Session and waits for its panel to appear. */
+async function openPanel() {
+  render(<App />);
+  await waitFor(() => expect(screen.getByRole("button", { name: "Review" })).toBeTruthy());
+}
+
+describe("the review panel in a Session", () => {
+  it("shows the guidance the session discovered as soon as it opens", async () => {
+    await openPanel();
+
+    expect(screen.getByText("1 guidance file · 2 KB")).toBeTruthy();
+    expect(screen.getByText("AGENTS.md")).toBeTruthy();
+    expect(screen.getByText("No review has been run.")).toBeTruthy();
+  });
+
+  it("shows no panel for a snapshot that cannot be reviewed", async () => {
+    reviewPanel.mockResolvedValue({ status: "ok", data: null });
+
+    render(<App />);
+    await waitFor(() => expect(screen.getByText("first")).toBeTruthy());
+
+    expect(screen.queryByRole("button", { name: "Review" })).toBeNull();
+  });
+
+  it("updates the summary line when a guidance file is turned off", async () => {
+    const user = userEvent.setup();
+    toggleGuidance.mockResolvedValue({
+      status: "ok",
+      data: makePanel({
+        guidance: makeGuidance({
+          summary: "No guidance will be sent",
+          entries: [makeGuidanceEntry({ included: false })],
+        }),
+      }),
+    });
+    await openPanel();
+
+    await user.click(screen.getByRole("button", { name: /AGENTS\.md/ }));
+
+    expect(toggleGuidance).toHaveBeenCalledWith("AGENTS.md");
+    await waitFor(() => expect(screen.getByText("No guidance will be sent")).toBeTruthy());
+    expect(screen.getByRole("button", { name: /AGENTS\.md/ }).getAttribute("aria-pressed")).toBe(
+      "false",
+    );
+  });
+
+  it("opens and closes the guidance section on the summary line", async () => {
+    const user = userEvent.setup();
+    toggleGuidancePanel.mockResolvedValue({
+      status: "ok",
+      data: makePanel({ guidance: makeGuidance({ expanded: false }) }),
+    });
+    await openPanel();
+
+    await user.click(screen.getByRole("button", { name: /1 guidance file/ }));
+
+    expect(toggleGuidancePanel).toHaveBeenCalledOnce();
+    await waitFor(() => expect(screen.queryByText("AGENTS.md")).toBeNull());
+    expect(screen.getByText("1 guidance file · 2 KB")).toBeTruthy();
+  });
+
+  it("starts one run when Review is pressed twice before the backend has answered", async () => {
+    const user = userEvent.setup();
+    await openPanel();
+
+    await user.click(screen.getByRole("button", { name: "Review" }));
+    await user.click(screen.getByRole("button", { name: "Review" }));
+
+    expect(runReview).toHaveBeenCalledOnce();
+  });
+
+  it("starts a run on cmd-shift-R, and a second trigger during it starts nothing", async () => {
+    const user = userEvent.setup();
+    let channel: Channel<ReviewPanelDto> | undefined;
+    runReview.mockImplementation((given: Channel<ReviewPanelDto>) => {
+      channel = given;
+      return new Promise(() => {});
+    });
+    await openPanel();
+
+    await user.keyboard("{Meta>}{Shift>}r{/Shift}{/Meta}");
+    expect(runReview).toHaveBeenCalledOnce();
+
+    act(() => channel?.onmessage(runningPanel("Starting...")));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy());
+
+    await user.keyboard("{Meta>}{Shift>}r{/Shift}{/Meta}");
+
+    expect(runReview).toHaveBeenCalledOnce();
+  });
+
+  it("leaves cmd-shift-R to the composer while one has focus", async () => {
+    const user = userEvent.setup();
+    await openPanel();
+
+    await user.keyboard("c");
+    const editorContent = await waitFor(() => {
+      const element = document.querySelector("[data-composer] .cm-content");
+      if (!element) {
+        throw new Error("composer editor not mounted yet");
+      }
+      return element;
+    });
+
+    editorContent.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "r", metaKey: true, shiftKey: true, bubbles: true }),
+    );
+
+    expect(runReview).not.toHaveBeenCalled();
+  });
+
+  it("shows each progress line the backend reports", async () => {
+    const user = userEvent.setup();
+    let channel: Channel<ReviewPanelDto> | undefined;
+    runReview.mockImplementation((given: Channel<ReviewPanelDto>) => {
+      channel = given;
+      return new Promise(() => {});
+    });
+    await openPanel();
+
+    await user.click(screen.getByRole("button", { name: "Review" }));
+
+    act(() => channel?.onmessage(runningPanel("Starting claude")));
+    await waitFor(() => expect(screen.getByText("Starting claude")).toBeTruthy());
+
+    act(() => channel?.onmessage(runningPanel("Checking 3 findings against the diff")));
+    await waitFor(() =>
+      expect(screen.getByText("Checking 3 findings against the diff")).toBeTruthy(),
+    );
+    expect(screen.queryByText("Starting claude")).toBeNull();
+  });
+
+  it("asks the run to stop on Cancel, and says so once it ends", async () => {
+    const user = userEvent.setup();
+    let channel: Channel<ReviewPanelDto> | undefined;
+    let settle: (outcome: unknown) => void = () => {};
+    runReview.mockImplementation((given: Channel<ReviewPanelDto>) => {
+      channel = given;
+      return new Promise((resolve) => {
+        settle = resolve;
+      });
+    });
+    cancelReview.mockResolvedValue({ status: "ok", data: runningPanel("Reading the diff") });
+    await openPanel();
+
+    await user.click(screen.getByRole("button", { name: "Review" }));
+    act(() => channel?.onmessage(runningPanel("Reading the diff")));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy());
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(cancelReview).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      settle({
+        status: "ok",
+        data: makePanel({
+          run: { state: "Failed", summary: "the review was cancelled", remediation: null },
+          note: { heading: "the review was cancelled", detail: null },
+        }),
+      });
+    });
+
+    expect(screen.getByText("the review was cancelled")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Review" })).toBeTruthy();
+  });
+
+  it("shows a failed run's summary and what to do about it", async () => {
+    const user = userEvent.setup();
+    runReview.mockResolvedValue({
+      status: "ok",
+      data: makePanel({
+        run: {
+          state: "Failed",
+          summary: "claude is not installed",
+          remediation: "Install claude and make sure it is on your PATH.",
+        },
+        note: {
+          heading: "claude is not installed",
+          detail: "Install claude and make sure it is on your PATH.",
+        },
+      }),
+    });
+    await openPanel();
+
+    await user.click(screen.getByRole("button", { name: "Review" }));
+
+    await waitFor(() => expect(screen.getByText("claude is not installed")).toBeTruthy());
+    expect(screen.getByText("Install claude and make sure it is on your PATH.")).toBeTruthy();
+  });
+
+  it("shows a completed run's counts and the files it did not see, guidance collapsed", async () => {
+    const user = userEvent.setup();
+    runReview.mockResolvedValue({
+      status: "ok",
+      data: makePanel({
+        guidance: makeGuidance({ expanded: false }),
+        run: {
+          state: "Complete",
+          accepted: 0,
+          rejected: 2,
+          suppressed: 1,
+          unreviewed: ["vendor/lib.rs"],
+        },
+        note: {
+          heading: "Nothing to act on.",
+          detail: "2 claim(s) did not check out and 1 were previously dismissed.",
+        },
+        footer: { refused: "2 claim(s) refused", not_reviewed: "1 file(s) not reviewed" },
+      }),
+    });
+    await openPanel();
+
+    await user.click(screen.getByRole("button", { name: "Review" }));
+
+    await waitFor(() => expect(screen.getByText("Nothing to act on.")).toBeTruthy());
+    expect(
+      screen.getByText("2 claim(s) did not check out and 1 were previously dismissed."),
+    ).toBeTruthy();
+    expect(screen.getByText("2 claim(s) refused")).toBeTruthy();
+    expect(screen.getByText("1 file(s) not reviewed")).toBeTruthy();
+    expect(screen.getByText("vendor/lib.rs")).toBeTruthy();
+    // The disclosure has served its purpose; the summary line stays either way.
+    expect(screen.queryByText("AGENTS.md")).toBeNull();
+    expect(screen.getByText("1 guidance file · 2 KB")).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/SessionApp.tsx
+++ b/apps/desktop/src/SessionApp.tsx
@@ -23,6 +23,10 @@ export function SessionApp({
     composerChange,
     composerDiscard,
     reanchorDraft,
+    runReview,
+    cancelReview,
+    toggleGuidanceSection,
+    toggleGuidanceFile,
   } = useSession(description, isShowing);
 
   switch (state.status) {
@@ -43,6 +47,10 @@ export function SessionApp({
           onComposerClose={closeComposer}
           onComposerDiscard={composerDiscard}
           onReanchorDraft={reanchorDraft}
+          onRunReview={runReview}
+          onCancelReview={cancelReview}
+          onToggleGuidanceSection={toggleGuidanceSection}
+          onToggleGuidanceFile={toggleGuidanceFile}
         />
       );
   }

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -152,6 +152,11 @@ export const commands = {
 	 *  Returns a failure when no session is open.
 	 */
 	reviewPanel: () => typedError<{
+	/**
+	 *  How many times the panel has changed, so a snapshot that was read before
+	 *  a change can be told from one that carries it.
+	 */
+	revision: number,
 	/**  "Review" before there is anything to act on, otherwise the finding count. */
 	heading: string,
 	guidance: GuidanceDto,
@@ -174,6 +179,11 @@ export const commands = {
 	 *  does not finish.
 	 */
 	runReview: (onProgress: Channel<ReviewPanelDto>) => typedError<{
+	/**
+	 *  How many times the panel has changed, so a snapshot that was read before
+	 *  a change can be told from one that carries it.
+	 */
+	revision: number,
 	/**  "Review" before there is anything to act on, otherwise the finding count. */
 	heading: string,
 	guidance: GuidanceDto,
@@ -189,6 +199,11 @@ export const commands = {
 	 *  Returns a failure when no session is open.
 	 */
 	cancelReview: () => typedError<{
+	/**
+	 *  How many times the panel has changed, so a snapshot that was read before
+	 *  a change can be told from one that carries it.
+	 */
+	revision: number,
 	/**  "Review" before there is anything to act on, otherwise the finding count. */
 	heading: string,
 	guidance: GuidanceDto,
@@ -204,6 +219,11 @@ export const commands = {
 	 *  Returns a failure when no session is open.
 	 */
 	toggleGuidancePanel: () => typedError<{
+	/**
+	 *  How many times the panel has changed, so a snapshot that was read before
+	 *  a change can be told from one that carries it.
+	 */
+	revision: number,
 	/**  "Review" before there is anything to act on, otherwise the finding count. */
 	heading: string,
 	guidance: GuidanceDto,
@@ -220,6 +240,11 @@ export const commands = {
 	 *  file the session discovered.
 	 */
 	toggleGuidance: (path: string) => typedError<{
+	/**
+	 *  How many times the panel has changed, so a snapshot that was read before
+	 *  a change can be told from one that carries it.
+	 */
+	revision: number,
 	/**  "Review" before there is anything to act on, otherwise the finding count. */
 	heading: string,
 	guidance: GuidanceDto,
@@ -304,7 +329,7 @@ export type FileSummaryDto = {
 export type GuidanceDto = 
 /**
  *  Discovery ran and found nothing. Saying so is not the same as showing
- *  nothing: a reviewer needs to tell "this repository states no conventions"
+ *  nothing. A reviewer needs to tell "this repository states no conventions"
  *  from "guidance was never looked for".
  */
 { kind: "NothingFound"; note: string } | { kind: "Discovered"; 
@@ -430,6 +455,8 @@ export type PanelFooterDto = {
 	refused: string | null,
 	/**  Present when a completed run did not see the whole change. */
 	not_reviewed: string | null,
+	/**  The files that run did not see, named under the count that describes them. */
+	unreviewed: string[],
 };
 
 /**
@@ -466,6 +493,11 @@ export type RefusalDto = {
  *  that populates it has got.
  */
 export type ReviewPanelDto = {
+	/**
+	 *  How many times the panel has changed, so a snapshot that was read before
+	 *  a change can be told from one that carries it.
+	 */
+	revision: number,
 	/**  "Review" before there is anything to act on, otherwise the finding count. */
 	heading: string,
 	guidance: GuidanceDto,
@@ -479,9 +511,7 @@ export type ReviewRunDto = { state: "Idle" } | { state: "Running";
 /**  The backend's most recent progress line. */
 detail: string } | { state: "Complete"; accepted: number; rejected: number; 
 /**  Claims suppressed because the reviewer dismissed them before. */
-suppressed: number; 
-/**  Files the run did not see. */
-unreviewed: string[] } | { state: "Failed"; summary: string; remediation: string | null };
+suppressed: number } | { state: "Failed"; summary: string; remediation: string | null };
 
 export type RowDto = {
 	kind: DiffLineKindDto,

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -141,6 +141,92 @@ export const commands = {
 	 *  `(path, side, line)`, or `row` cannot carry a comment.
 	 */
 	reanchorDraft: (fileIndex: number, path: string, side: DiffSideDto, line: number, row: number) => typedError<DraftsDto, SessionFailureDto>(__TAURI_INVOKE("reanchor_draft", { fileIndex, path, side, line, row })),
+	/**
+	 *  The Session's review panel, asked for once the session is ready.
+	 * 
+	 *  `null` means this snapshot cannot be reviewed at all, which is the generated
+	 *  fixture, and the Session shows no panel.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns a failure when no session is open.
+	 */
+	reviewPanel: () => typedError<{
+	/**  "Review" before there is anything to act on, otherwise the finding count. */
+	heading: string,
+	guidance: GuidanceDto,
+	run: ReviewRunDto,
+	note: PanelNoteDto | null,
+	footer: PanelFooterDto | null,
+} | null, SessionFailureDto>(__TAURI_INVOKE("review_panel")),
+	/**
+	 *  Runs a review against the Claude coding agent at the repository root, on a
+	 *  background thread, reporting the panel to `on_progress` as the backend speaks.
+	 * 
+	 *  A trigger that arrives while a run is in flight starts nothing and answers with
+	 *  the panel already on screen. The model is taken out of the window as its own
+	 *  handle, so a Session dropped or a window closed mid-run leaves the background
+	 *  work finishing into a model nobody reads rather than panicking.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns a failure when no session is open, or when the task doing the review
+	 *  does not finish.
+	 */
+	runReview: (onProgress: Channel<ReviewPanelDto>) => typedError<{
+	/**  "Review" before there is anything to act on, otherwise the finding count. */
+	heading: string,
+	guidance: GuidanceDto,
+	run: ReviewRunDto,
+	note: PanelNoteDto | null,
+	footer: PanelFooterDto | null,
+} | null, SessionFailureDto>(__TAURI_INVOKE("run_review", { onProgress })),
+	/**
+	 *  Asks the running review to stop. It ends at the backend's next step.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns a failure when no session is open.
+	 */
+	cancelReview: () => typedError<{
+	/**  "Review" before there is anything to act on, otherwise the finding count. */
+	heading: string,
+	guidance: GuidanceDto,
+	run: ReviewRunDto,
+	note: PanelNoteDto | null,
+	footer: PanelFooterDto | null,
+} | null, SessionFailureDto>(__TAURI_INVOKE("cancel_review")),
+	/**
+	 *  Opens or closes the guidance section.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns a failure when no session is open.
+	 */
+	toggleGuidancePanel: () => typedError<{
+	/**  "Review" before there is anything to act on, otherwise the finding count. */
+	heading: string,
+	guidance: GuidanceDto,
+	run: ReviewRunDto,
+	note: PanelNoteDto | null,
+	footer: PanelFooterDto | null,
+} | null, SessionFailureDto>(__TAURI_INVOKE("toggle_guidance_panel")),
+	/**
+	 *  Turns one guidance file on or off for the next run.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns a failure when no session is open, or when `path` names no guidance
+	 *  file the session discovered.
+	 */
+	toggleGuidance: (path: string) => typedError<{
+	/**  "Review" before there is anything to act on, otherwise the finding count. */
+	heading: string,
+	guidance: GuidanceDto,
+	run: ReviewRunDto,
+	note: PanelNoteDto | null,
+	footer: PanelFooterDto | null,
+} | null, SessionFailureDto>(__TAURI_INVOKE("toggle_guidance", { path })),
 };
 
 /* Types */
@@ -212,6 +298,36 @@ export type FileSummaryDto = {
 	deletions: number,
 	viewed: boolean,
 	thread_count: number,
+};
+
+/**  The guidance section at the top of the panel. */
+export type GuidanceDto = 
+/**
+ *  Discovery ran and found nothing. Saying so is not the same as showing
+ *  nothing: a reviewer needs to tell "this repository states no conventions"
+ *  from "guidance was never looked for".
+ */
+{ kind: "NothingFound"; note: string } | { kind: "Discovered"; 
+/**  The one line that stays on screen whether or not the section is open. */
+summary: string; expanded: boolean; entries: GuidanceEntryDto[]; skipped: GuidanceSkipDto[]; 
+/**  What configuration keeps out of the review, when it keeps anything out. */
+excluded: string | null };
+
+/**  One guidance file discovery found, as the panel draws its row. */
+export type GuidanceEntryDto = {
+	/**  Repository-relative path, which is also how a finding cites it. */
+	path: string,
+	/**  What it applies to, already rendered, e.g. "whole repository". */
+	scope: string,
+	kilobytes: number,
+	/**  Whether the next run will send it. */
+	included: boolean,
+};
+
+/**  Something discovery found and will not use, and why. */
+export type GuidanceSkipDto = {
+	path: string,
+	reason: string,
 };
 
 /**  One of Home's three groups, always rendered whether or not it has rows. */
@@ -308,6 +424,25 @@ export type OpenSessionDto = {
 	row_identity: string | null,
 };
 
+/**  The caveats under the panel: what was refused, and what was never looked at. */
+export type PanelFooterDto = {
+	/**  Claims that did not survive checking against the diff. */
+	refused: string | null,
+	/**  Present when a completed run did not see the whole change. */
+	not_reviewed: string | null,
+};
+
+/**
+ *  What the panel says when there is no finding to show.
+ * 
+ *  Every run state has one. An empty panel with no explanation is the failure
+ *  this projection exists to avoid.
+ */
+export type PanelNoteDto = {
+	heading: string,
+	detail: string | null,
+};
+
 /**  How current the list is, which the header stamp reads. */
 export type RefreshStateDto = 
 /**  There is no stamp at all until the first refresh starts. */
@@ -325,6 +460,28 @@ export type RefusalDto = {
 	path: string,
 	reason: string,
 };
+
+/**
+ *  The Session's right-hand panel: what a review is held to, and how far the run
+ *  that populates it has got.
+ */
+export type ReviewPanelDto = {
+	/**  "Review" before there is anything to act on, otherwise the finding count. */
+	heading: string,
+	guidance: GuidanceDto,
+	run: ReviewRunDto,
+	note: PanelNoteDto | null,
+	footer: PanelFooterDto | null,
+};
+
+/**  How far the current review run has got. */
+export type ReviewRunDto = { state: "Idle" } | { state: "Running"; 
+/**  The backend's most recent progress line. */
+detail: string } | { state: "Complete"; accepted: number; rejected: number; 
+/**  Claims suppressed because the reviewer dismissed them before. */
+suppressed: number; 
+/**  Files the run did not see. */
+unreviewed: string[] } | { state: "Failed"; summary: string; remediation: string | null };
 
 export type RowDto = {
 	kind: DiffLineKindDto,

--- a/apps/desktop/src/components/ReviewPanel.css
+++ b/apps/desktop/src/components/ReviewPanel.css
@@ -1,0 +1,207 @@
+.review-panel {
+  width: 340px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border-left: 1px solid var(--border-default);
+  background: var(--surface-base);
+  font-family: var(--font-mono);
+  font-size: var(--size-meta);
+}
+
+.review-panel__header {
+  flex-shrink: 0;
+  padding: 8px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border-bottom: 1px solid var(--border-default);
+}
+
+.review-panel__title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.review-panel__heading {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.review-panel__run {
+  padding: 4px 8px;
+  border: none;
+  border-radius: 6px;
+  color: var(--text-on-accent);
+  font-family: inherit;
+  font-size: var(--size-label);
+  cursor: pointer;
+}
+
+.review-panel__run--start {
+  background: var(--accent-base);
+}
+
+.review-panel__run--cancel {
+  background: var(--severity-error);
+}
+
+.review-panel__progress {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--size-label);
+}
+
+.review-panel__guidance {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  border-bottom: 1px solid var(--border-default);
+}
+
+.review-panel__nothing-found {
+  margin: 0;
+  padding: 8px 12px;
+  color: var(--text-secondary);
+  font-size: var(--size-label);
+}
+
+.review-panel__guidance-header {
+  padding: 8px 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  border: none;
+  background: none;
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.review-panel__disclosure {
+  color: var(--text-secondary);
+  font-size: var(--size-label);
+}
+
+.review-panel__entry {
+  padding: 4px 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border: none;
+  background: none;
+  font-family: inherit;
+  font-size: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.review-panel__include {
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+  border-radius: 3px;
+  border: 1px solid var(--border-strong);
+}
+
+.review-panel__include--on {
+  border-color: var(--severity-success-text);
+  background: var(--severity-success);
+}
+
+.review-panel__entry-path {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.review-panel__entry-path--on {
+  color: var(--text-primary);
+}
+
+.review-panel__entry-path--off {
+  color: var(--text-secondary);
+}
+
+.review-panel__entry-meta {
+  flex-shrink: 0;
+  color: var(--text-secondary);
+  font-size: var(--size-label);
+}
+
+.review-panel__skipped {
+  padding: 4px 12px;
+  display: flex;
+  flex-direction: column;
+  color: var(--text-tertiary);
+}
+
+.review-panel__skipped-reason {
+  font-size: var(--size-label);
+}
+
+.review-panel__excluded {
+  margin: 0;
+  padding: 4px 12px;
+  color: var(--severity-warning);
+  font-size: var(--size-label);
+}
+
+.review-panel__body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.review-panel__note {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.review-panel__note-heading {
+  margin: 0;
+  color: var(--text-primary);
+}
+
+.review-panel__note-detail {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--size-label);
+}
+
+.review-panel__footer {
+  flex-shrink: 0;
+  padding: 8px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border-top: 1px solid var(--border-default);
+  color: var(--text-secondary);
+  font-size: var(--size-label);
+}
+
+.review-panel__footer p {
+  margin: 0;
+}
+
+.review-panel__not-reviewed {
+  color: var(--severity-warning);
+}
+
+.review-panel__unreviewed {
+  margin: 0;
+  padding-left: 16px;
+  list-style: disc;
+}

--- a/apps/desktop/src/components/ReviewPanel.css
+++ b/apps/desktop/src/components/ReviewPanel.css
@@ -1,5 +1,5 @@
 .review-panel {
-  width: 340px;
+  width: var(--review-panel-width);
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
@@ -52,6 +52,16 @@
 .review-panel__progress {
   margin: 0;
   color: var(--text-secondary);
+  font-size: var(--size-label);
+}
+
+.review-panel__notice {
+  flex-shrink: 0;
+  margin: 0;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-default);
+  background: var(--severity-error-dim);
+  color: var(--severity-error-text);
   font-size: var(--size-label);
 }
 

--- a/apps/desktop/src/components/ReviewPanel.test.tsx
+++ b/apps/desktop/src/components/ReviewPanel.test.tsx
@@ -7,6 +7,7 @@ import { ReviewPanel } from "./ReviewPanel";
 /** Every handler the panel needs beyond the one a test wants to watch. */
 function baseHandlers() {
   return {
+    notice: null,
     onRunReview: () => {},
     onCancelReview: () => {},
     onToggleGuidanceSection: () => {},
@@ -181,13 +182,16 @@ describe("ReviewPanel", () => {
             accepted: 0,
             rejected: 2,
             suppressed: 1,
-            unreviewed: ["vendor/lib.rs", "huge.json"],
           },
           note: {
             heading: "Nothing to act on.",
             detail: "2 claim(s) did not check out and 1 were previously dismissed.",
           },
-          footer: { refused: "2 claim(s) refused", not_reviewed: "2 file(s) not reviewed" },
+          footer: {
+            refused: "2 claim(s) refused",
+            not_reviewed: "2 file(s) not reviewed",
+            unreviewed: ["vendor/lib.rs", "huge.json"],
+          },
         })}
         {...baseHandlers()}
       />,

--- a/apps/desktop/src/components/ReviewPanel.test.tsx
+++ b/apps/desktop/src/components/ReviewPanel.test.tsx
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { makeGuidance, makeGuidanceEntry, makePanel } from "../test/fixtures";
+import { ReviewPanel } from "./ReviewPanel";
+
+/** Every handler the panel needs beyond the one a test wants to watch. */
+function baseHandlers() {
+  return {
+    onRunReview: () => {},
+    onCancelReview: () => {},
+    onToggleGuidanceSection: () => {},
+    onToggleGuidanceFile: () => {},
+  };
+}
+
+describe("ReviewPanel", () => {
+  it("lists every discovered file with what it applies to and how big it is", () => {
+    render(
+      <ReviewPanel
+        panel={makePanel({
+          guidance: makeGuidance({
+            entries: [
+              makeGuidanceEntry({ path: "AGENTS.md", scope: "whole repository", kilobytes: 2 }),
+              makeGuidanceEntry({ path: "src/AGENTS.md", scope: "src/", kilobytes: 1 }),
+            ],
+            summary: "2 guidance files · 3 KB",
+          }),
+        })}
+        {...baseHandlers()}
+      />,
+    );
+
+    expect(screen.getByText("2 guidance files · 3 KB")).toBeTruthy();
+    expect(screen.getByText("AGENTS.md")).toBeTruthy();
+    expect(screen.getByText("whole repository · 2K")).toBeTruthy();
+    expect(screen.getByText("src/AGENTS.md")).toBeTruthy();
+    expect(screen.getByText("src/ · 1K")).toBeTruthy();
+  });
+
+  it("shows what discovery skipped with the reason, and what config keeps out of the review", () => {
+    render(
+      <ReviewPanel
+        panel={makePanel({
+          guidance: makeGuidance({
+            skipped: [{ path: "CLAUDE.md", reason: "90000 bytes, over the 65536-byte limit" }],
+            excluded: "1 file excluded from review by .zreview.toml",
+          }),
+        })}
+        {...baseHandlers()}
+      />,
+    );
+
+    expect(screen.getByText("CLAUDE.md")).toBeTruthy();
+    expect(screen.getByText("90000 bytes, over the 65536-byte limit")).toBeTruthy();
+    expect(screen.getByText("1 file excluded from review by .zreview.toml")).toBeTruthy();
+  });
+
+  it("says plainly when discovery found nothing", () => {
+    render(
+      <ReviewPanel
+        panel={makePanel({
+          guidance: {
+            kind: "NothingFound",
+            note: "No guidance files found. The review will judge the diff alone.",
+          },
+        })}
+        {...baseHandlers()}
+      />,
+    );
+
+    expect(
+      screen.getByText("No guidance files found. The review will judge the diff alone."),
+    ).toBeTruthy();
+  });
+
+  it("keeps the summary line but hides the files while the section is collapsed", async () => {
+    const onToggleGuidanceSection = vi.fn();
+    render(
+      <ReviewPanel
+        panel={makePanel({ guidance: makeGuidance({ expanded: false }) })}
+        {...baseHandlers()}
+        onToggleGuidanceSection={onToggleGuidanceSection}
+      />,
+    );
+
+    expect(screen.getByText("1 guidance file · 2 KB")).toBeTruthy();
+    expect(screen.queryByText("AGENTS.md")).toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: /1 guidance file/ }));
+
+    expect(onToggleGuidanceSection).toHaveBeenCalledOnce();
+  });
+
+  it("hands back the path of the guidance file whose toggle was pressed", async () => {
+    const onToggleGuidanceFile = vi.fn();
+    render(
+      <ReviewPanel
+        panel={makePanel()}
+        {...baseHandlers()}
+        onToggleGuidanceFile={onToggleGuidanceFile}
+      />,
+    );
+
+    const toggle = screen.getByRole("button", { name: /AGENTS\.md/ });
+    expect(toggle.getAttribute("aria-pressed")).toBe("true");
+
+    await userEvent.click(toggle);
+
+    expect(onToggleGuidanceFile).toHaveBeenCalledWith("AGENTS.md");
+  });
+
+  it("offers Review while nothing is running, and says a run has not happened", () => {
+    render(<ReviewPanel panel={makePanel()} {...baseHandlers()} />);
+
+    expect(screen.getByRole("button", { name: "Review" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+    expect(screen.getByText("No review has been run.")).toBeTruthy();
+  });
+
+  it("shows the backend's latest line and a Cancel control while a run is in flight", () => {
+    render(
+      <ReviewPanel
+        panel={makePanel({
+          run: { state: "Running", detail: "Reading the diff" },
+          note: { heading: "Reviewing...", detail: null },
+        })}
+        {...baseHandlers()}
+      />,
+    );
+
+    expect(screen.getByText("Reading the diff")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Review" })).toBeNull();
+  });
+
+  it("shows a failed run's summary and what to do about it", () => {
+    render(
+      <ReviewPanel
+        panel={makePanel({
+          run: {
+            state: "Failed",
+            summary: "claude is not installed",
+            remediation: "Install claude and make sure it is on your PATH.",
+          },
+          note: {
+            heading: "claude is not installed",
+            detail: "Install claude and make sure it is on your PATH.",
+          },
+        })}
+        {...baseHandlers()}
+      />,
+    );
+
+    expect(screen.getByText("claude is not installed")).toBeTruthy();
+    expect(screen.getByText("Install claude and make sure it is on your PATH.")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Review" })).toBeTruthy();
+  });
+
+  it("says so when the run the reviewer cancelled ends", () => {
+    render(
+      <ReviewPanel
+        panel={makePanel({
+          run: { state: "Failed", summary: "the review was cancelled", remediation: null },
+          note: { heading: "the review was cancelled", detail: null },
+        })}
+        {...baseHandlers()}
+      />,
+    );
+
+    expect(screen.getByText("the review was cancelled")).toBeTruthy();
+  });
+
+  it("shows a completed run's counts and names the files it did not see", () => {
+    render(
+      <ReviewPanel
+        panel={makePanel({
+          guidance: makeGuidance({ expanded: false }),
+          run: {
+            state: "Complete",
+            accepted: 0,
+            rejected: 2,
+            suppressed: 1,
+            unreviewed: ["vendor/lib.rs", "huge.json"],
+          },
+          note: {
+            heading: "Nothing to act on.",
+            detail: "2 claim(s) did not check out and 1 were previously dismissed.",
+          },
+          footer: { refused: "2 claim(s) refused", not_reviewed: "2 file(s) not reviewed" },
+        })}
+        {...baseHandlers()}
+      />,
+    );
+
+    expect(screen.getByText("Nothing to act on.")).toBeTruthy();
+    expect(
+      screen.getByText("2 claim(s) did not check out and 1 were previously dismissed."),
+    ).toBeTruthy();
+    expect(screen.getByText("2 claim(s) refused")).toBeTruthy();
+    expect(screen.getByText("2 file(s) not reviewed")).toBeTruthy();
+    expect(screen.getByText("vendor/lib.rs")).toBeTruthy();
+    expect(screen.getByText("huge.json")).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/components/ReviewPanel.tsx
+++ b/apps/desktop/src/components/ReviewPanel.tsx
@@ -1,0 +1,156 @@
+import type { GuidanceDto, ReviewPanelDto } from "../bindings";
+import "./ReviewPanel.css";
+
+/**
+ * What this review is held to, and how far the run that populates it has got.
+ *
+ * Two things this panel is careful to show rather than hide. What was refused, so
+ * a run that kept one claim out of twelve does not read as a run that found one.
+ * And what was never looked at, so a review that skipped files cannot present
+ * itself as having covered the change. The findings themselves are not drawn yet.
+ */
+export function ReviewPanel({
+  panel,
+  onRunReview,
+  onCancelReview,
+  onToggleGuidanceSection,
+  onToggleGuidanceFile,
+}: {
+  panel: ReviewPanelDto;
+  onRunReview: () => void;
+  onCancelReview: () => void;
+  onToggleGuidanceSection: () => void;
+  onToggleGuidanceFile: (path: string) => void;
+}) {
+  const { run, note, footer } = panel;
+  const isRunning = run.state === "Running";
+  const unreviewed = run.state === "Complete" ? run.unreviewed : [];
+
+  return (
+    <aside className="review-panel">
+      <header className="review-panel__header">
+        <div className="review-panel__title">
+          <span className="review-panel__heading">{panel.heading}</span>
+          <button
+            type="button"
+            className={`review-panel__run review-panel__run--${isRunning ? "cancel" : "start"}`}
+            onClick={isRunning ? onCancelReview : onRunReview}
+          >
+            {isRunning ? "Cancel" : "Review"}
+          </button>
+        </div>
+        {run.state === "Running" && <p className="review-panel__progress">{run.detail}</p>}
+      </header>
+      <GuidanceSection
+        guidance={panel.guidance}
+        onToggleSection={onToggleGuidanceSection}
+        onToggleFile={onToggleGuidanceFile}
+      />
+      <div className="review-panel__body">
+        {note !== null && (
+          <div className="review-panel__note">
+            <p className="review-panel__note-heading">{note.heading}</p>
+            {note.detail !== null && <p className="review-panel__note-detail">{note.detail}</p>}
+          </div>
+        )}
+      </div>
+      {footer !== null && (
+        <footer className="review-panel__footer">
+          {footer.refused !== null && <p>{footer.refused}</p>}
+          {footer.not_reviewed !== null && (
+            <>
+              <p className="review-panel__not-reviewed">{footer.not_reviewed}</p>
+              <ul className="review-panel__unreviewed">
+                {unreviewed.map((path) => (
+                  <li key={path}>{path}</li>
+                ))}
+              </ul>
+            </>
+          )}
+        </footer>
+      )}
+    </aside>
+  );
+}
+
+/**
+ * The guidance a run would be held to, and what of it will be sent.
+ *
+ * Open before the first run, because what leaves the machine has to be seen
+ * before it is sent, and collapsed to its summary line once a run has happened.
+ */
+function GuidanceSection({
+  guidance,
+  onToggleSection,
+  onToggleFile,
+}: {
+  guidance: GuidanceDto;
+  onToggleSection: () => void;
+  onToggleFile: (path: string) => void;
+}) {
+  if (guidance.kind === "NothingFound") {
+    // Discovery ran and found nothing. Saying so is not the same as showing
+    // nothing, which would read as though guidance was never looked for.
+    return (
+      <section className="review-panel__guidance">
+        <p className="review-panel__nothing-found">{guidance.note}</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="review-panel__guidance">
+      <button
+        type="button"
+        className="review-panel__guidance-header"
+        aria-expanded={guidance.expanded}
+        onClick={onToggleSection}
+      >
+        <span>{guidance.summary}</span>
+        <span className="review-panel__disclosure">{guidance.expanded ? "hide" : "show"}</span>
+      </button>
+      {guidance.expanded && (
+        <>
+          {guidance.entries.map((entry) => (
+            <button
+              key={entry.path}
+              type="button"
+              className="review-panel__entry"
+              aria-pressed={entry.included}
+              onClick={() => onToggleFile(entry.path)}
+            >
+              {/* A filled box is sent, an empty one is not. This is the disclosure control. */}
+              <span
+                className={`review-panel__include review-panel__include--${
+                  entry.included ? "on" : "off"
+                }`}
+                aria-hidden="true"
+              />
+              <span
+                className={`review-panel__entry-path review-panel__entry-path--${
+                  entry.included ? "on" : "off"
+                }`}
+              >
+                {entry.path}
+              </span>
+              <span className="review-panel__entry-meta">
+                {entry.scope} · {entry.kilobytes}K
+              </span>
+            </button>
+          ))}
+          {/* Found and not used, each with its reason. Silently dropping a file
+              the reviewer expected to matter is worse than not finding it. */}
+          {guidance.skipped.map((skip) => (
+            <div key={skip.path} className="review-panel__skipped">
+              <span>{skip.path}</span>
+              <span className="review-panel__skipped-reason">{skip.reason}</span>
+            </div>
+          ))}
+          {guidance.excluded !== null && (
+            <p className="review-panel__excluded">{guidance.excluded}</p>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/apps/desktop/src/components/ReviewPanel.tsx
+++ b/apps/desktop/src/components/ReviewPanel.tsx
@@ -11,12 +11,15 @@ import "./ReviewPanel.css";
  */
 export function ReviewPanel({
   panel,
+  notice,
   onRunReview,
   onCancelReview,
   onToggleGuidanceSection,
   onToggleGuidanceFile,
 }: {
   panel: ReviewPanelDto;
+  /** What a review command refused, until the next panel lands. */
+  notice: string | null;
   onRunReview: () => void;
   onCancelReview: () => void;
   onToggleGuidanceSection: () => void;
@@ -24,7 +27,6 @@ export function ReviewPanel({
 }) {
   const { run, note, footer } = panel;
   const isRunning = run.state === "Running";
-  const unreviewed = run.state === "Complete" ? run.unreviewed : [];
 
   return (
     <aside className="review-panel">
@@ -41,6 +43,7 @@ export function ReviewPanel({
         </div>
         {run.state === "Running" && <p className="review-panel__progress">{run.detail}</p>}
       </header>
+      {notice !== null && <p className="review-panel__notice">{notice}</p>}
       <GuidanceSection
         guidance={panel.guidance}
         onToggleSection={onToggleGuidanceSection}
@@ -61,7 +64,7 @@ export function ReviewPanel({
             <>
               <p className="review-panel__not-reviewed">{footer.not_reviewed}</p>
               <ul className="review-panel__unreviewed">
-                {unreviewed.map((path) => (
+                {footer.unreviewed.map((path) => (
                   <li key={path}>{path}</li>
                 ))}
               </ul>
@@ -90,7 +93,8 @@ function GuidanceSection({
 }) {
   if (guidance.kind === "NothingFound") {
     // Discovery ran and found nothing. Saying so is not the same as showing
-    // nothing, which would read as though guidance was never looked for.
+    // nothing. A reviewer needs to tell "this repository states no conventions"
+    // from "guidance was never looked for".
     return (
       <section className="review-panel__guidance">
         <p className="review-panel__nothing-found">{guidance.note}</p>

--- a/apps/desktop/src/components/SessionShell.test.tsx
+++ b/apps/desktop/src/components/SessionShell.test.tsx
@@ -33,6 +33,7 @@ function readyState(overrides: Partial<ReadyState["file"]> = {}): ReadyState {
     drafts: makeFile().drafts,
     composer: null,
     panel: null,
+    panelNotice: null,
   };
 }
 

--- a/apps/desktop/src/components/SessionShell.test.tsx
+++ b/apps/desktop/src/components/SessionShell.test.tsx
@@ -16,6 +16,10 @@ function baseHandlers() {
     onComposerClose: () => {},
     onComposerDiscard: () => {},
     onReanchorDraft: () => {},
+    onRunReview: () => {},
+    onCancelReview: () => {},
+    onToggleGuidanceSection: () => {},
+    onToggleGuidanceFile: () => {},
   };
 }
 
@@ -28,6 +32,7 @@ function readyState(overrides: Partial<ReadyState["file"]> = {}): ReadyState {
     anchor: 0,
     drafts: makeFile().drafts,
     composer: null,
+    panel: null,
   };
 }
 

--- a/apps/desktop/src/components/SessionShell.tsx
+++ b/apps/desktop/src/components/SessionShell.tsx
@@ -85,6 +85,7 @@ export function SessionShell({
       {state.panel !== null && (
         <ReviewPanel
           panel={state.panel}
+          notice={state.panelNotice}
           onRunReview={onRunReview}
           onCancelReview={onCancelReview}
           onToggleGuidanceSection={onToggleGuidanceSection}

--- a/apps/desktop/src/components/SessionShell.tsx
+++ b/apps/desktop/src/components/SessionShell.tsx
@@ -4,6 +4,7 @@ import { composerPrefill, selectionRange } from "../hooks/sessionReducer";
 import { DiffList } from "./DiffList";
 import { EmptyDiffPane } from "./EmptyDiffPane";
 import { FileSidebar } from "./FileSidebar";
+import { ReviewPanel } from "./ReviewPanel";
 import "./SessionShell.css";
 
 export function SessionShell({
@@ -17,6 +18,10 @@ export function SessionShell({
   onComposerClose,
   onComposerDiscard,
   onReanchorDraft,
+  onRunReview,
+  onCancelReview,
+  onToggleGuidanceSection,
+  onToggleGuidanceFile,
 }: {
   state: ReadyState;
   /** False while Home is in front, which is when this Session has no screen. */
@@ -30,6 +35,10 @@ export function SessionShell({
   onComposerClose: () => void;
   onComposerDiscard: () => void;
   onReanchorDraft: (path: string, side: DiffSideDto, line: number, row: number) => void;
+  onRunReview: () => void;
+  onCancelReview: () => void;
+  onToggleGuidanceSection: () => void;
+  onToggleGuidanceFile: (path: string) => void;
 }) {
   const [selectionStart, selectionEnd] = selectionRange(state);
   const { empty_reason: emptyReason, rows } = state.file;
@@ -71,6 +80,15 @@ export function SessionShell({
           onComposerChange={onComposerChange}
           onComposerClose={onComposerClose}
           onComposerDiscard={onComposerDiscard}
+        />
+      )}
+      {state.panel !== null && (
+        <ReviewPanel
+          panel={state.panel}
+          onRunReview={onRunReview}
+          onCancelReview={onCancelReview}
+          onToggleGuidanceSection={onToggleGuidanceSection}
+          onToggleGuidanceFile={onToggleGuidanceFile}
         />
       )}
     </div>

--- a/apps/desktop/src/hooks/sessionReducer.test.ts
+++ b/apps/desktop/src/hooks/sessionReducer.test.ts
@@ -34,6 +34,7 @@ function readyState(rowCount: number, cursor = 0, anchor = 0): ReadyState {
     drafts: file.drafts,
     composer: null,
     panel: null,
+    panelNotice: null,
   };
 }
 
@@ -77,6 +78,43 @@ describe("sessionReducer", () => {
     const next = sessionReducer(initialState, { type: "panel", panel: makePanel() });
 
     expect(next).toEqual(initialState);
+  });
+
+  it("drops a panel that was read before the one it already holds", () => {
+    const held = sessionReducer(readyState(1), {
+      type: "panel",
+      panel: makePanel({ revision: 7, heading: "2 findings" }),
+    });
+
+    const next = sessionReducer(held, {
+      type: "panel",
+      panel: makePanel({ revision: 5, heading: "Review" }),
+    });
+
+    expect(next).toMatchObject({ panel: { revision: 7, heading: "2 findings" } });
+  });
+
+  it("keeps a panel read at the same revision, which carries the same state", () => {
+    const held = sessionReducer(readyState(1), { type: "panel", panel: makePanel({ revision: 7 }) });
+
+    const next = sessionReducer(held, {
+      type: "panel",
+      panel: makePanel({ revision: 7, heading: "1 finding" }),
+    });
+
+    expect(next).toMatchObject({ panel: { heading: "1 finding" } });
+  });
+
+  it("shows what a review command refused until the next panel lands", () => {
+    const refused = sessionReducer(readyState(1), {
+      type: "panelNotice",
+      notice: "no guidance file at AGENTS.md",
+    });
+    expect(refused).toMatchObject({ panelNotice: "no guidance file at AGENTS.md" });
+
+    const next = sessionReducer(refused, { type: "panel", panel: makePanel() });
+
+    expect(next).toMatchObject({ panelNotice: null });
   });
 
   it("clamps the cursor at the top of the file", () => {

--- a/apps/desktop/src/hooks/sessionReducer.test.ts
+++ b/apps/desktop/src/hooks/sessionReducer.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type { FileDetailDto, SessionFailureDto } from "../bindings";
-import { makeAnchoredDraft, makeDrafts, makeFile, makeRow, makeSnapshot } from "../test/fixtures";
+import {
+  makeAnchoredDraft,
+  makeDrafts,
+  makeFile,
+  makePanel,
+  makeRow,
+  makeSnapshot,
+} from "../test/fixtures";
 import {
   type ReadyState,
   composerPrefill,
@@ -26,6 +33,7 @@ function readyState(rowCount: number, cursor = 0, anchor = 0): ReadyState {
     anchor,
     drafts: file.drafts,
     composer: null,
+    panel: null,
   };
 }
 
@@ -57,6 +65,18 @@ describe("sessionReducer", () => {
   it("updates the stage while loading", () => {
     const next = sessionReducer(initialState, { type: "stage", stage: "Fetching objects" });
     expect(next).toEqual({ ...initialState, stage: "Fetching objects" });
+  });
+
+  it("keeps the panel a review command answered with", () => {
+    const next = sessionReducer(readyState(1), { type: "panel", panel: makePanel() });
+
+    expect(next).toMatchObject({ panel: { heading: "Review" } });
+  });
+
+  it("ignores a panel that arrives before the session is ready", () => {
+    const next = sessionReducer(initialState, { type: "panel", panel: makePanel() });
+
+    expect(next).toEqual(initialState);
   });
 
   it("clamps the cursor at the top of the file", () => {

--- a/apps/desktop/src/hooks/sessionReducer.ts
+++ b/apps/desktop/src/hooks/sessionReducer.ts
@@ -28,6 +28,14 @@ export type SessionState =
       composer: ComposerState;
       /** The review panel, absent for a snapshot that cannot be reviewed at all. */
       panel: ReviewPanelDto | null;
+      /**
+       * What a review command refused, shown inside the panel.
+       *
+       * A refused toggle or a cancel that could not be delivered is about the
+       * review, not the sitting. Replacing the Session with a failure screen
+       * would throw away the diff and whatever is unsent in the composer.
+       */
+      panelNotice: string | null;
     };
 
 export type ReadyState = Extract<SessionState, { status: "ready" }>;
@@ -49,6 +57,7 @@ export type SessionAction =
       panel: ReviewPanelDto | null;
     }
   | { type: "panel"; panel: ReviewPanelDto | null }
+  | { type: "panelNotice"; notice: string }
   | { type: "file"; file: FileDetailDto }
   | { type: "sidebar"; sidebar: SidebarDto }
   | { type: "move"; delta: 1 | -1; extend: boolean }
@@ -91,13 +100,32 @@ export function sessionReducer(state: SessionState, action: SessionAction): Sess
         drafts: action.file.drafts,
         composer: null,
         panel: action.panel,
+        panelNotice: null,
       };
 
-    case "panel":
+    case "panel": {
       if (state.status !== "ready") {
         return state;
       }
-      return { ...state, panel: action.panel };
+      // Several commands answer with the whole panel and they run at once. One
+      // that read the model before a change must not land on top of one that
+      // carries it, which would put a finished run back on screen as a running
+      // one with a live Cancel button.
+      const stale =
+        action.panel !== null &&
+        state.panel !== null &&
+        action.panel.revision < state.panel.revision;
+      if (stale) {
+        return state;
+      }
+      return { ...state, panel: action.panel, panelNotice: null };
+    }
+
+    case "panelNotice":
+      if (state.status !== "ready") {
+        return state;
+      }
+      return { ...state, panelNotice: action.notice };
 
     case "file":
       if (state.status !== "ready") {

--- a/apps/desktop/src/hooks/sessionReducer.ts
+++ b/apps/desktop/src/hooks/sessionReducer.ts
@@ -2,6 +2,7 @@ import type {
   AnchoredDraftDto,
   DraftsDto,
   FileDetailDto,
+  ReviewPanelDto,
   SessionFailureDto,
   SessionSnapshotDto,
   SidebarDto,
@@ -25,6 +26,8 @@ export type SessionState =
       anchor: number;
       drafts: DraftsDto;
       composer: ComposerState;
+      /** The review panel, absent for a snapshot that cannot be reviewed at all. */
+      panel: ReviewPanelDto | null;
     };
 
 export type ReadyState = Extract<SessionState, { status: "ready" }>;
@@ -39,7 +42,13 @@ export type SessionAction =
   | { type: "describe"; description: string }
   | { type: "stage"; stage: string }
   | { type: "failed"; failure: SessionFailureDto }
-  | { type: "ready"; snapshot: SessionSnapshotDto; file: FileDetailDto }
+  | {
+      type: "ready";
+      snapshot: SessionSnapshotDto;
+      file: FileDetailDto;
+      panel: ReviewPanelDto | null;
+    }
+  | { type: "panel"; panel: ReviewPanelDto | null }
   | { type: "file"; file: FileDetailDto }
   | { type: "sidebar"; sidebar: SidebarDto }
   | { type: "move"; delta: 1 | -1; extend: boolean }
@@ -81,7 +90,14 @@ export function sessionReducer(state: SessionState, action: SessionAction): Sess
         anchor: 0,
         drafts: action.file.drafts,
         composer: null,
+        panel: action.panel,
       };
+
+    case "panel":
+      if (state.status !== "ready") {
+        return state;
+      }
+      return { ...state, panel: action.panel };
 
     case "file":
       if (state.status !== "ready") {

--- a/apps/desktop/src/hooks/useSession.ts
+++ b/apps/desktop/src/hooks/useSession.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useReducer, useRef } from "react";
 import { Channel } from "@tauri-apps/api/core";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
-import type { DiffSideDto } from "../bindings";
+import type { DiffSideDto, ReviewPanelDto } from "../bindings";
 import { commands } from "../bindings";
 import { clamp } from "../lib/clamp";
 import { toFailure } from "../lib/failure";
@@ -20,6 +20,9 @@ export function useSession(description: string, isShowing: boolean) {
   stateRef.current = state;
   const hasOpened = useRef(false);
   const draftQueue = useDraftQueue(dispatch);
+  // Held here rather than read off the panel, because a second trigger can arrive
+  // before the first run's own "Running" panel has come back over the channel.
+  const isRunning = useRef(false);
 
   useEffect(() => {
     if (hasOpened.current) {
@@ -39,12 +42,16 @@ export function useSession(description: string, isShowing: boolean) {
           return;
         }
         const snapshot = opened.data;
-        commands.selectFile(0).then((selected) => {
+        Promise.all([commands.selectFile(0), commands.reviewPanel()]).then(([selected, panel]) => {
           if (selected.status === "error") {
             dispatch({ type: "failed", failure: toFailure(selected.error) });
             return;
           }
-          dispatch({ type: "ready", snapshot, file: selected.data });
+          if (panel.status === "error") {
+            dispatch({ type: "failed", failure: toFailure(panel.error) });
+            return;
+          }
+          dispatch({ type: "ready", snapshot, file: selected.data, panel: panel.data });
         });
       })
       .catch((error: unknown) => {
@@ -69,6 +76,69 @@ export function useSession(description: string, isShowing: boolean) {
         return;
       }
       dispatch({ type: "sidebar", sidebar: toggled.data });
+    });
+  }, []);
+
+  /**
+   * Starts a review, unless one is already in flight.
+   *
+   * The run holds the session in the backend for as long as the coding agent
+   * takes, so the panel arrives in pieces: the running state and every progress
+   * line over the channel, the outcome when the promise settles.
+   */
+  const runReview = useCallback(() => {
+    if (isRunning.current) {
+      return;
+    }
+    isRunning.current = true;
+
+    const channel = new Channel<ReviewPanelDto>();
+    channel.onmessage = (panel) => dispatch({ type: "panel", panel });
+
+    commands
+      .runReview(channel)
+      .then((finished) => {
+        isRunning.current = false;
+        if (finished.status === "error") {
+          dispatch({ type: "failed", failure: toFailure(finished.error) });
+          return;
+        }
+        dispatch({ type: "panel", panel: finished.data });
+      })
+      .catch((error: unknown) => {
+        isRunning.current = false;
+        dispatch({ type: "failed", failure: toFailure(error) });
+      });
+  }, []);
+
+  /** Asks the running review to stop. It ends at the backend's next step. */
+  const cancelReview = useCallback(() => {
+    commands.cancelReview().then((cancelled) => {
+      if (cancelled.status === "error") {
+        dispatch({ type: "failed", failure: toFailure(cancelled.error) });
+        return;
+      }
+      dispatch({ type: "panel", panel: cancelled.data });
+    });
+  }, []);
+
+  const toggleGuidanceSection = useCallback(() => {
+    commands.toggleGuidancePanel().then((toggled) => {
+      if (toggled.status === "error") {
+        dispatch({ type: "failed", failure: toFailure(toggled.error) });
+        return;
+      }
+      dispatch({ type: "panel", panel: toggled.data });
+    });
+  }, []);
+
+  const toggleGuidanceFile = useCallback((path: string) => {
+    commands.toggleGuidance(path).then((toggled) => {
+      if (toggled.status === "error") {
+        dispatch({ type: "failed", failure: toFailure(toggled.error) });
+        return;
+      }
+      dispatch({ type: "panel", panel: toggled.data });
     });
   }, []);
 
@@ -146,6 +216,11 @@ export function useSession(description: string, isShowing: boolean) {
         toggleViewed();
         return;
       }
+      if (event.metaKey && event.shiftKey && key === "r") {
+        event.preventDefault();
+        runReview();
+        return;
+      }
       if (event.metaKey && !event.shiftKey && key === "c") {
         event.preventDefault();
         const [start, end] = selectionRange(current);
@@ -174,7 +249,7 @@ export function useSession(description: string, isShowing: boolean) {
 
     window.addEventListener("keydown", handleKeydown);
     return () => window.removeEventListener("keydown", handleKeydown);
-  }, [state.status, isShowing, selectFile, toggleViewed]);
+  }, [state.status, isShowing, selectFile, toggleViewed, runReview]);
 
   return {
     state,
@@ -185,5 +260,9 @@ export function useSession(description: string, isShowing: boolean) {
     composerChange,
     composerDiscard,
     reanchorDraft,
+    runReview,
+    cancelReview,
+    toggleGuidanceSection,
+    toggleGuidanceFile,
   };
 }

--- a/apps/desktop/src/hooks/useSession.ts
+++ b/apps/desktop/src/hooks/useSession.ts
@@ -8,6 +8,11 @@ import { toFailure } from "../lib/failure";
 import { initialState, selectionRange, sessionReducer } from "./sessionReducer";
 import { useDraftQueue } from "./useDraftQueue";
 
+/** What a command answering with the review panel hands back. */
+type PanelResult =
+  | { status: "ok"; data: ReviewPanelDto | null }
+  | { status: "error"; error: unknown };
+
 /**
  * Loads one session and exposes every action the UI can take on it.
  *
@@ -92,55 +97,69 @@ export function useSession(description: string, isShowing: boolean) {
     }
     isRunning.current = true;
 
-    const channel = new Channel<ReviewPanelDto>();
-    channel.onmessage = (panel) => dispatch({ type: "panel", panel });
+    try {
+      const channel = new Channel<ReviewPanelDto>();
+      channel.onmessage = (panel) => dispatch({ type: "panel", panel });
 
-    commands
-      .runReview(channel)
-      .then((finished) => {
-        isRunning.current = false;
-        if (finished.status === "error") {
-          dispatch({ type: "failed", failure: toFailure(finished.error) });
-          return;
-        }
-        dispatch({ type: "panel", panel: finished.data });
-      })
-      .catch((error: unknown) => {
-        isRunning.current = false;
-        dispatch({ type: "failed", failure: toFailure(error) });
-      });
+      commands
+        .runReview(channel)
+        .then((finished) => {
+          if (finished.status === "error") {
+            dispatch({ type: "panelNotice", notice: toFailure(finished.error).summary });
+            return;
+          }
+          dispatch({ type: "panel", panel: finished.data });
+        })
+        .catch((error: unknown) => {
+          dispatch({ type: "panelNotice", notice: toFailure(error).summary });
+        })
+        .finally(() => {
+          isRunning.current = false;
+        });
+    } catch (error: unknown) {
+      // A throw before the promise exists would otherwise leave the flag set and
+      // no review startable for the rest of the sitting.
+      isRunning.current = false;
+      dispatch({ type: "panelNotice", notice: toFailure(error).summary });
+    }
   }, []);
+
+  /**
+   * Runs one of the panel's own commands, showing a refusal inside the panel.
+   *
+   * These are about the review, not the sitting. Replacing the Session with a
+   * failure screen would throw away the diff and whatever is unsent in the
+   * composer, over a toggle that did not take.
+   */
+  const onPanel = useCallback(
+    (call: Promise<PanelResult>) => {
+      call
+        .then((answered) => {
+          if (answered.status === "error") {
+            dispatch({ type: "panelNotice", notice: toFailure(answered.error).summary });
+            return;
+          }
+          dispatch({ type: "panel", panel: answered.data });
+        })
+        .catch((error: unknown) => {
+          dispatch({ type: "panelNotice", notice: toFailure(error).summary });
+        });
+    },
+    [],
+  );
 
   /** Asks the running review to stop. It ends at the backend's next step. */
-  const cancelReview = useCallback(() => {
-    commands.cancelReview().then((cancelled) => {
-      if (cancelled.status === "error") {
-        dispatch({ type: "failed", failure: toFailure(cancelled.error) });
-        return;
-      }
-      dispatch({ type: "panel", panel: cancelled.data });
-    });
-  }, []);
+  const cancelReview = useCallback(() => onPanel(commands.cancelReview()), [onPanel]);
 
-  const toggleGuidanceSection = useCallback(() => {
-    commands.toggleGuidancePanel().then((toggled) => {
-      if (toggled.status === "error") {
-        dispatch({ type: "failed", failure: toFailure(toggled.error) });
-        return;
-      }
-      dispatch({ type: "panel", panel: toggled.data });
-    });
-  }, []);
+  const toggleGuidanceSection = useCallback(
+    () => onPanel(commands.toggleGuidancePanel()),
+    [onPanel],
+  );
 
-  const toggleGuidanceFile = useCallback((path: string) => {
-    commands.toggleGuidance(path).then((toggled) => {
-      if (toggled.status === "error") {
-        dispatch({ type: "failed", failure: toFailure(toggled.error) });
-        return;
-      }
-      dispatch({ type: "panel", panel: toggled.data });
-    });
-  }, []);
+  const toggleGuidanceFile = useCallback(
+    (path: string) => onPanel(commands.toggleGuidance(path)),
+    [onPanel],
+  );
 
   const clickRow = useCallback((index: number) => dispatch({ type: "click", index }), []);
 

--- a/apps/desktop/src/test/fixtures.ts
+++ b/apps/desktop/src/test/fixtures.ts
@@ -131,6 +131,7 @@ export function makeGuidance(overrides: Partial<DiscoveredGuidance> = {}): Guida
 
 export function makePanel(overrides: Partial<ReviewPanelDto> = {}): ReviewPanelDto {
   return {
+    revision: 1,
     heading: "Review",
     guidance: makeGuidance(),
     run: { state: "Idle" },

--- a/apps/desktop/src/test/fixtures.ts
+++ b/apps/desktop/src/test/fixtures.ts
@@ -3,15 +3,21 @@ import type {
   DraftsDto,
   FileDetailDto,
   FileSummaryDto,
+  GuidanceDto,
+  GuidanceEntryDto,
   HomeGroupDto,
   HomeRepositoryDto,
   HomeRowDto,
   HomeSnapshotDto,
+  ReviewPanelDto,
   RowDto,
   SessionSnapshotDto,
   SidebarDto,
   StaleDraftDto,
 } from "../bindings";
+
+/** The guidance section once discovery has found something. */
+type DiscoveredGuidance = Extract<GuidanceDto, { kind: "Discovered" }>;
 
 export function makeRow(overrides: Partial<RowDto> = {}): RowDto {
   return {
@@ -97,6 +103,42 @@ export function makeSnapshot(overrides: Partial<SessionSnapshotDto> = {}): Sessi
     subtitle: "Diff virtualization demo",
     sidebar: makeSidebar(),
     warnings: [],
+    ...overrides,
+  };
+}
+
+export function makeGuidanceEntry(overrides: Partial<GuidanceEntryDto> = {}): GuidanceEntryDto {
+  return {
+    path: "AGENTS.md",
+    scope: "whole repository",
+    kilobytes: 2,
+    included: true,
+    ...overrides,
+  };
+}
+
+export function makeGuidance(overrides: Partial<DiscoveredGuidance> = {}): GuidanceDto {
+  return {
+    kind: "Discovered",
+    summary: "1 guidance file · 2 KB",
+    expanded: true,
+    entries: [makeGuidanceEntry()],
+    skipped: [],
+    excluded: null,
+    ...overrides,
+  };
+}
+
+export function makePanel(overrides: Partial<ReviewPanelDto> = {}): ReviewPanelDto {
+  return {
+    heading: "Review",
+    guidance: makeGuidance(),
+    run: { state: "Idle" },
+    note: {
+      heading: "No review has been run.",
+      detail: "Press Review to check this change against the repository's guidance.",
+    },
+    footer: null,
     ...overrides,
   };
 }

--- a/apps/desktop/src/tokens.css
+++ b/apps/desktop/src/tokens.css
@@ -65,6 +65,7 @@
   --gutter-width: 46px;
   --rail-width: 2px;
   --sidebar-width: 290px;
+  --review-panel-width: 340px;
   --file-row-height: 36px;
   --marker-width: 20px;
   --viewed-opacity: 0.55;

--- a/crates/app/src/review.rs
+++ b/crates/app/src/review.rs
@@ -90,6 +90,17 @@ pub struct ReviewModel {
     /// Open before the first run, because PLAN wants what will be sent seen before
     /// it is sent; collapsed afterwards, when the findings are what matters.
     pub(crate) guidance_expanded: bool,
+    /// How many times anything the review panel shows has changed.
+    ///
+    /// A front end learns about this model through whole-panel snapshots, from
+    /// several commands running at once. One that read the model before a change
+    /// can be delivered after a snapshot that carries it, which would put a
+    /// finished run back on screen as a running one. This is how the receiver
+    /// tells which of two snapshots is older.
+    ///
+    /// Saturating rather than wrapping, so it can never go backwards. Reaching the
+    /// ceiling would take billions of changes in one sitting.
+    revision: u32,
 }
 
 impl ReviewModel {
@@ -99,7 +110,18 @@ impl ReviewModel {
             run: ReviewRunState::Idle,
             selected_finding: None,
             guidance_expanded: true,
+            revision: 0,
         }
+    }
+
+    #[must_use]
+    pub const fn revision(&self) -> u32 {
+        self.revision
+    }
+
+    /// Records that something the panel shows has changed.
+    pub(crate) fn touch(&mut self) {
+        self.revision = self.revision.saturating_add(1);
     }
 
     #[must_use]

--- a/crates/app/src/session.rs
+++ b/crates/app/src/session.rs
@@ -237,7 +237,7 @@ impl SessionModel {
         let SessionPhase::Ready(review) = phase else {
             return FindingDisposition::Unknown;
         };
-        match review.session.accept_finding(id) {
+        let disposition = match review.session.accept_finding(id) {
             FindingAcceptance::Drafted { anchor, body } => {
                 let provenance = review
                     .session
@@ -282,7 +282,11 @@ impl SessionModel {
                 FindingDisposition::Summary { body: merged }
             }
             FindingAcceptance::Unknown => FindingDisposition::Unknown,
+        };
+        if !matches!(disposition, FindingDisposition::Unknown) {
+            review.touch();
         }
+        disposition
     }
 
     /// Rejects a claim and remembers the decision, so a re-run does not offer it
@@ -303,6 +307,7 @@ impl SessionModel {
         {
             sink.dismiss_finding(head_sha, &fingerprint);
         }
+        review.touch();
         true
     }
 
@@ -343,6 +348,7 @@ impl SessionModel {
             detail: "Starting...".to_owned(),
             cancel,
         };
+        review.touch();
     }
 
     /// Publishes the backend's latest progress line, reporting whether it changed.
@@ -362,6 +368,7 @@ impl SessionModel {
             return false;
         }
         *detail = line;
+        review.touch();
         true
     }
 
@@ -387,6 +394,7 @@ impl SessionModel {
         // The disclosure has served its purpose; the findings are what the reviewer
         // wants the space for now. The summary line stays visible either way.
         review.guidance_expanded = false;
+        review.touch();
     }
 
     /// Reports a run that produced nothing, with what to do about it.
@@ -398,6 +406,7 @@ impl SessionModel {
             summary: summary.into(),
             remediation,
         };
+        review.touch();
     }
 
     /// Asks the running review to stop.
@@ -414,6 +423,7 @@ impl SessionModel {
             return;
         };
         review.guidance_expanded = !review.guidance_expanded;
+        review.touch();
     }
 
     /// Turns one guidance file on or off for the next run.
@@ -424,7 +434,11 @@ impl SessionModel {
         let SessionPhase::Ready(review) = &mut self.phase else {
             return false;
         };
-        review.session.toggle_guidance(path).is_some()
+        let toggled = review.session.toggle_guidance(path).is_some();
+        if toggled {
+            review.touch();
+        }
+        toggled
     }
 
     /// Switches the displayed file, reporting whether it moved.
@@ -1061,6 +1075,64 @@ mod tests {
 
         model.cancel_review();
         assert!(cancel.load(Ordering::Relaxed));
+    }
+
+    /// Asserts the revision moved, and hands back the new one.
+    fn bumped(model: &SessionModel, previous: u32, what: &str) -> u32 {
+        let revision = review(model).revision();
+        assert!(revision > previous, "{what} did not bump the revision");
+        revision
+    }
+
+    /// The panel reaches a front end from several commands at once, and one that
+    /// read the model before a change can be delivered after it. Dropping the
+    /// stale one needs a number that only ever goes up.
+    #[test]
+    fn every_change_the_panel_shows_bumps_the_revision() {
+        let mut session = repository_backed_session(&["src/review.rs"]);
+        session.set_guidance(guidance_selection());
+        let mut model = loaded_model(session, None, None);
+        let mut revision = review(&model).revision();
+
+        model.toggle_guidance_panel();
+        revision = bumped(&model, revision, "opening the guidance section");
+
+        assert!(model.toggle_guidance("AGENTS.md"));
+        revision = bumped(&model, revision, "turning a guidance file off");
+
+        model.review_started(Arc::new(AtomicBool::new(false)));
+        revision = bumped(&model, revision, "starting a run");
+
+        assert!(model.review_progress("Reading the diff"));
+        revision = bumped(&model, revision, "a progress line");
+
+        assert!(!model.review_progress("Reading the diff"));
+        assert_eq!(
+            review(&model).revision(),
+            revision,
+            "a line that did not move is not a change"
+        );
+
+        model.review_failed("claude is not installed", None);
+        revision = bumped(&model, revision, "a failed run");
+
+        model.review_started(Arc::new(AtomicBool::new(false)));
+        revision = bumped(&model, revision, "starting a second run");
+
+        model.review_finished(Findings::default(), Vec::new());
+        revision = bumped(&model, revision, "a completed run");
+
+        let id = give_one_finding(&mut model, "risky() is unchecked");
+        revision = bumped(&model, revision, "findings arriving");
+
+        assert!(model.dismiss_finding(id));
+        revision = bumped(&model, revision, "dismissing a finding");
+
+        let id = give_one_finding(&mut model, "still risky");
+        revision = bumped(&model, revision, "findings arriving again");
+
+        assert_eq!(model.accept_finding(id), FindingDisposition::Drafted);
+        bumped(&model, revision, "accepting a finding");
     }
 
     /// The panel shows the latest line, so a report that arrives once the run is

--- a/crates/app/src/session.rs
+++ b/crates/app/src/session.rs
@@ -1063,6 +1063,60 @@ mod tests {
         assert!(cancel.load(Ordering::Relaxed));
     }
 
+    /// The panel shows the latest line, so a report that arrives once the run is
+    /// over must not make a finished review look like it is still going.
+    #[test]
+    fn progress_lands_only_while_a_run_is_in_flight() {
+        let mut model = ready_model(None);
+
+        assert!(
+            !model.review_progress("Starting claude"),
+            "nothing is running yet"
+        );
+
+        model.review_started(Arc::new(AtomicBool::new(false)));
+        assert!(model.review_progress("Starting claude"));
+        assert!(
+            !model.review_progress("Starting claude"),
+            "the same line again is not worth a redraw"
+        );
+        let ReviewRunState::Running { detail, .. } = review(&model).run() else {
+            panic!("the run should be in flight");
+        };
+        assert_eq!(detail, "Starting claude");
+
+        model.review_finished(Findings::default(), Vec::new());
+        assert!(!model.review_progress("Reading the diff"));
+    }
+
+    /// A run that skipped files must not present itself as having covered the
+    /// change, and a run that suppressed claims must not look like one that
+    /// found nothing.
+    #[test]
+    fn a_completed_run_keeps_its_counts_and_what_it_did_not_see() {
+        let mut model = ready_model(None);
+        model.review_started(Arc::new(AtomicBool::new(false)));
+
+        model.review_finished(
+            Findings::default(),
+            vec!["vendor/lib.rs".to_owned(), "huge.json".to_owned()],
+        );
+
+        let ReviewRunState::Complete {
+            accepted,
+            rejected,
+            suppressed,
+            unreviewed,
+        } = review(&model).run()
+        else {
+            panic!("the run should have completed");
+        };
+        assert_eq!(*accepted, 0);
+        assert_eq!(*rejected, 0);
+        assert_eq!(*suppressed, 0);
+        assert_eq!(unreviewed, &["vendor/lib.rs", "huge.json"]);
+    }
+
     #[test]
     fn a_failed_run_keeps_its_remediation() {
         let mut model = ready_model(None);

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -148,7 +148,13 @@ fn attach_guidance(session: &mut ReviewSession) {
     session.set_guidance(review::into_selection(&discovered, &paths));
 }
 
-fn repository_root(source: &SessionSource) -> Option<&Path> {
+/// The clone a session was opened out of, when it came from one.
+///
+/// `None` for the generated fixture, which has no repository and so no anchors to
+/// validate findings against. [`run_review`] refuses such a session, and nothing
+/// that needs a working directory may quietly invent one for it.
+#[must_use]
+pub fn repository_root(source: &SessionSource) -> Option<&Path> {
     match source {
         SessionSource::Demo => None,
         SessionSource::LocalComparison {


### PR DESCRIPTION
Closes #28

The desktop Session could show a diff and take drafts but had no guided review, the GPUI app's main feature. This is the first half of migration stage 4, the Guidance panel and the review run, ending with a run that completes and reports its counts.

What changed:
- A right-hand review panel in the Session, showing every discovered Guidance file with scope and size, an include toggle per file, the skipped files with reasons, a summary line, and a plain sentence when nothing was found
- Cmd-Shift-R or the Review button runs the Claude coding agent at the repository root on a blocking task, with progress lines over a channel, Cancel, and the failed and completed states, copy matched to the GPUI panel
- Tauri commands are thin adapters over the session model's existing review methods; a second trigger during a run starts nothing at the model level
- The panel carries a revision so a late command answer cannot resurrect a finished run, and a refused command shows a notice in the panel instead of replacing the Session
- The generated fixture has no panel and a run on it refuses before reaching a backend

Notes:
Stacked on #27 and retargets to main when that merges. Start with the run orchestration in the commands module, then the panel projection. Findings themselves are #29. A completed run with real findings could not be checked from an agent session because the injected ANTHROPIC_API_KEY shadows the subscription on this machine; please run one review by hand. Cancel during a running agent does not interrupt it, which is parity and filed as #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189um4LrckqAAq5fgnixT1p
