### PR TITLE
Act on review findings in the desktop Session

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -597,7 +597,7 @@ fn accept_finding_on_model(
 ) -> Option<dto::AcceptOutcomeDto> {
     let mut guard = lock(model);
     let finding_id = FindingId(id);
-    // Read before the call: an occupied disposition leaves the finding pending,
+    // Read before the call. An occupied disposition leaves the finding pending,
     // but its proposed text is needed for the confirmation regardless.
     let proposed = match guard.phase() {
         SessionPhase::Ready(review) => review
@@ -615,31 +615,29 @@ fn accept_finding_on_model(
 /// Forces a finding onto its anchor, overwriting the reviewer's own draft there.
 ///
 /// Reached only once the reviewer has chosen to replace what they wrote, after
-/// `accept_finding` answered with the confirmation.
+/// `accept_finding` answered with the confirmation. Refused, with an `Unknown`
+/// disposition, for any id other than the one the reviewer was actually asked
+/// about.
 fn overwrite_finding_on_model(
     model: &Mutex<app::SessionModel>,
     id: u32,
 ) -> Option<dto::AcceptOutcomeDto> {
     let mut guard = lock(model);
-    let disposition = if guard.overwrite_finding(FindingId(id)) {
-        app::FindingDisposition::Drafted
-    } else {
-        app::FindingDisposition::Unknown
-    };
+    let disposition = guard.overwrite_finding(FindingId(id));
     accept_outcome(&guard, &disposition, None)
 }
 
-/// The reviewer's own text and the finding's proposal, when accepting answered
-/// with [`app::FindingDisposition::Composer`].
+/// The reviewer's own text, the finding's proposal, and where it sits, when
+/// accepting answered with [`app::FindingDisposition::Composer`].
 ///
-/// The GPUI composer merges both into one seed string to open pre-filled; the
-/// desktop panel needs them apart to ask its replace-or-keep question, so they
-/// are read straight off the session instead.
+/// The GPUI composer merges the two texts into one seed string to open
+/// pre-filled; the desktop panel needs them apart to ask its replace-or-keep
+/// question, so they are read straight off the session instead.
 fn occupied_texts(
     model: &app::SessionModel,
     disposition: &app::FindingDisposition,
     proposed: Option<String>,
-) -> Option<(String, String)> {
+) -> Option<(String, String, AnchorLocation)> {
     let app::FindingDisposition::Composer { location, .. } = disposition else {
         return None;
     };
@@ -649,9 +647,12 @@ fn occupied_texts(
     let existing = review
         .session()
         .draft_at(location.file, location.row)
-        .map(|draft| draft.body.clone())
-        .unwrap_or_default();
-    Some((existing, proposed.unwrap_or_default()))
+        .expect("a Composer disposition means the anchor holds a draft")
+        .body
+        .clone();
+    let proposed = proposed
+        .expect("a Composer disposition means the finding still holds its proposed comment");
+    Some((existing, proposed, *location))
 }
 
 /// Bundles the panel and the selected file's drafts with a mapped disposition.
@@ -660,7 +661,7 @@ fn occupied_texts(
 fn accept_outcome(
     model: &app::SessionModel,
     disposition: &app::FindingDisposition,
-    occupied: Option<(String, String)>,
+    occupied: Option<(String, String, AnchorLocation)>,
 ) -> Option<dto::AcceptOutcomeDto> {
     let panel = panel_of(model)?;
     let selected = match model.phase() {
@@ -3391,7 +3392,12 @@ mod tests {
 
         let outcome = accept_finding_on_model(&model, id).expect("the session can be reviewed");
 
-        let dto::AcceptDispositionDto::Occupied { existing, proposed } = outcome.disposition else {
+        let dto::AcceptDispositionDto::Occupied {
+            existing,
+            proposed,
+            location,
+        } = outcome.disposition
+        else {
             panic!(
                 "expected an occupied disposition, got {:?}",
                 outcome.disposition
@@ -3399,6 +3405,7 @@ mod tests {
         };
         assert_eq!(existing, "mine");
         assert_eq!(proposed, "Handle the failure here.");
+        assert_eq!(location, dto::FindingLocationDto { file: 0, row: 1 });
         assert_eq!(outcome.panel.findings.len(), 1, "still pending");
     }
 
@@ -3499,13 +3506,22 @@ mod tests {
     fn the_footer_survives_a_run_that_also_found_findings() {
         let repository = guided_repository();
         let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
-        let backend = FakeBackend::new(Vec::new(), Ok(vec![raw_finding_on(2, "unchecked index")]));
+        // A line outside the diff is refused, so the run keeps one claim and
+        // rejects another, which is the shape the criterion is about.
+        let backend = FakeBackend::new(
+            Vec::new(),
+            Ok(vec![
+                raw_finding_on(2, "unchecked index"),
+                raw_finding_on(9999, "impossible"),
+            ]),
+        );
 
         let (finished, _) = run_with(&model, &backend);
 
         let panel = finished.expect("the session can be reviewed");
         assert_eq!(panel.findings.len(), 1);
         let footer = panel.footer.expect("a partial review says it was partial");
+        assert_eq!(footer.refused, Some("1 claim(s) refused".to_owned()));
         assert_eq!(footer.unreviewed, vec!["vendor/lib.rs".to_owned()]);
     }
 }

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -11,7 +11,10 @@ use std::{
 use app::{
     Opened, PullRequestId, RepositoryOutcome, SessionPhase, SettingsWrite, Showing, lock, try_lock,
 };
-use domain::{DiffSide, ReviewBackend, ReviewError, ReviewEventSink, ReviewProgress};
+use domain::{
+    AnchorLocation, DiffSide, FindingId, ReviewBackend, ReviewError, ReviewEventSink,
+    ReviewProgress,
+};
 use review::{Agent, CodingAgent};
 use session::{ReviewStorage, SessionRequest};
 use tauri::ipc::Channel;
@@ -43,6 +46,11 @@ pub fn specta_builder() -> tauri_specta::Builder<tauri::Wry> {
         cancel_review,
         toggle_guidance_panel,
         toggle_guidance,
+        accept_finding,
+        overwrite_finding,
+        dismiss_finding,
+        reveal_finding,
+        select_next_finding,
     ])
 }
 
@@ -580,6 +588,136 @@ fn toggle_guidance_on_model(
     Ok(panel_of(&guard))
 }
 
+/// Accepts a finding, turning it into a draft where the model allows it.
+///
+/// `None` for a session that has no panel to answer with at all.
+fn accept_finding_on_model(
+    model: &Mutex<app::SessionModel>,
+    id: u32,
+) -> Option<dto::AcceptOutcomeDto> {
+    let mut guard = lock(model);
+    let finding_id = FindingId(id);
+    // Read before the call: an occupied disposition leaves the finding pending,
+    // but its proposed text is needed for the confirmation regardless.
+    let proposed = match guard.phase() {
+        SessionPhase::Ready(review) => review
+            .session()
+            .findings()
+            .get(finding_id)
+            .map(|finding| finding.proposed_comment.clone()),
+        SessionPhase::Loading { .. } | SessionPhase::Failed(_) => None,
+    };
+    let disposition = guard.accept_finding(finding_id);
+    let occupied = occupied_texts(&guard, &disposition, proposed);
+    accept_outcome(&guard, &disposition, occupied)
+}
+
+/// Forces a finding onto its anchor, overwriting the reviewer's own draft there.
+///
+/// Reached only once the reviewer has chosen to replace what they wrote, after
+/// `accept_finding` answered with the confirmation.
+fn overwrite_finding_on_model(
+    model: &Mutex<app::SessionModel>,
+    id: u32,
+) -> Option<dto::AcceptOutcomeDto> {
+    let mut guard = lock(model);
+    let disposition = if guard.overwrite_finding(FindingId(id)) {
+        app::FindingDisposition::Drafted
+    } else {
+        app::FindingDisposition::Unknown
+    };
+    accept_outcome(&guard, &disposition, None)
+}
+
+/// The reviewer's own text and the finding's proposal, when accepting answered
+/// with [`app::FindingDisposition::Composer`].
+///
+/// The GPUI composer merges both into one seed string to open pre-filled; the
+/// desktop panel needs them apart to ask its replace-or-keep question, so they
+/// are read straight off the session instead.
+fn occupied_texts(
+    model: &app::SessionModel,
+    disposition: &app::FindingDisposition,
+    proposed: Option<String>,
+) -> Option<(String, String)> {
+    let app::FindingDisposition::Composer { location, .. } = disposition else {
+        return None;
+    };
+    let SessionPhase::Ready(review) = model.phase() else {
+        unreachable!("a Composer disposition means the session is Ready")
+    };
+    let existing = review
+        .session()
+        .draft_at(location.file, location.row)
+        .map(|draft| draft.body.clone())
+        .unwrap_or_default();
+    Some((existing, proposed.unwrap_or_default()))
+}
+
+/// Bundles the panel and the selected file's drafts with a mapped disposition.
+///
+/// `None` for a session that has no panel to answer with at all.
+fn accept_outcome(
+    model: &app::SessionModel,
+    disposition: &app::FindingDisposition,
+    occupied: Option<(String, String)>,
+) -> Option<dto::AcceptOutcomeDto> {
+    let panel = panel_of(model)?;
+    let selected = match model.phase() {
+        SessionPhase::Ready(review) => review.session().selected_file_index(),
+        SessionPhase::Loading { .. } | SessionPhase::Failed(_) => {
+            unreachable!("panel_of answered, so the session is Ready")
+        }
+    };
+    Some(dto::AcceptOutcomeDto {
+        panel,
+        drafts: drafts_snapshot(model, selected),
+        disposition: dto::project_disposition(disposition, occupied),
+    })
+}
+
+/// Dismisses a finding, recording the decision so a later run suppresses the
+/// same claim.
+fn dismiss_finding_on_model(
+    model: &Mutex<app::SessionModel>,
+    id: u32,
+) -> Option<dto::ReviewPanelDto> {
+    let mut guard = lock(model);
+    guard.dismiss_finding(FindingId(id));
+    panel_of(&guard)
+}
+
+/// Selects a finding and says where the diff should scroll to show it.
+fn reveal_finding_on_model(
+    model: &Mutex<app::SessionModel>,
+    id: u32,
+) -> Option<dto::RevealOutcomeDto> {
+    let mut guard = lock(model);
+    let location = guard.reveal_finding(FindingId(id));
+    reveal_outcome(&guard, location)
+}
+
+/// Moves the selection to the finding after the one selected, wrapping to the
+/// first, and says where the diff should scroll to show it.
+fn select_next_finding_on_model(model: &Mutex<app::SessionModel>) -> Option<dto::RevealOutcomeDto> {
+    let mut guard = lock(model);
+    let next = guard.review().and_then(app::ReviewModel::next_finding);
+    let location = next.and_then(|id| guard.reveal_finding(id));
+    reveal_outcome(&guard, location)
+}
+
+/// Bundles the panel with where a reveal should scroll the diff to.
+fn reveal_outcome(
+    model: &app::SessionModel,
+    location: Option<AnchorLocation>,
+) -> Option<dto::RevealOutcomeDto> {
+    let panel = panel_of(model)?;
+    Some(dto::RevealOutcomeDto {
+        panel,
+        location: location.map(Into::into),
+    })
+}
+
 /// Loads the review session the window was opened with, reporting each stage on
 /// `on_stage` as it goes.
 ///
@@ -1086,6 +1224,93 @@ pub fn toggle_guidance(
 ) -> Result<Option<dto::ReviewPanelDto>, dto::SessionFailureDto> {
     let model = session_model(&state)?;
     toggle_guidance_on_model(&model, &path)
+}
+
+/// Accepts a finding, turning it into a draft where the model allows it.
+///
+/// Refuses to overwrite the reviewer's own draft. The disposition answers
+/// `Occupied` instead, and the panel asks whether to replace it.
+///
+/// # Errors
+///
+/// Returns a failure when no session is open.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn accept_finding(
+    state: tauri::State<'_, AppRoot>,
+    id: u32,
+) -> Result<Option<dto::AcceptOutcomeDto>, dto::SessionFailureDto> {
+    let model = session_model(&state)?;
+    Ok(accept_finding_on_model(&model, id))
+}
+
+/// Forces a finding onto its anchor, overwriting the reviewer's own draft there.
+///
+/// Reached only once the reviewer has chosen to replace what they wrote, after
+/// `accept_finding` answered with the confirmation.
+///
+/// # Errors
+///
+/// Returns a failure when no session is open.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn overwrite_finding(
+    state: tauri::State<'_, AppRoot>,
+    id: u32,
+) -> Result<Option<dto::AcceptOutcomeDto>, dto::SessionFailureDto> {
+    let model = session_model(&state)?;
+    Ok(overwrite_finding_on_model(&model, id))
+}
+
+/// Dismisses a finding, recording the decision so a later run suppresses the
+/// same claim.
+///
+/// # Errors
+///
+/// Returns a failure when no session is open.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn dismiss_finding(
+    state: tauri::State<'_, AppRoot>,
+    id: u32,
+) -> Result<Option<dto::ReviewPanelDto>, dto::SessionFailureDto> {
+    let model = session_model(&state)?;
+    Ok(dismiss_finding_on_model(&model, id))
+}
+
+/// Selects a finding, scrolling the diff to its anchor and selecting the row.
+///
+/// # Errors
+///
+/// Returns a failure when no session is open.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn reveal_finding(
+    state: tauri::State<'_, AppRoot>,
+    id: u32,
+) -> Result<Option<dto::RevealOutcomeDto>, dto::SessionFailureDto> {
+    let model = session_model(&state)?;
+    Ok(reveal_finding_on_model(&model, id))
+}
+
+/// Moves the selection to the finding after the one selected, wrapping to the
+/// first, and scrolls the diff to show it.
+///
+/// # Errors
+///
+/// Returns a failure when no session is open.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn select_next_finding(
+    state: tauri::State<'_, AppRoot>,
+) -> Result<Option<dto::RevealOutcomeDto>, dto::SessionFailureDto> {
+    let model = session_model(&state)?;
+    Ok(select_next_finding_on_model(&model))
 }
 
 #[cfg(test)]
@@ -3092,5 +3317,195 @@ mod tests {
             .note
             .expect("the failure is what the panel has to say");
         assert_eq!(note.heading, "claude is not installed");
+    }
+
+    /// A raw finding on `line` of feature.txt, which `temporary_repository` makes
+    /// commentable on the right side.
+    fn raw_finding_on(line: u32, title: &str) -> domain::RawFinding {
+        domain::RawFinding {
+            location: Some(domain::RawLocation {
+                path: "feature.txt".into(),
+                side: DiffSide::Right,
+                line,
+                start_line: None,
+            }),
+            severity: domain::Severity::Warning,
+            confidence: 0.9,
+            title: title.to_owned(),
+            rationale: "because".to_owned(),
+            proposed_comment: "Handle the failure here.".to_owned(),
+            guidance_sources: vec![domain::GuidanceCitation {
+                path: "AGENTS.md".into(),
+                content_hash: "hash".into(),
+            }],
+        }
+    }
+
+    /// Runs `model` against a backend reporting one hand-built finding, returning
+    /// its id from the panel the run ends with.
+    fn seed_one_finding(model: &Mutex<app::SessionModel>, line: u32, title: &str) -> u32 {
+        let backend = FakeBackend::new(Vec::new(), Ok(vec![raw_finding_on(line, title)]));
+        let (finished, _) = run_with(model, &backend);
+        finished.expect("the session can be reviewed").findings[0].id
+    }
+
+    /// The finding named `title` on a panel, or a panic saying it was not there.
+    fn finding_named<'a>(panel: &'a dto::ReviewPanelDto, title: &str) -> &'a dto::FindingDto {
+        panel
+            .findings
+            .iter()
+            .find(|finding| finding.title == title)
+            .unwrap_or_else(|| panic!("no finding named {title} on the panel"))
+    }
+
+    #[test]
+    fn accepting_a_finding_drafts_it_and_leaves_the_list() {
+        let repository = temporary_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+        let id = seed_one_finding(&model, 2, "unchecked index");
+
+        let outcome = accept_finding_on_model(&model, id).expect("the session can be reviewed");
+
+        assert!(matches!(
+            outcome.disposition,
+            dto::AcceptDispositionDto::Drafted
+        ));
+        assert!(outcome.panel.findings.is_empty(), "acted on");
+        let draft = outcome
+            .drafts
+            .anchored
+            .iter()
+            .find(|draft| draft.row == 1)
+            .expect("the finding's row has a draft");
+        assert_eq!(draft.body, "Handle the failure here.");
+        assert!(draft.is_proposed);
+    }
+
+    /// Acceptance must never overwrite; the panel is asked instead.
+    #[test]
+    fn accepting_onto_an_occupied_line_asks_before_overwriting() {
+        let repository = temporary_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+        edit_draft_on_model(&model, 0, 1, 1, "mine".to_owned()).expect("session is ready");
+        let id = seed_one_finding(&model, 2, "unchecked index");
+
+        let outcome = accept_finding_on_model(&model, id).expect("the session can be reviewed");
+
+        let dto::AcceptDispositionDto::Occupied { existing, proposed } = outcome.disposition else {
+            panic!(
+                "expected an occupied disposition, got {:?}",
+                outcome.disposition
+            );
+        };
+        assert_eq!(existing, "mine");
+        assert_eq!(proposed, "Handle the failure here.");
+        assert_eq!(outcome.panel.findings.len(), 1, "still pending");
+    }
+
+    #[test]
+    fn replacing_an_occupied_findings_draft_overwrites_it_with_the_proposal() {
+        let repository = temporary_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+        edit_draft_on_model(&model, 0, 1, 1, "mine".to_owned()).expect("session is ready");
+        let id = seed_one_finding(&model, 2, "unchecked index");
+        accept_finding_on_model(&model, id).expect("the session can be reviewed");
+
+        let outcome = overwrite_finding_on_model(&model, id).expect("the session can be reviewed");
+
+        assert!(matches!(
+            outcome.disposition,
+            dto::AcceptDispositionDto::Drafted
+        ));
+        assert!(outcome.panel.findings.is_empty(), "acted on");
+        let draft = outcome
+            .drafts
+            .anchored
+            .iter()
+            .find(|draft| draft.row == 1)
+            .expect("the finding's row has a draft");
+        assert_eq!(draft.body, "Handle the failure here.");
+        assert!(draft.is_proposed);
+    }
+
+    #[test]
+    fn replacing_an_unknown_finding_changes_nothing() {
+        let repository = temporary_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+
+        let outcome = overwrite_finding_on_model(&model, 7).expect("the session can be reviewed");
+
+        assert!(matches!(
+            outcome.disposition,
+            dto::AcceptDispositionDto::Unknown
+        ));
+    }
+
+    #[test]
+    fn dismissing_a_finding_removes_it_and_a_second_run_suppresses_it() {
+        let repository = temporary_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+        let id = seed_one_finding(&model, 2, "unchecked index");
+
+        let panel = dismiss_finding_on_model(&model, id).expect("the session can be reviewed");
+        assert!(panel.findings.is_empty());
+
+        let backend = FakeBackend::new(Vec::new(), Ok(vec![raw_finding_on(2, "unchecked index")]));
+        let (finished, _) = run_with(&model, &backend);
+
+        let panel = finished.expect("the session can be reviewed");
+        assert!(panel.findings.is_empty(), "the claim was suppressed");
+        let dto::ReviewRunDto::Complete { suppressed, .. } = panel.run else {
+            panic!("expected a completed run, got {:?}", panel.run);
+        };
+        assert_eq!(suppressed, 1);
+    }
+
+    #[test]
+    fn revealing_a_finding_selects_it_and_says_where_to_scroll() {
+        let repository = temporary_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+        let id = seed_one_finding(&model, 2, "unchecked index");
+
+        let outcome = reveal_finding_on_model(&model, id).expect("the session can be reviewed");
+
+        assert!(outcome.panel.findings[0].is_selected);
+        assert_eq!(
+            outcome.location,
+            Some(dto::FindingLocationDto { file: 0, row: 1 })
+        );
+    }
+
+    #[test]
+    fn selecting_the_next_finding_wraps_around() {
+        let repository = temporary_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+        let backend = FakeBackend::new(
+            Vec::new(),
+            Ok(vec![
+                raw_finding_on(2, "first"),
+                raw_finding_on(4, "second"),
+            ]),
+        );
+        run_with(&model, &backend);
+
+        let moved = select_next_finding_on_model(&model).expect("the session can be reviewed");
+        assert!(finding_named(&moved.panel, "second").is_selected);
+
+        let wrapped = select_next_finding_on_model(&model).expect("the session can be reviewed");
+        assert!(finding_named(&wrapped.panel, "first").is_selected);
+    }
+
+    #[test]
+    fn the_footer_survives_a_run_that_also_found_findings() {
+        let repository = guided_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+        let backend = FakeBackend::new(Vec::new(), Ok(vec![raw_finding_on(2, "unchecked index")]));
+
+        let (finished, _) = run_with(&model, &backend);
+
+        let panel = finished.expect("the session can be reviewed");
+        assert_eq!(panel.findings.len(), 1);
+        let footer = panel.footer.expect("a partial review says it was partial");
+        assert_eq!(footer.unreviewed, vec!["vendor/lib.rs".to_owned()]);
     }
 }

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -319,7 +319,7 @@ pub struct FindingDto {
     pub severity: SeverityDto,
     /// Rounded to a whole percentage; a fraction reads as odd precision to a
     /// reviewer deciding whether to spend attention on it.
-    pub confidence: u32,
+    pub confidence_percent: u32,
     pub title: String,
     pub rationale: String,
     /// Guidance paths this finding cites, e.g. "AGENTS.md".
@@ -366,8 +366,13 @@ pub enum AcceptDispositionDto {
     /// Became a draft at the anchor, which the diff now shows the mark for.
     Drafted,
     /// The anchor already held the reviewer's own draft. Neither text was
-    /// written; the panel asks whether to replace it.
-    Occupied { existing: String, proposed: String },
+    /// written; the panel asks whether to replace it. `location` is where
+    /// accepting it should first reveal, as the GPUI composer path does.
+    Occupied {
+        existing: String,
+        proposed: String,
+        location: FindingLocationDto,
+    },
     /// The finding was about the change as a whole, so it went into the summary.
     Summary,
     /// No pending finding had that id.
@@ -376,22 +381,26 @@ pub enum AcceptDispositionDto {
 
 /// Maps what accepting a finding left for the panel to do.
 ///
-/// `occupied` is the reviewer's own text and the finding's proposal, read off the
-/// session by the caller; present exactly when `disposition` is
-/// [`FindingDisposition::Composer`], which the GPUI composer opens pre-filled
-/// with and the desktop panel asks a plain replace-or-keep question about
-/// instead.
+/// `occupied` is the reviewer's own text, the finding's proposal, and where it
+/// sits, read off the session by the caller; present exactly when
+/// `disposition` is [`FindingDisposition::Composer`], which the GPUI composer
+/// opens pre-filled with and the desktop panel asks a plain replace-or-keep
+/// question about instead.
 #[must_use]
 pub fn project_disposition(
     disposition: &FindingDisposition,
-    occupied: Option<(String, String)>,
+    occupied: Option<(String, String, AnchorLocation)>,
 ) -> AcceptDispositionDto {
     match disposition {
         FindingDisposition::Drafted => AcceptDispositionDto::Drafted,
         FindingDisposition::Composer { .. } => {
-            let (existing, proposed) =
-                occupied.expect("an occupied disposition always carries its two texts");
-            AcceptDispositionDto::Occupied { existing, proposed }
+            let (existing, proposed, location) = occupied
+                .expect("an occupied disposition always carries its two texts and location");
+            AcceptDispositionDto::Occupied {
+                existing,
+                proposed,
+                location: location.into(),
+            }
         }
         FindingDisposition::Summary { .. } => AcceptDispositionDto::Summary,
         FindingDisposition::Unknown => AcceptDispositionDto::Unknown,
@@ -859,8 +868,9 @@ pub fn project_drafts(session: &ReviewSession, file_index: usize) -> DraftsDto {
 /// The Session's review panel, or `None` when this session has nothing to put one
 /// on.
 ///
-/// Mirrors `crates/ui/src/findings.rs`, which is the parity target: the same copy
-/// in the same order, read off the same model.
+/// Mirrors `crates/ui/src/findings.rs` for the guidance, run, and footer copy,
+/// read off the same model in the same order. The finding card goes further,
+/// adding the rationale and the proposing backend that the GPUI list omits.
 #[must_use]
 pub fn project_panel(review: &ReviewModel) -> Option<ReviewPanelDto> {
     if !review.findings_panel_visible() {
@@ -893,7 +903,7 @@ fn project_finding(finding: &Finding, selected: Option<domain::FindingId>) -> Fi
     FindingDto {
         id: finding.id.0,
         severity: finding.severity.into(),
-        confidence: confidence_percent(finding.confidence),
+        confidence_percent: confidence_percent(finding.confidence),
         title: finding.title.clone(),
         rationale: finding.rationale.clone(),
         citations: finding

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -4,10 +4,10 @@
 //! `&SessionFailure`) and returns a value, which is what keeps them testable
 //! without a running app.
 
-use app::{PullRequestId, ReviewModel, ReviewRunState};
+use app::{FindingDisposition, PullRequestId, ReviewModel, ReviewRunState};
 use domain::{
-    DiffFile, DiffLineKind, DiffSide, EmptyDiffReason, FileStatus, GuidanceSelection,
-    ReviewSession, SessionFailure, SessionSource,
+    AnchorLocation, DiffFile, DiffLineKind, DiffSide, EmptyDiffReason, FileStatus, Finding,
+    GuidanceSelection, ReviewSession, SessionFailure, SessionSource, Severity,
 };
 use serde::{Deserialize, Serialize};
 
@@ -278,6 +278,59 @@ pub struct PanelNoteDto {
     pub detail: Option<String>,
 }
 
+/// How much a finding claims to matter.
+#[derive(Clone, Copy, Debug, Serialize, specta::Type)]
+pub enum SeverityDto {
+    Info,
+    Warning,
+    Error,
+}
+
+impl From<Severity> for SeverityDto {
+    fn from(severity: Severity) -> Self {
+        match severity {
+            Severity::Info => Self::Info,
+            Severity::Warning => Self::Warning,
+            Severity::Error => Self::Error,
+        }
+    }
+}
+
+/// Where a finding's anchor lands in the displayed diff.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, specta::Type)]
+pub struct FindingLocationDto {
+    pub file: u32,
+    pub row: u32,
+}
+
+impl From<AnchorLocation> for FindingLocationDto {
+    fn from(location: AnchorLocation) -> Self {
+        Self {
+            file: as_u32(location.file),
+            row: as_u32(location.row),
+        }
+    }
+}
+
+/// A suggestion a review backend proposed, waiting for the reviewer to act on it.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct FindingDto {
+    pub id: u32,
+    pub severity: SeverityDto,
+    /// Rounded to a whole percentage; a fraction reads as odd precision to a
+    /// reviewer deciding whether to spend attention on it.
+    pub confidence: u32,
+    pub title: String,
+    pub rationale: String,
+    /// Guidance paths this finding cites, e.g. "AGENTS.md".
+    pub citations: Vec<String>,
+    /// The backend that proposed this, e.g. "claude-code".
+    pub origin: String,
+    /// "path:line", absent for a finding about the change as a whole.
+    pub position: Option<String>,
+    pub is_selected: bool,
+}
+
 /// The caveats under the panel: what was refused, and what was never looked at.
 #[derive(Clone, Debug, Serialize, specta::Type)]
 pub struct PanelFooterDto {
@@ -301,7 +354,66 @@ pub struct ReviewPanelDto {
     pub guidance: GuidanceDto,
     pub run: ReviewRunDto,
     pub note: Option<PanelNoteDto>,
+    /// Waiting for the reviewer, most severe and most confident first.
+    pub findings: Vec<FindingDto>,
     pub footer: Option<PanelFooterDto>,
+}
+
+/// What accepting a finding left for the panel to do.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+#[serde(tag = "outcome")]
+pub enum AcceptDispositionDto {
+    /// Became a draft at the anchor, which the diff now shows the mark for.
+    Drafted,
+    /// The anchor already held the reviewer's own draft. Neither text was
+    /// written; the panel asks whether to replace it.
+    Occupied { existing: String, proposed: String },
+    /// The finding was about the change as a whole, so it went into the summary.
+    Summary,
+    /// No pending finding had that id.
+    Unknown,
+}
+
+/// Maps what accepting a finding left for the panel to do.
+///
+/// `occupied` is the reviewer's own text and the finding's proposal, read off the
+/// session by the caller; present exactly when `disposition` is
+/// [`FindingDisposition::Composer`], which the GPUI composer opens pre-filled
+/// with and the desktop panel asks a plain replace-or-keep question about
+/// instead.
+#[must_use]
+pub fn project_disposition(
+    disposition: &FindingDisposition,
+    occupied: Option<(String, String)>,
+) -> AcceptDispositionDto {
+    match disposition {
+        FindingDisposition::Drafted => AcceptDispositionDto::Drafted,
+        FindingDisposition::Composer { .. } => {
+            let (existing, proposed) =
+                occupied.expect("an occupied disposition always carries its two texts");
+            AcceptDispositionDto::Occupied { existing, proposed }
+        }
+        FindingDisposition::Summary { .. } => AcceptDispositionDto::Summary,
+        FindingDisposition::Unknown => AcceptDispositionDto::Unknown,
+    }
+}
+
+/// What accepting or replacing a finding answers with.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct AcceptOutcomeDto {
+    pub panel: ReviewPanelDto,
+    /// The selected file's drafts, refreshed in case the finding landed there.
+    pub drafts: DraftsDto,
+    pub disposition: AcceptDispositionDto,
+}
+
+/// What revealing a finding, or selecting the next one, answers with.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct RevealOutcomeDto {
+    pub panel: ReviewPanelDto,
+    /// Absent for a finding about the change as a whole, which has nowhere to
+    /// scroll to.
+    pub location: Option<FindingLocationDto>,
 }
 
 #[derive(Clone, Debug, Serialize, specta::Type)]
@@ -748,8 +860,7 @@ pub fn project_drafts(session: &ReviewSession, file_index: usize) -> DraftsDto {
 /// on.
 ///
 /// Mirrors `crates/ui/src/findings.rs`, which is the parity target: the same copy
-/// in the same order, read off the same model. The findings list itself is not
-/// projected yet.
+/// in the same order, read off the same model.
 #[must_use]
 pub fn project_panel(review: &ReviewModel) -> Option<ReviewPanelDto> {
     if !review.findings_panel_visible() {
@@ -757,6 +868,7 @@ pub fn project_panel(review: &ReviewModel) -> Option<ReviewPanelDto> {
     }
     let session = review.session();
     let run = review.run();
+    let selected = review.selected_finding();
     Some(ReviewPanelDto {
         revision: review.revision(),
         heading: match session.findings().len() {
@@ -767,8 +879,46 @@ pub fn project_panel(review: &ReviewModel) -> Option<ReviewPanelDto> {
         guidance: project_guidance(session.guidance(), review.guidance_expanded()),
         run: project_run(run),
         note: project_note(session, run),
+        findings: session
+            .findings()
+            .accepted()
+            .iter()
+            .map(|finding| project_finding(finding, selected))
+            .collect(),
         footer: project_footer(session, run),
     })
+}
+
+fn project_finding(finding: &Finding, selected: Option<domain::FindingId>) -> FindingDto {
+    FindingDto {
+        id: finding.id.0,
+        severity: finding.severity.into(),
+        confidence: confidence_percent(finding.confidence),
+        title: finding.title.clone(),
+        rationale: finding.rationale.clone(),
+        citations: finding
+            .guidance_sources
+            .iter()
+            .map(|source| source.path.to_string())
+            .collect(),
+        origin: finding.origin.to_string(),
+        position: finding
+            .anchor
+            .as_ref()
+            .map(|anchor| format!("{}:{}", anchor.path, anchor.line)),
+        is_selected: selected == Some(finding.id),
+    }
+}
+
+/// A finding's confidence as a whole percentage, mirroring the GPUI panel.
+fn confidence_percent(confidence: f32) -> u32 {
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "confidence is validated into 0..=1 before it reaches a view"
+    )]
+    let percent = (confidence * 100.0).round() as u32;
+    percent
 }
 
 fn project_guidance(guidance: &GuidanceSelection, expanded: bool) -> GuidanceDto {

--- a/apps/desktop/src/Navigation.test.tsx
+++ b/apps/desktop/src/Navigation.test.tsx
@@ -14,6 +14,7 @@ import {
   makeHomeSnapshot,
   makeRow,
   makeSidebar,
+  makeFinding,
   makePanel,
   makeSnapshot,
 } from "./test/fixtures";
@@ -35,6 +36,9 @@ const discardDraft = vi.fn();
 const reanchorDraft = vi.fn();
 const reviewPanel = vi.fn();
 const runReview = vi.fn();
+const selectNextFinding = vi.fn();
+const acceptFinding = vi.fn();
+const dismissFinding = vi.fn();
 
 vi.mock("./bindings", () => ({
   commands: {
@@ -55,6 +59,9 @@ vi.mock("./bindings", () => ({
     reanchorDraft: (...args: unknown[]) => reanchorDraft(...args),
     reviewPanel: () => reviewPanel(),
     runReview: (channel: unknown) => runReview(channel),
+    selectNextFinding: () => selectNextFinding(),
+    acceptFinding: (id: unknown) => acceptFinding(id),
+    dismissFinding: (id: unknown) => dismissFinding(id),
   },
 }));
 
@@ -177,6 +184,9 @@ beforeEach(() => {
   discardDraft.mockReset();
   reanchorDraft.mockReset();
   reviewPanel.mockReset();
+  selectNextFinding.mockReset();
+  acceptFinding.mockReset();
+  dismissFinding.mockReset();
   reviewPanel.mockResolvedValue({ status: "ok", data: null });
   runReview.mockReset();
 });
@@ -315,6 +325,28 @@ describe("the Session kept alive behind Home", () => {
     fireEvent.keyDown(window, { key: "r", metaKey: true, shiftKey: true });
 
     expect(runReview).toHaveBeenCalledOnce();
+  });
+
+  it("leaves the finding shortcuts alone once Home is in front of the Session", async () => {
+    // A selected finding, so accept and dismiss have something to act on and
+    // the assertions below can only pass because Home has the keys.
+    reviewPanel.mockResolvedValue(
+      ok(makePanel({ findings: [makeFinding({ is_selected: true })] })),
+    );
+    await openTheCursorRow();
+
+    fireEvent.keyDown(window, { key: "[", metaKey: true });
+    await waitFor(() =>
+      expect(document.querySelector(".app__session")?.hasAttribute("hidden")).toBe(true),
+    );
+
+    for (const key of ["f", "y", "d"]) {
+      fireEvent.keyDown(window, { key, metaKey: true, shiftKey: true });
+    }
+
+    expect(selectNextFinding).not.toHaveBeenCalled();
+    expect(acceptFinding).not.toHaveBeenCalled();
+    expect(dismissFinding).not.toHaveBeenCalled();
   });
 
   it("keeps its tree mounted and hidden, with its file, cursor, and composer intact", async () => {

--- a/apps/desktop/src/Review.test.tsx
+++ b/apps/desktop/src/Review.test.tsx
@@ -2,13 +2,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { Channel } from "@tauri-apps/api/core";
-import type { ReviewPanelDto } from "./bindings";
+import type { FindingDto, ReviewPanelDto } from "./bindings";
 import App from "./App";
 import {
   makeAnchoredDraft,
   makeDrafts,
   makeFile,
   makeFileSummary,
+  makeFinding,
   makeGuidance,
   makeGuidanceEntry,
   makePanel,
@@ -29,6 +30,11 @@ const runReview = vi.fn();
 const cancelReview = vi.fn();
 const toggleGuidancePanel = vi.fn();
 const toggleGuidance = vi.fn();
+const acceptFinding = vi.fn();
+const overwriteFinding = vi.fn();
+const dismissFinding = vi.fn();
+const revealFinding = vi.fn();
+const selectNextFinding = vi.fn();
 
 vi.mock("./bindings", () => ({
   commands: {
@@ -44,6 +50,11 @@ vi.mock("./bindings", () => ({
     cancelReview: () => cancelReview(),
     toggleGuidancePanel: () => toggleGuidancePanel(),
     toggleGuidance: (path: unknown) => toggleGuidance(path),
+    acceptFinding: (id: unknown) => acceptFinding(id),
+    overwriteFinding: (id: unknown) => overwriteFinding(id),
+    dismissFinding: (id: unknown) => dismissFinding(id),
+    revealFinding: (id: unknown) => revealFinding(id),
+    selectNextFinding: () => selectNextFinding(),
   },
 }));
 
@@ -84,6 +95,11 @@ beforeEach(() => {
   cancelReview.mockReset();
   toggleGuidancePanel.mockReset();
   toggleGuidance.mockReset();
+  acceptFinding.mockReset();
+  overwriteFinding.mockReset();
+  dismissFinding.mockReset();
+  revealFinding.mockReset();
+  selectNextFinding.mockReset();
 });
 
 /** Renders the Session and waits for its panel to appear. */
@@ -417,5 +433,174 @@ describe("the review panel in a Session", () => {
     // The disclosure has served its purpose; the summary line stays either way.
     expect(screen.queryByText("AGENTS.md")).toBeNull();
     expect(screen.getByText("1 guidance file · 2 KB")).toBeTruthy();
+  });
+
+  it("keeps the rejected count and unreviewed files on screen once a run also finds findings", async () => {
+    const user = userEvent.setup();
+    runReview.mockResolvedValue({
+      status: "ok",
+      data: makePanel({
+        findings: [makeFinding({ id: 1 })],
+        run: { state: "Complete", accepted: 1, rejected: 1, suppressed: 0 },
+        footer: {
+          refused: "1 claim(s) refused",
+          not_reviewed: "1 file(s) not reviewed",
+          unreviewed: ["vendor/lib.rs"],
+        },
+      }),
+    });
+    await openPanel();
+
+    await user.click(screen.getByRole("button", { name: "Review" }));
+
+    await waitFor(() => expect(screen.getByText("Unchecked index")).toBeTruthy());
+    expect(screen.getByText("1 claim(s) refused")).toBeTruthy();
+    expect(screen.getByText("1 file(s) not reviewed")).toBeTruthy();
+    expect(screen.getByText("vendor/lib.rs")).toBeTruthy();
+  });
+});
+
+describe("findings in the review panel", () => {
+  /** A panel already showing one finding, selected. */
+  function panelWithFinding(overrides: Partial<FindingDto> = {}) {
+    return makePanel({ findings: [makeFinding({ id: 7, is_selected: true, ...overrides })] });
+  }
+
+  it("clicking a finding reveals it, scrolling the diff and selecting the row", async () => {
+    const user = userEvent.setup();
+    reviewPanel.mockResolvedValue({ status: "ok", data: panelWithFinding() });
+    revealFinding.mockResolvedValue({
+      status: "ok",
+      data: { panel: panelWithFinding(), location: { file: 0, row: 1 } },
+    });
+    await openPanel();
+
+    await user.click(screen.getByText("Unchecked index"));
+
+    expect(revealFinding).toHaveBeenCalledWith(7);
+    await waitFor(() =>
+      expect(screen.getByText("second").closest(".diff-row")?.className).toContain(
+        "diff-row--selected",
+      ),
+    );
+  });
+
+  it("cmd-shift-F selects the next finding", async () => {
+    const user = userEvent.setup();
+    reviewPanel.mockResolvedValue({ status: "ok", data: panelWithFinding() });
+    selectNextFinding.mockResolvedValue({
+      status: "ok",
+      data: { panel: panelWithFinding(), location: null },
+    });
+    await openPanel();
+
+    await user.keyboard("{Meta>}{Shift>}f{/Shift}{/Meta}");
+
+    expect(selectNextFinding).toHaveBeenCalledOnce();
+  });
+
+  it("cmd-shift-Y accepts the selected finding", async () => {
+    const user = userEvent.setup();
+    reviewPanel.mockResolvedValue({ status: "ok", data: panelWithFinding() });
+    acceptFinding.mockResolvedValue({
+      status: "ok",
+      data: { panel: makePanel({ findings: [] }), drafts: makeDrafts(), disposition: { outcome: "Drafted" } },
+    });
+    await openPanel();
+
+    await user.keyboard("{Meta>}{Shift>}y{/Shift}{/Meta}");
+
+    expect(acceptFinding).toHaveBeenCalledWith(7);
+  });
+
+  it("cmd-shift-D dismisses the selected finding", async () => {
+    const user = userEvent.setup();
+    reviewPanel.mockResolvedValue({ status: "ok", data: panelWithFinding() });
+    dismissFinding.mockResolvedValue({ status: "ok", data: makePanel({ findings: [] }) });
+    await openPanel();
+
+    await user.keyboard("{Meta>}{Shift>}d{/Shift}{/Meta}");
+
+    expect(dismissFinding).toHaveBeenCalledWith(7);
+  });
+
+  it("does nothing on the finding shortcuts while the composer has focus", async () => {
+    const user = userEvent.setup();
+    reviewPanel.mockResolvedValue({ status: "ok", data: panelWithFinding() });
+    await openPanel();
+
+    await user.keyboard("c");
+    const editorContent = await waitFor(() => {
+      const element = document.querySelector("[data-composer] .cm-content");
+      if (!element) {
+        throw new Error("composer editor not mounted yet");
+      }
+      return element;
+    });
+
+    editorContent.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "y", metaKey: true, shiftKey: true, bubbles: true }),
+    );
+
+    expect(acceptFinding).not.toHaveBeenCalled();
+  });
+
+  it("asks whether to replace, then replaces the reviewer's draft on confirmation", async () => {
+    const user = userEvent.setup();
+    reviewPanel.mockResolvedValue({ status: "ok", data: panelWithFinding() });
+    acceptFinding.mockResolvedValue({
+      status: "ok",
+      data: {
+        panel: panelWithFinding(),
+        drafts: makeDrafts(),
+        disposition: { outcome: "Occupied", existing: "mine", proposed: "Handle the failure here." },
+      },
+    });
+    overwriteFinding.mockResolvedValue({
+      status: "ok",
+      data: {
+        panel: makePanel({ findings: [] }),
+        drafts: makeDrafts({
+          anchored: [makeAnchoredDraft({ row: 0, body: "Handle the failure here.", is_proposed: true })],
+        }),
+        disposition: { outcome: "Drafted" },
+      },
+    });
+    await openPanel();
+
+    await user.click(screen.getByRole("button", { name: "Accept" }));
+    await waitFor(() =>
+      expect(
+        screen.getByText("This line already has your comment. Replace it with the proposal?"),
+      ).toBeTruthy(),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Replace" }));
+
+    expect(overwriteFinding).toHaveBeenCalledWith(7);
+    await waitFor(() => expect(screen.queryByText("Unchecked index")).toBeNull());
+  });
+
+  it("keeping leaves the reviewer's draft and the finding both untouched", async () => {
+    const user = userEvent.setup();
+    reviewPanel.mockResolvedValue({ status: "ok", data: panelWithFinding() });
+    acceptFinding.mockResolvedValue({
+      status: "ok",
+      data: {
+        panel: panelWithFinding(),
+        drafts: makeDrafts(),
+        disposition: { outcome: "Occupied", existing: "mine", proposed: "Handle the failure here." },
+      },
+    });
+    await openPanel();
+
+    await user.click(screen.getByRole("button", { name: "Accept" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Keep" })).toBeTruthy());
+
+    await user.click(screen.getByRole("button", { name: "Keep" }));
+
+    expect(overwriteFinding).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Keep" })).toBeNull());
+    expect(screen.getByText("Unchecked index")).toBeTruthy();
   });
 });

--- a/apps/desktop/src/Review.test.tsx
+++ b/apps/desktop/src/Review.test.tsx
@@ -538,11 +538,15 @@ describe("findings in the review panel", () => {
       return element;
     });
 
-    editorContent.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "y", metaKey: true, shiftKey: true, bubbles: true }),
-    );
+    for (const key of ["f", "y", "d"]) {
+      editorContent.dispatchEvent(
+        new KeyboardEvent("keydown", { key, metaKey: true, shiftKey: true, bubbles: true }),
+      );
+    }
 
+    expect(selectNextFinding).not.toHaveBeenCalled();
     expect(acceptFinding).not.toHaveBeenCalled();
+    expect(dismissFinding).not.toHaveBeenCalled();
   });
 
   it("asks whether to replace, then replaces the reviewer's draft on confirmation", async () => {

--- a/apps/desktop/src/Review.test.tsx
+++ b/apps/desktop/src/Review.test.tsx
@@ -553,7 +553,12 @@ describe("findings in the review panel", () => {
       data: {
         panel: panelWithFinding(),
         drafts: makeDrafts(),
-        disposition: { outcome: "Occupied", existing: "mine", proposed: "Handle the failure here." },
+        disposition: {
+          outcome: "Occupied",
+          existing: "mine",
+          proposed: "Handle the failure here.",
+          location: { file: 0, row: 0 },
+        },
       },
     });
     overwriteFinding.mockResolvedValue({
@@ -570,9 +575,7 @@ describe("findings in the review panel", () => {
 
     await user.click(screen.getByRole("button", { name: "Accept" }));
     await waitFor(() =>
-      expect(
-        screen.getByText("This line already has your comment. Replace it with the proposal?"),
-      ).toBeTruthy(),
+      expect(screen.getByText("Replace your comment with this proposal?")).toBeTruthy(),
     );
 
     await user.click(screen.getByRole("button", { name: "Replace" }));
@@ -589,7 +592,12 @@ describe("findings in the review panel", () => {
       data: {
         panel: panelWithFinding(),
         drafts: makeDrafts(),
-        disposition: { outcome: "Occupied", existing: "mine", proposed: "Handle the failure here." },
+        disposition: {
+          outcome: "Occupied",
+          existing: "mine",
+          proposed: "Handle the failure here.",
+          location: { file: 0, row: 0 },
+        },
       },
     });
     await openPanel();

--- a/apps/desktop/src/SessionApp.tsx
+++ b/apps/desktop/src/SessionApp.tsx
@@ -27,6 +27,11 @@ export function SessionApp({
     cancelReview,
     toggleGuidanceSection,
     toggleGuidanceFile,
+    revealFinding,
+    acceptFinding,
+    dismissFinding,
+    replaceFinding,
+    keepFinding,
   } = useSession(description, isShowing);
 
   switch (state.status) {
@@ -51,6 +56,11 @@ export function SessionApp({
           onCancelReview={cancelReview}
           onToggleGuidanceSection={toggleGuidanceSection}
           onToggleGuidanceFile={toggleGuidanceFile}
+          onRevealFinding={revealFinding}
+          onAcceptFinding={acceptFinding}
+          onDismissFinding={dismissFinding}
+          onReplaceFinding={replaceFinding}
+          onKeepFinding={keepFinding}
         />
       );
   }

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -357,9 +357,10 @@ export type AcceptDispositionDto =
 { outcome: "Drafted" } | 
 /**
  *  The anchor already held the reviewer's own draft. Neither text was
- *  written; the panel asks whether to replace it.
+ *  written; the panel asks whether to replace it. `location` is where
+ *  accepting it should first reveal, as the GPUI composer path does.
  */
-{ outcome: "Occupied"; existing: string; proposed: string } | 
+{ outcome: "Occupied"; existing: string; proposed: string; location: FindingLocationDto } | 
 /**  The finding was about the change as a whole, so it went into the summary. */
 { outcome: "Summary" } | 
 /**  No pending finding had that id. */
@@ -451,7 +452,7 @@ export type FindingDto = {
 	 *  Rounded to a whole percentage; a fraction reads as odd precision to a
 	 *  reviewer deciding whether to spend attention on it.
 	 */
-	confidence: number,
+	confidence_percent: number,
 	title: string,
 	rationale: string,
 	/**  Guidance paths this finding cites, e.g. "AGENTS.md". */

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -162,6 +162,8 @@ export const commands = {
 	guidance: GuidanceDto,
 	run: ReviewRunDto,
 	note: PanelNoteDto | null,
+	/**  Waiting for the reviewer, most severe and most confident first. */
+	findings: FindingDto[],
 	footer: PanelFooterDto | null,
 } | null, SessionFailureDto>(__TAURI_INVOKE("review_panel")),
 	/**
@@ -189,6 +191,8 @@ export const commands = {
 	guidance: GuidanceDto,
 	run: ReviewRunDto,
 	note: PanelNoteDto | null,
+	/**  Waiting for the reviewer, most severe and most confident first. */
+	findings: FindingDto[],
 	footer: PanelFooterDto | null,
 } | null, SessionFailureDto>(__TAURI_INVOKE("run_review", { onProgress })),
 	/**
@@ -209,6 +213,8 @@ export const commands = {
 	guidance: GuidanceDto,
 	run: ReviewRunDto,
 	note: PanelNoteDto | null,
+	/**  Waiting for the reviewer, most severe and most confident first. */
+	findings: FindingDto[],
 	footer: PanelFooterDto | null,
 } | null, SessionFailureDto>(__TAURI_INVOKE("cancel_review")),
 	/**
@@ -229,6 +235,8 @@ export const commands = {
 	guidance: GuidanceDto,
 	run: ReviewRunDto,
 	note: PanelNoteDto | null,
+	/**  Waiting for the reviewer, most severe and most confident first. */
+	findings: FindingDto[],
 	footer: PanelFooterDto | null,
 } | null, SessionFailureDto>(__TAURI_INVOKE("toggle_guidance_panel")),
 	/**
@@ -250,11 +258,121 @@ export const commands = {
 	guidance: GuidanceDto,
 	run: ReviewRunDto,
 	note: PanelNoteDto | null,
+	/**  Waiting for the reviewer, most severe and most confident first. */
+	findings: FindingDto[],
 	footer: PanelFooterDto | null,
 } | null, SessionFailureDto>(__TAURI_INVOKE("toggle_guidance", { path })),
+	/**
+	 *  Accepts a finding, turning it into a draft where the model allows it.
+	 * 
+	 *  Refuses to overwrite the reviewer's own draft. The disposition answers
+	 *  `Occupied` instead, and the panel asks whether to replace it.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns a failure when no session is open.
+	 */
+	acceptFinding: (id: number) => typedError<{
+	panel: ReviewPanelDto,
+	/**  The selected file's drafts, refreshed in case the finding landed there. */
+	drafts: DraftsDto,
+	disposition: AcceptDispositionDto,
+} | null, SessionFailureDto>(__TAURI_INVOKE("accept_finding", { id })),
+	/**
+	 *  Forces a finding onto its anchor, overwriting the reviewer's own draft there.
+	 * 
+	 *  Reached only once the reviewer has chosen to replace what they wrote, after
+	 *  `accept_finding` answered with the confirmation.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns a failure when no session is open.
+	 */
+	overwriteFinding: (id: number) => typedError<{
+	panel: ReviewPanelDto,
+	/**  The selected file's drafts, refreshed in case the finding landed there. */
+	drafts: DraftsDto,
+	disposition: AcceptDispositionDto,
+} | null, SessionFailureDto>(__TAURI_INVOKE("overwrite_finding", { id })),
+	/**
+	 *  Dismisses a finding, recording the decision so a later run suppresses the
+	 *  same claim.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns a failure when no session is open.
+	 */
+	dismissFinding: (id: number) => typedError<{
+	/**
+	 *  How many times the panel has changed, so a snapshot that was read before
+	 *  a change can be told from one that carries it.
+	 */
+	revision: number,
+	/**  "Review" before there is anything to act on, otherwise the finding count. */
+	heading: string,
+	guidance: GuidanceDto,
+	run: ReviewRunDto,
+	note: PanelNoteDto | null,
+	/**  Waiting for the reviewer, most severe and most confident first. */
+	findings: FindingDto[],
+	footer: PanelFooterDto | null,
+} | null, SessionFailureDto>(__TAURI_INVOKE("dismiss_finding", { id })),
+	/**
+	 *  Selects a finding, scrolling the diff to its anchor and selecting the row.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns a failure when no session is open.
+	 */
+	revealFinding: (id: number) => typedError<{
+	panel: ReviewPanelDto,
+	/**
+	 *  Absent for a finding about the change as a whole, which has nowhere to
+	 *  scroll to.
+	 */
+	location: FindingLocationDto | null,
+} | null, SessionFailureDto>(__TAURI_INVOKE("reveal_finding", { id })),
+	/**
+	 *  Moves the selection to the finding after the one selected, wrapping to the
+	 *  first, and scrolls the diff to show it.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns a failure when no session is open.
+	 */
+	selectNextFinding: () => typedError<{
+	panel: ReviewPanelDto,
+	/**
+	 *  Absent for a finding about the change as a whole, which has nowhere to
+	 *  scroll to.
+	 */
+	location: FindingLocationDto | null,
+} | null, SessionFailureDto>(__TAURI_INVOKE("select_next_finding")),
 };
 
 /* Types */
+/**  What accepting a finding left for the panel to do. */
+export type AcceptDispositionDto = 
+/**  Became a draft at the anchor, which the diff now shows the mark for. */
+{ outcome: "Drafted" } | 
+/**
+ *  The anchor already held the reviewer's own draft. Neither text was
+ *  written; the panel asks whether to replace it.
+ */
+{ outcome: "Occupied"; existing: string; proposed: string } | 
+/**  The finding was about the change as a whole, so it went into the summary. */
+{ outcome: "Summary" } | 
+/**  No pending finding had that id. */
+{ outcome: "Unknown" };
+
+/**  What accepting or replacing a finding answers with. */
+export type AcceptOutcomeDto = {
+	panel: ReviewPanelDto,
+	/**  The selected file's drafts, refreshed in case the finding landed there. */
+	drafts: DraftsDto,
+	disposition: AcceptDispositionDto,
+};
+
 /**  A draft resolved to the row it is drawn on. */
 export type AnchoredDraftDto = {
 	row: number,
@@ -323,6 +441,32 @@ export type FileSummaryDto = {
 	deletions: number,
 	viewed: boolean,
 	thread_count: number,
+};
+
+/**  A suggestion a review backend proposed, waiting for the reviewer to act on it. */
+export type FindingDto = {
+	id: number,
+	severity: SeverityDto,
+	/**
+	 *  Rounded to a whole percentage; a fraction reads as odd precision to a
+	 *  reviewer deciding whether to spend attention on it.
+	 */
+	confidence: number,
+	title: string,
+	rationale: string,
+	/**  Guidance paths this finding cites, e.g. "AGENTS.md". */
+	citations: string[],
+	/**  The backend that proposed this, e.g. "claude-code". */
+	origin: string,
+	/**  "path:line", absent for a finding about the change as a whole. */
+	position: string | null,
+	is_selected: boolean,
+};
+
+/**  Where a finding's anchor lands in the displayed diff. */
+export type FindingLocationDto = {
+	file: number,
+	row: number,
 };
 
 /**  The guidance section at the top of the panel. */
@@ -488,6 +632,16 @@ export type RefusalDto = {
 	reason: string,
 };
 
+/**  What revealing a finding, or selecting the next one, answers with. */
+export type RevealOutcomeDto = {
+	panel: ReviewPanelDto,
+	/**
+	 *  Absent for a finding about the change as a whole, which has nowhere to
+	 *  scroll to.
+	 */
+	location: FindingLocationDto | null,
+};
+
 /**
  *  The Session's right-hand panel: what a review is held to, and how far the run
  *  that populates it has got.
@@ -503,6 +657,8 @@ export type ReviewPanelDto = {
 	guidance: GuidanceDto,
 	run: ReviewRunDto,
 	note: PanelNoteDto | null,
+	/**  Waiting for the reviewer, most severe and most confident first. */
+	findings: FindingDto[],
 	footer: PanelFooterDto | null,
 };
 
@@ -546,6 +702,9 @@ export type SessionSnapshotDto = {
 	sidebar: SidebarDto,
 	warnings: SessionFailureDto[],
 };
+
+/**  How much a finding claims to matter. */
+export type SeverityDto = "Info" | "Warning" | "Error";
 
 export type SidebarDto = {
 	files: FileSummaryDto[],

--- a/apps/desktop/src/components/ReviewPanel.css
+++ b/apps/desktop/src/components/ReviewPanel.css
@@ -310,6 +310,26 @@
   margin: 0 0 4px;
 }
 
+.review-panel__finding-conflict-intro {
+  color: var(--text-primary);
+}
+
+.review-panel__finding-conflict-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 4px 6px;
+  border-radius: 4px;
+  background: var(--surface-overlay);
+  white-space: pre-wrap;
+}
+
+.review-panel__finding-conflict-label {
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  font-size: 10px;
+}
+
 .review-panel__footer {
   flex-shrink: 0;
   padding: 8px 12px;

--- a/apps/desktop/src/components/ReviewPanel.css
+++ b/apps/desktop/src/components/ReviewPanel.css
@@ -191,6 +191,125 @@
   font-size: var(--size-label);
 }
 
+.review-panel__findings {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.review-panel__finding {
+  padding: 8px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border-bottom: 1px solid var(--border-default);
+  cursor: pointer;
+}
+
+.review-panel__finding--selected {
+  background: var(--surface-selected);
+}
+
+.review-panel__finding-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.review-panel__severity {
+  text-transform: uppercase;
+  font-size: var(--size-label);
+  font-weight: 600;
+}
+
+.review-panel__severity--error {
+  color: var(--severity-error-text);
+}
+
+.review-panel__severity--warning {
+  color: var(--severity-warning-text);
+}
+
+.review-panel__severity--info {
+  color: var(--severity-info-text);
+}
+
+.review-panel__confidence {
+  color: var(--text-secondary);
+  font-size: var(--size-label);
+}
+
+.review-panel__position {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-secondary);
+  font-size: var(--size-label);
+}
+
+.review-panel__finding-title {
+  margin: 0;
+  color: var(--text-primary);
+}
+
+.review-panel__finding-rationale {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--size-label);
+}
+
+.review-panel__finding-citations {
+  margin: 0;
+  color: var(--text-tertiary);
+  font-size: var(--size-label);
+}
+
+/* The one place a finding is marked as a model's proposal, in the hue reserved
+   for exactly that and nothing else. */
+.review-panel__finding-origin {
+  margin: 0;
+  color: var(--proposed-text);
+  font-size: var(--size-label);
+}
+
+.review-panel__finding-actions {
+  display: flex;
+  gap: 8px;
+  padding-top: 4px;
+}
+
+.review-panel__finding-actions button {
+  padding: 4px 8px;
+  border: none;
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: var(--size-label);
+  cursor: pointer;
+}
+
+.review-panel__finding-accept,
+.review-panel__finding-replace {
+  background: var(--severity-success);
+  color: var(--text-on-accent);
+}
+
+.review-panel__finding-dismiss,
+.review-panel__finding-keep {
+  background: var(--surface-overlay);
+  color: var(--text-secondary);
+}
+
+.review-panel__finding-conflict {
+  padding-top: 4px;
+  color: var(--text-secondary);
+  font-size: var(--size-label);
+}
+
+.review-panel__finding-conflict p {
+  margin: 0 0 4px;
+}
+
 .review-panel__footer {
   flex-shrink: 0;
   padding: 8px 12px;

--- a/apps/desktop/src/components/ReviewPanel.test.tsx
+++ b/apps/desktop/src/components/ReviewPanel.test.tsx
@@ -1,17 +1,23 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { makeGuidance, makeGuidanceEntry, makePanel } from "../test/fixtures";
+import { makeFinding, makeGuidance, makeGuidanceEntry, makePanel } from "../test/fixtures";
 import { ReviewPanel } from "./ReviewPanel";
 
 /** Every handler the panel needs beyond the one a test wants to watch. */
 function baseHandlers() {
   return {
     notice: null,
+    findingConflict: null,
     onRunReview: () => {},
     onCancelReview: () => {},
     onToggleGuidanceSection: () => {},
     onToggleGuidanceFile: () => {},
+    onRevealFinding: () => {},
+    onAcceptFinding: () => {},
+    onDismissFinding: () => {},
+    onReplaceFinding: () => {},
+    onKeepFinding: () => {},
   };
 }
 
@@ -205,5 +211,177 @@ describe("ReviewPanel", () => {
     expect(screen.getByText("2 file(s) not reviewed")).toBeTruthy();
     expect(screen.getByText("vendor/lib.rs")).toBeTruthy();
     expect(screen.getByText("huge.json")).toBeTruthy();
+  });
+
+  it("renders a finding with its severity, confidence, position, rationale, citations, and who proposed it", () => {
+    render(
+      <ReviewPanel
+        panel={makePanel({
+          findings: [
+            makeFinding({
+              severity: "Error",
+              confidence: 82,
+              title: "Unchecked index",
+              rationale: "This can panic on an empty slice.",
+              citations: ["AGENTS.md", "src/AGENTS.md"],
+              origin: "claude-code",
+              position: "src/review.rs:6",
+            }),
+          ],
+        })}
+        {...baseHandlers()}
+      />,
+    );
+
+    expect(screen.getByText("error")).toBeTruthy();
+    expect(screen.getByText("82%")).toBeTruthy();
+    expect(screen.getByText("src/review.rs:6")).toBeTruthy();
+    expect(screen.getByText("Unchecked index")).toBeTruthy();
+    expect(screen.getByText("This can panic on an empty slice.")).toBeTruthy();
+    expect(screen.getByText("per AGENTS.md, src/AGENTS.md")).toBeTruthy();
+    expect(screen.getByText("Proposed by claude-code")).toBeTruthy();
+    // The note is what the empty list shows; a finding gives way to the list.
+    expect(screen.queryByText("No review has been run.")).toBeNull();
+  });
+
+  it("shows a finding about the whole change as such, with an Accept still offered", () => {
+    render(
+      <ReviewPanel
+        panel={makePanel({ findings: [makeFinding({ position: null, title: "no tests anywhere" })] })}
+        {...baseHandlers()}
+      />,
+    );
+
+    expect(screen.getByText("whole change")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Accept" })).toBeTruthy();
+  });
+
+  it("highlights the finding the model has selected", () => {
+    render(
+      <ReviewPanel
+        panel={makePanel({
+          findings: [
+            makeFinding({ id: 1, title: "first", is_selected: false }),
+            makeFinding({ id: 2, title: "second", is_selected: true }),
+          ],
+        })}
+        {...baseHandlers()}
+      />,
+    );
+
+    const selected = screen.getByText("second").closest("li");
+    expect(selected?.className).toContain("review-panel__finding--selected");
+    const unselected = screen.getByText("first").closest("li");
+    expect(unselected?.className).not.toContain("review-panel__finding--selected");
+  });
+
+  it("reveals a finding when its card is clicked", async () => {
+    const onRevealFinding = vi.fn();
+    render(
+      <ReviewPanel
+        panel={makePanel({ findings: [makeFinding({ id: 5, title: "unchecked index" })] })}
+        {...baseHandlers()}
+        onRevealFinding={onRevealFinding}
+      />,
+    );
+
+    await userEvent.click(screen.getByText("unchecked index"));
+
+    expect(onRevealFinding).toHaveBeenCalledWith(5);
+  });
+
+  it("accepts and dismisses a finding through its own buttons, without also revealing it", async () => {
+    const onRevealFinding = vi.fn();
+    const onAcceptFinding = vi.fn();
+    const onDismissFinding = vi.fn();
+    render(
+      <ReviewPanel
+        panel={makePanel({ findings: [makeFinding({ id: 5 })] })}
+        {...baseHandlers()}
+        onRevealFinding={onRevealFinding}
+        onAcceptFinding={onAcceptFinding}
+        onDismissFinding={onDismissFinding}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Accept" }));
+    await userEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    expect(onAcceptFinding).toHaveBeenCalledWith(5);
+    expect(onDismissFinding).toHaveBeenCalledWith(5);
+    expect(onRevealFinding).not.toHaveBeenCalled();
+  });
+
+  it("asks whether to replace before overwriting an occupied line", () => {
+    render(
+      <ReviewPanel
+        panel={makePanel({ findings: [makeFinding({ id: 5 })] })}
+        {...baseHandlers()}
+        findingConflict={{ id: 5, existing: "mine", proposed: "Handle the failure here." }}
+      />,
+    );
+
+    expect(
+      screen.getByText("This line already has your comment. Replace it with the proposal?"),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Replace" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Keep" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Accept" })).toBeNull();
+  });
+
+  it("only asks about the finding the conflict names", () => {
+    render(
+      <ReviewPanel
+        panel={makePanel({
+          findings: [makeFinding({ id: 5, title: "first" }), makeFinding({ id: 6, title: "second" })],
+        })}
+        {...baseHandlers()}
+        findingConflict={{ id: 5, existing: "mine", proposed: "Handle the failure here." }}
+      />,
+    );
+
+    expect(screen.getAllByRole("button", { name: "Accept" })).toHaveLength(1);
+    expect(screen.getAllByRole("button", { name: "Replace" })).toHaveLength(1);
+  });
+
+  it("replaces or keeps through the confirmation's two buttons", async () => {
+    const onReplaceFinding = vi.fn();
+    const onKeepFinding = vi.fn();
+    render(
+      <ReviewPanel
+        panel={makePanel({ findings: [makeFinding({ id: 5 })] })}
+        {...baseHandlers()}
+        findingConflict={{ id: 5, existing: "mine", proposed: "Handle the failure here." }}
+        onReplaceFinding={onReplaceFinding}
+        onKeepFinding={onKeepFinding}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Replace" }));
+    expect(onReplaceFinding).toHaveBeenCalledWith(5);
+
+    await userEvent.click(screen.getByRole("button", { name: "Keep" }));
+    expect(onKeepFinding).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the rejected count and unreviewed files visible even though findings exist", () => {
+    render(
+      <ReviewPanel
+        panel={makePanel({
+          findings: [makeFinding()],
+          footer: {
+            refused: "1 claim(s) refused",
+            not_reviewed: "1 file(s) not reviewed",
+            unreviewed: ["vendor/lib.rs"],
+          },
+        })}
+        {...baseHandlers()}
+      />,
+    );
+
+    expect(screen.getByText("Unchecked index")).toBeTruthy();
+    expect(screen.getByText("1 claim(s) refused")).toBeTruthy();
+    expect(screen.getByText("1 file(s) not reviewed")).toBeTruthy();
+    expect(screen.getByText("vendor/lib.rs")).toBeTruthy();
   });
 });

--- a/apps/desktop/src/components/ReviewPanel.test.tsx
+++ b/apps/desktop/src/components/ReviewPanel.test.tsx
@@ -220,7 +220,7 @@ describe("ReviewPanel", () => {
           findings: [
             makeFinding({
               severity: "Error",
-              confidence: 82,
+              confidence_percent: 82,
               title: "Unchecked index",
               rationale: "This can panic on an empty slice.",
               citations: ["AGENTS.md", "src/AGENTS.md"],
@@ -244,7 +244,7 @@ describe("ReviewPanel", () => {
     expect(screen.queryByText("No review has been run.")).toBeNull();
   });
 
-  it("shows a finding about the whole change as such, with an Accept still offered", () => {
+  it("shows a finding about the whole change as such, offering no Accept", () => {
     render(
       <ReviewPanel
         panel={makePanel({ findings: [makeFinding({ position: null, title: "no tests anywhere" })] })}
@@ -253,7 +253,10 @@ describe("ReviewPanel", () => {
     );
 
     expect(screen.getByText("whole change")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Accept" })).toBeTruthy();
+    // The desktop has no summary editor yet, so accepting a whole-change
+    // finding would write to storage the reviewer would never see.
+    expect(screen.queryByRole("button", { name: "Accept" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Dismiss" })).toBeTruthy();
   });
 
   it("highlights the finding the model has selected", () => {
@@ -270,9 +273,9 @@ describe("ReviewPanel", () => {
     );
 
     const selected = screen.getByText("second").closest("li");
-    expect(selected?.className).toContain("review-panel__finding--selected");
+    expect(selected?.getAttribute("aria-selected")).toBe("true");
     const unselected = screen.getByText("first").closest("li");
-    expect(unselected?.className).not.toContain("review-panel__finding--selected");
+    expect(unselected?.getAttribute("aria-selected")).toBe("false");
   });
 
   it("reveals a finding when its card is clicked", async () => {
@@ -321,9 +324,10 @@ describe("ReviewPanel", () => {
       />,
     );
 
-    expect(
-      screen.getByText("This line already has your comment. Replace it with the proposal?"),
-    ).toBeTruthy();
+    expect(screen.getByText("Replace your comment with this proposal?")).toBeTruthy();
+    // Both texts are on screen, so nobody replaces words they cannot see.
+    expect(screen.getByText("mine")).toBeTruthy();
+    expect(screen.getByText("Handle the failure here.")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Replace" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Keep" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Accept" })).toBeNull();

--- a/apps/desktop/src/components/ReviewPanel.tsx
+++ b/apps/desktop/src/components/ReviewPanel.tsx
@@ -229,6 +229,7 @@ function FindingCard({
       className={`review-panel__finding ${
         finding.is_selected ? "review-panel__finding--selected" : ""
       }`}
+      aria-selected={finding.is_selected}
       onClick={onReveal}
     >
       <div className="review-panel__finding-meta">
@@ -237,7 +238,7 @@ function FindingCard({
         >
           {SEVERITY_LABEL[finding.severity]}
         </span>
-        <span className="review-panel__confidence">{finding.confidence}%</span>
+        <span className="review-panel__confidence">{finding.confidence_percent}%</span>
         <span className="review-panel__position">{finding.position ?? "whole change"}</span>
       </div>
       <p className="review-panel__finding-title">{finding.title}</p>
@@ -250,7 +251,17 @@ function FindingCard({
       <p className="review-panel__finding-origin">Proposed by {finding.origin}</p>
       {conflict !== null ? (
         <div className="review-panel__finding-conflict">
-          <p>This line already has your comment. Replace it with the proposal?</p>
+          <p className="review-panel__finding-conflict-intro">
+            Replace your comment with this proposal?
+          </p>
+          <p className="review-panel__finding-conflict-text">
+            <span className="review-panel__finding-conflict-label">Your comment</span>
+            {conflict.existing}
+          </p>
+          <p className="review-panel__finding-conflict-text">
+            <span className="review-panel__finding-conflict-label">Proposal</span>
+            {conflict.proposed}
+          </p>
           <div className="review-panel__finding-actions">
             <button
               type="button"
@@ -276,16 +287,19 @@ function FindingCard({
         </div>
       ) : (
         <div className="review-panel__finding-actions">
-          <button
-            type="button"
-            className="review-panel__finding-accept"
-            onClick={(event) => {
-              event.stopPropagation();
-              onAccept();
-            }}
-          >
-            Accept
-          </button>
+          {/* No summary editor yet, so a whole-change finding can only be dismissed. */}
+          {finding.position !== null && (
+            <button
+              type="button"
+              className="review-panel__finding-accept"
+              onClick={(event) => {
+                event.stopPropagation();
+                onAccept();
+              }}
+            >
+              Accept
+            </button>
+          )}
           <button
             type="button"
             className="review-panel__finding-dismiss"

--- a/apps/desktop/src/components/ReviewPanel.tsx
+++ b/apps/desktop/src/components/ReviewPanel.tsx
@@ -1,31 +1,52 @@
-import type { GuidanceDto, ReviewPanelDto } from "../bindings";
+import type { FindingConflict } from "../hooks/sessionReducer";
+import type { FindingDto, GuidanceDto, ReviewPanelDto, SeverityDto } from "../bindings";
 import "./ReviewPanel.css";
 
+const SEVERITY_LABEL: Record<SeverityDto, string> = {
+  Error: "error",
+  Warning: "warning",
+  Info: "info",
+};
+
 /**
- * What this review is held to, and how far the run that populates it has got.
+ * What this review is held to, the findings it proposes, and how far the run
+ * that populates it has got.
  *
  * Two things this panel is careful to show rather than hide. What was refused, so
  * a run that kept one claim out of twelve does not read as a run that found one.
  * And what was never looked at, so a review that skipped files cannot present
- * itself as having covered the change. The findings themselves are not drawn yet.
+ * itself as having covered the change.
  */
 export function ReviewPanel({
   panel,
   notice,
+  findingConflict,
   onRunReview,
   onCancelReview,
   onToggleGuidanceSection,
   onToggleGuidanceFile,
+  onRevealFinding,
+  onAcceptFinding,
+  onDismissFinding,
+  onReplaceFinding,
+  onKeepFinding,
 }: {
   panel: ReviewPanelDto;
   /** What a review command refused, until the next panel lands. */
   notice: string | null;
+  /** The confirmation accepting a finding onto an occupied line is asking. */
+  findingConflict: FindingConflict;
   onRunReview: () => void;
   onCancelReview: () => void;
   onToggleGuidanceSection: () => void;
   onToggleGuidanceFile: (path: string) => void;
+  onRevealFinding: (id: number) => void;
+  onAcceptFinding: (id: number) => void;
+  onDismissFinding: (id: number) => void;
+  onReplaceFinding: (id: number) => void;
+  onKeepFinding: () => void;
 }) {
-  const { run, note, footer } = panel;
+  const { run, note, findings, footer } = panel;
   const isRunning = run.state === "Running";
 
   return (
@@ -50,11 +71,32 @@ export function ReviewPanel({
         onToggleFile={onToggleGuidanceFile}
       />
       <div className="review-panel__body">
-        {note !== null && (
-          <div className="review-panel__note">
-            <p className="review-panel__note-heading">{note.heading}</p>
-            {note.detail !== null && <p className="review-panel__note-detail">{note.detail}</p>}
-          </div>
+        {findings.length > 0 ? (
+          <ul className="review-panel__findings">
+            {findings.map((finding) => (
+              <FindingCard
+                key={finding.id}
+                finding={finding}
+                conflict={
+                  findingConflict !== null && findingConflict.id === finding.id
+                    ? findingConflict
+                    : null
+                }
+                onReveal={() => onRevealFinding(finding.id)}
+                onAccept={() => onAcceptFinding(finding.id)}
+                onDismiss={() => onDismissFinding(finding.id)}
+                onReplace={() => onReplaceFinding(finding.id)}
+                onKeep={onKeepFinding}
+              />
+            ))}
+          </ul>
+        ) : (
+          note !== null && (
+            <div className="review-panel__note">
+              <p className="review-panel__note-heading">{note.heading}</p>
+              {note.detail !== null && <p className="review-panel__note-detail">{note.detail}</p>}
+            </div>
+          )
         )}
       </div>
       {footer !== null && (
@@ -156,5 +198,106 @@ function GuidanceSection({
         </>
       )}
     </section>
+  );
+}
+
+/**
+ * One proposal from a review backend. Nothing here is a comment until the
+ * reviewer accepts it, which is why every card carries both what the model
+ * decided and a plain Accept or Dismiss.
+ */
+function FindingCard({
+  finding,
+  conflict,
+  onReveal,
+  onAccept,
+  onDismiss,
+  onReplace,
+  onKeep,
+}: {
+  finding: FindingDto;
+  /** Present when accepting this finding found the anchor already occupied. */
+  conflict: FindingConflict;
+  onReveal: () => void;
+  onAccept: () => void;
+  onDismiss: () => void;
+  onReplace: () => void;
+  onKeep: () => void;
+}) {
+  return (
+    <li
+      className={`review-panel__finding ${
+        finding.is_selected ? "review-panel__finding--selected" : ""
+      }`}
+      onClick={onReveal}
+    >
+      <div className="review-panel__finding-meta">
+        <span
+          className={`review-panel__severity review-panel__severity--${SEVERITY_LABEL[finding.severity]}`}
+        >
+          {SEVERITY_LABEL[finding.severity]}
+        </span>
+        <span className="review-panel__confidence">{finding.confidence}%</span>
+        <span className="review-panel__position">{finding.position ?? "whole change"}</span>
+      </div>
+      <p className="review-panel__finding-title">{finding.title}</p>
+      {finding.rationale !== "" && (
+        <p className="review-panel__finding-rationale">{finding.rationale}</p>
+      )}
+      {finding.citations.length > 0 && (
+        <p className="review-panel__finding-citations">per {finding.citations.join(", ")}</p>
+      )}
+      <p className="review-panel__finding-origin">Proposed by {finding.origin}</p>
+      {conflict !== null ? (
+        <div className="review-panel__finding-conflict">
+          <p>This line already has your comment. Replace it with the proposal?</p>
+          <div className="review-panel__finding-actions">
+            <button
+              type="button"
+              className="review-panel__finding-replace"
+              onClick={(event) => {
+                event.stopPropagation();
+                onReplace();
+              }}
+            >
+              Replace
+            </button>
+            <button
+              type="button"
+              className="review-panel__finding-keep"
+              onClick={(event) => {
+                event.stopPropagation();
+                onKeep();
+              }}
+            >
+              Keep
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="review-panel__finding-actions">
+          <button
+            type="button"
+            className="review-panel__finding-accept"
+            onClick={(event) => {
+              event.stopPropagation();
+              onAccept();
+            }}
+          >
+            Accept
+          </button>
+          <button
+            type="button"
+            className="review-panel__finding-dismiss"
+            onClick={(event) => {
+              event.stopPropagation();
+              onDismiss();
+            }}
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+    </li>
   );
 }

--- a/apps/desktop/src/components/SessionShell.test.tsx
+++ b/apps/desktop/src/components/SessionShell.test.tsx
@@ -20,6 +20,11 @@ function baseHandlers() {
     onCancelReview: () => {},
     onToggleGuidanceSection: () => {},
     onToggleGuidanceFile: () => {},
+    onRevealFinding: () => {},
+    onAcceptFinding: () => {},
+    onDismissFinding: () => {},
+    onReplaceFinding: () => {},
+    onKeepFinding: () => {},
   };
 }
 
@@ -34,6 +39,7 @@ function readyState(overrides: Partial<ReadyState["file"]> = {}): ReadyState {
     composer: null,
     panel: null,
     panelNotice: null,
+    findingConflict: null,
   };
 }
 

--- a/apps/desktop/src/components/SessionShell.tsx
+++ b/apps/desktop/src/components/SessionShell.tsx
@@ -22,6 +22,11 @@ export function SessionShell({
   onCancelReview,
   onToggleGuidanceSection,
   onToggleGuidanceFile,
+  onRevealFinding,
+  onAcceptFinding,
+  onDismissFinding,
+  onReplaceFinding,
+  onKeepFinding,
 }: {
   state: ReadyState;
   /** False while Home is in front, which is when this Session has no screen. */
@@ -39,6 +44,11 @@ export function SessionShell({
   onCancelReview: () => void;
   onToggleGuidanceSection: () => void;
   onToggleGuidanceFile: (path: string) => void;
+  onRevealFinding: (id: number) => void;
+  onAcceptFinding: (id: number) => void;
+  onDismissFinding: (id: number) => void;
+  onReplaceFinding: (id: number) => void;
+  onKeepFinding: () => void;
 }) {
   const [selectionStart, selectionEnd] = selectionRange(state);
   const { empty_reason: emptyReason, rows } = state.file;
@@ -86,10 +96,16 @@ export function SessionShell({
         <ReviewPanel
           panel={state.panel}
           notice={state.panelNotice}
+          findingConflict={state.findingConflict}
           onRunReview={onRunReview}
           onCancelReview={onCancelReview}
           onToggleGuidanceSection={onToggleGuidanceSection}
           onToggleGuidanceFile={onToggleGuidanceFile}
+          onRevealFinding={onRevealFinding}
+          onAcceptFinding={onAcceptFinding}
+          onDismissFinding={onDismissFinding}
+          onReplaceFinding={onReplaceFinding}
+          onKeepFinding={onKeepFinding}
         />
       )}
     </div>

--- a/apps/desktop/src/hooks/sessionReducer.test.ts
+++ b/apps/desktop/src/hooks/sessionReducer.test.ts
@@ -4,6 +4,7 @@ import {
   makeAnchoredDraft,
   makeDrafts,
   makeFile,
+  makeFinding,
   makePanel,
   makeRow,
   makeSnapshot,
@@ -13,6 +14,7 @@ import {
   composerPrefill,
   draftAtRow,
   initialState,
+  selectedFindingId,
   selectionRange,
   sessionReducer,
 } from "./sessionReducer";
@@ -35,6 +37,7 @@ function readyState(rowCount: number, cursor = 0, anchor = 0): ReadyState {
     composer: null,
     panel: null,
     panelNotice: null,
+    findingConflict: null,
   };
 }
 
@@ -115,6 +118,21 @@ describe("sessionReducer", () => {
     const next = sessionReducer(refused, { type: "panel", panel: makePanel() });
 
     expect(next).toMatchObject({ panelNotice: null });
+  });
+
+  it("shows the confirmation accepting onto an occupied line asked", () => {
+    const conflict = { id: 3, existing: "mine", proposed: "Handle the failure here." };
+    const next = sessionReducer(readyState(1), { type: "findingConflict", conflict });
+    expect(next).toMatchObject({ findingConflict: conflict });
+  });
+
+  it("clears the confirmation once the reviewer resolves it", () => {
+    const conflict = { id: 3, existing: "mine", proposed: "Handle the failure here." };
+    const asked = sessionReducer(readyState(1), { type: "findingConflict", conflict });
+
+    const cleared = sessionReducer(asked, { type: "findingConflict", conflict: null });
+
+    expect(cleared).toMatchObject({ findingConflict: null });
   });
 
   it("clamps the cursor at the top of the file", () => {
@@ -285,5 +303,20 @@ describe("sessionReducer", () => {
     expect(composerPrefill(readyState(10))).toBe("");
     const opened = sessionReducer(readyState(10, 2, 2), { type: "toggleComposer" }) as ReadyState;
     expect(composerPrefill(opened)).toBe("");
+  });
+
+  it("finds the id of the panel's selected finding", () => {
+    const panel = makePanel({
+      findings: [
+        makeFinding({ id: 1, is_selected: false }),
+        makeFinding({ id: 2, is_selected: true }),
+      ],
+    });
+    expect(selectedFindingId(panel)).toBe(2);
+  });
+
+  it("has no selected finding on a null panel or an empty list", () => {
+    expect(selectedFindingId(null)).toBeNull();
+    expect(selectedFindingId(makePanel({ findings: [] }))).toBeNull();
   });
 });

--- a/apps/desktop/src/hooks/sessionReducer.test.ts
+++ b/apps/desktop/src/hooks/sessionReducer.test.ts
@@ -14,7 +14,7 @@ import {
   composerPrefill,
   draftAtRow,
   initialState,
-  selectedFindingId,
+  selectedFinding,
   selectionRange,
   sessionReducer,
 } from "./sessionReducer";
@@ -133,6 +133,19 @@ describe("sessionReducer", () => {
     const cleared = sessionReducer(asked, { type: "findingConflict", conflict: null });
 
     expect(cleared).toMatchObject({ findingConflict: null });
+  });
+
+  /**
+   * A re-run can reassign the pending finding's id to a different claim, so a
+   * panel that lands while a confirmation is showing must drop it too.
+   */
+  it("clears a pending conflict when a new panel lands", () => {
+    const conflict = { id: 3, existing: "mine", proposed: "Handle the failure here." };
+    const asked = sessionReducer(readyState(1), { type: "findingConflict", conflict });
+
+    const next = sessionReducer(asked, { type: "panel", panel: makePanel() });
+
+    expect(next).toMatchObject({ findingConflict: null });
   });
 
   it("clamps the cursor at the top of the file", () => {
@@ -305,18 +318,18 @@ describe("sessionReducer", () => {
     expect(composerPrefill(opened)).toBe("");
   });
 
-  it("finds the id of the panel's selected finding", () => {
+  it("finds the panel's selected finding", () => {
     const panel = makePanel({
       findings: [
         makeFinding({ id: 1, is_selected: false }),
         makeFinding({ id: 2, is_selected: true }),
       ],
     });
-    expect(selectedFindingId(panel)).toBe(2);
+    expect(selectedFinding(panel)?.id).toBe(2);
   });
 
   it("has no selected finding on a null panel or an empty list", () => {
-    expect(selectedFindingId(null)).toBeNull();
-    expect(selectedFindingId(makePanel({ findings: [] }))).toBeNull();
+    expect(selectedFinding(null)).toBeNull();
+    expect(selectedFinding(makePanel({ findings: [] }))).toBeNull();
   });
 });

--- a/apps/desktop/src/hooks/sessionReducer.ts
+++ b/apps/desktop/src/hooks/sessionReducer.ts
@@ -15,6 +15,12 @@ const REJECTED_NOTICE = "This selection cannot hold a comment";
 /** The composer's frozen span and any notice it is showing, or absent when closed. */
 export type ComposerState = { rows: [number, number]; notice: string | null } | null;
 
+/**
+ * The reviewer's own text and a finding's proposal, shown while accepting asks
+ * whether to replace what is already there.
+ */
+export type FindingConflict = { id: number; existing: string; proposed: string } | null;
+
 export type SessionState =
   | { status: "loading"; description: string; stage: string }
   | { status: "failed"; failure: SessionFailureDto }
@@ -36,6 +42,8 @@ export type SessionState =
        * would throw away the diff and whatever is unsent in the composer.
        */
       panelNotice: string | null;
+      /** The confirmation accepting a finding onto an occupied line is asking. */
+      findingConflict: FindingConflict;
     };
 
 export type ReadyState = Extract<SessionState, { status: "ready" }>;
@@ -58,6 +66,7 @@ export type SessionAction =
     }
   | { type: "panel"; panel: ReviewPanelDto | null }
   | { type: "panelNotice"; notice: string }
+  | { type: "findingConflict"; conflict: FindingConflict }
   | { type: "file"; file: FileDetailDto }
   | { type: "sidebar"; sidebar: SidebarDto }
   | { type: "move"; delta: 1 | -1; extend: boolean }
@@ -101,6 +110,7 @@ export function sessionReducer(state: SessionState, action: SessionAction): Sess
         composer: null,
         panel: action.panel,
         panelNotice: null,
+        findingConflict: null,
       };
 
     case "panel": {
@@ -126,6 +136,12 @@ export function sessionReducer(state: SessionState, action: SessionAction): Sess
         return state;
       }
       return { ...state, panelNotice: action.notice };
+
+    case "findingConflict":
+      if (state.status !== "ready") {
+        return state;
+      }
+      return { ...state, findingConflict: action.conflict };
 
     case "file":
       if (state.status !== "ready") {
@@ -222,4 +238,9 @@ export function composerPrefill(state: ReadyState): string {
     return "";
   }
   return draftAtRow(state.drafts, state.composer.rows[1])?.body ?? "";
+}
+
+/** The id of the finding the panel currently has selected, if any. */
+export function selectedFindingId(panel: ReviewPanelDto | null): number | null {
+  return panel?.findings.find((finding) => finding.is_selected)?.id ?? null;
 }

--- a/apps/desktop/src/hooks/sessionReducer.ts
+++ b/apps/desktop/src/hooks/sessionReducer.ts
@@ -2,6 +2,7 @@ import type {
   AnchoredDraftDto,
   DraftsDto,
   FileDetailDto,
+  FindingDto,
   ReviewPanelDto,
   SessionFailureDto,
   SessionSnapshotDto,
@@ -128,7 +129,10 @@ export function sessionReducer(state: SessionState, action: SessionAction): Sess
       if (stale) {
         return state;
       }
-      return { ...state, panel: action.panel, panelNotice: null };
+      // A finding's id can come to mean a different claim after a re-run, so a
+      // pending replace-or-keep confirmation cannot be trusted across any new
+      // panel and is dropped along with it.
+      return { ...state, panel: action.panel, panelNotice: null, findingConflict: null };
     }
 
     case "panelNotice":
@@ -240,7 +244,7 @@ export function composerPrefill(state: ReadyState): string {
   return draftAtRow(state.drafts, state.composer.rows[1])?.body ?? "";
 }
 
-/** The id of the finding the panel currently has selected, if any. */
-export function selectedFindingId(panel: ReviewPanelDto | null): number | null {
-  return panel?.findings.find((finding) => finding.is_selected)?.id ?? null;
+/** The finding the panel currently has selected, if any. */
+export function selectedFinding(panel: ReviewPanelDto | null): FindingDto | null {
+  return panel?.findings.find((finding) => finding.is_selected) ?? null;
 }

--- a/apps/desktop/src/hooks/useSession.ts
+++ b/apps/desktop/src/hooks/useSession.ts
@@ -5,13 +5,14 @@ import type { DiffSideDto, FindingLocationDto, ReviewPanelDto } from "../binding
 import { commands } from "../bindings";
 import { clamp } from "../lib/clamp";
 import { toFailure } from "../lib/failure";
-import { initialState, selectedFindingId, selectionRange, sessionReducer } from "./sessionReducer";
+import { initialState, selectedFinding, selectionRange, sessionReducer } from "./sessionReducer";
 import { useDraftQueue } from "./useDraftQueue";
 
+/** What a command answering with `T`, or `null` when nothing can be reviewed. */
+type CommandResult<T> = { status: "ok"; data: T | null } | { status: "error"; error: unknown };
+
 /** What a command answering with the review panel hands back. */
-type PanelResult =
-  | { status: "ok"; data: ReviewPanelDto | null }
-  | { status: "error"; error: unknown };
+type PanelResult = CommandResult<ReviewPanelDto>;
 
 /**
  * Loads one session and exposes every action the UI can take on it.
@@ -162,6 +163,28 @@ export function useSession(description: string, isShowing: boolean) {
   );
 
   /**
+   * Applies a finding command's answer: a refusal becomes a panel notice, and
+   * an answer of `null` (nothing to review) is silently skipped. Only a real
+   * answer reaches `onData`, which the caller uses to update the rest of the
+   * state.
+   */
+  const applyFindingResult = useCallback(
+    <T,>(promise: Promise<CommandResult<T>>, onData: (data: T) => void) => {
+      promise.then((result) => {
+        if (result.status === "error") {
+          dispatch({ type: "panelNotice", notice: toFailure(result.error).summary });
+          return;
+        }
+        if (result.data === null) {
+          return;
+        }
+        onData(result.data);
+      });
+    },
+    [],
+  );
+
+  /**
    * Switches to a finding's file and selects its row, if it has one.
    *
    * A finding about the change as a whole has nowhere to scroll to, so the panel
@@ -189,63 +212,46 @@ export function useSession(description: string, isShowing: boolean) {
   /** Selects a finding, scrolling the diff to its anchor and selecting the row. */
   const revealFinding = useCallback(
     (id: number) => {
-      commands.revealFinding(id).then((result) => {
-        if (result.status === "error") {
-          dispatch({ type: "panelNotice", notice: toFailure(result.error).summary });
-          return;
-        }
-        if (result.data === null) {
-          return;
-        }
-        dispatch({ type: "panel", panel: result.data.panel });
-        applyLocation(result.data.location);
+      applyFindingResult(commands.revealFinding(id), (data) => {
+        dispatch({ type: "panel", panel: data.panel });
+        applyLocation(data.location);
       });
     },
-    [applyLocation],
+    [applyFindingResult, applyLocation],
   );
 
   /** Moves the selection to the finding after the one selected, wrapping to the first. */
   const selectNextFinding = useCallback(() => {
-    commands.selectNextFinding().then((result) => {
-      if (result.status === "error") {
-        dispatch({ type: "panelNotice", notice: toFailure(result.error).summary });
-        return;
-      }
-      if (result.data === null) {
-        return;
-      }
-      dispatch({ type: "panel", panel: result.data.panel });
-      applyLocation(result.data.location);
+    applyFindingResult(commands.selectNextFinding(), (data) => {
+      dispatch({ type: "panel", panel: data.panel });
+      applyLocation(data.location);
     });
-  }, [applyLocation]);
+  }, [applyFindingResult, applyLocation]);
 
   /**
    * Accepts a finding, turning it into a draft where the model allows it.
    *
    * When the anchor already holds the reviewer's own draft, neither text is
-   * written; the panel asks whether to replace it instead.
+   * written; the panel asks whether to replace it instead, first revealing the
+   * row so the reviewer can see what they are being asked about.
    */
-  const acceptFinding = useCallback((id: number) => {
-    commands.acceptFinding(id).then((result) => {
-      if (result.status === "error") {
-        dispatch({ type: "panelNotice", notice: toFailure(result.error).summary });
-        return;
-      }
-      if (result.data === null) {
-        return;
-      }
-      const { panel, drafts, disposition } = result.data;
-      dispatch({ type: "panel", panel });
-      dispatch({ type: "drafts", drafts });
-      dispatch({
-        type: "findingConflict",
-        conflict:
-          disposition.outcome === "Occupied"
-            ? { id, existing: disposition.existing, proposed: disposition.proposed }
-            : null,
+  const acceptFinding = useCallback(
+    (id: number) => {
+      applyFindingResult(commands.acceptFinding(id), (data) => {
+        const { panel, drafts, disposition } = data;
+        dispatch({ type: "panel", panel });
+        dispatch({ type: "drafts", drafts });
+        if (disposition.outcome === "Occupied") {
+          applyLocation(disposition.location);
+          dispatch({
+            type: "findingConflict",
+            conflict: { id, existing: disposition.existing, proposed: disposition.proposed },
+          });
+        }
       });
-    });
-  }, []);
+    },
+    [applyFindingResult, applyLocation],
+  );
 
   const dismissFinding = useCallback(
     (id: number) => {
@@ -255,21 +261,28 @@ export function useSession(description: string, isShowing: boolean) {
     [onPanel],
   );
 
-  /** Forces a finding onto its anchor, overwriting the reviewer's own draft there. */
-  const replaceFinding = useCallback((id: number) => {
-    commands.overwriteFinding(id).then((result) => {
+  /**
+   * Forces a finding onto its anchor, overwriting the reviewer's own draft
+   * there. A stale answer (the finding this was asked about no longer exists,
+   * or is no longer the one awaiting a reply) is refused rather than applied,
+   * which is surfaced as a panel notice rather than treated as success.
+   */
+  const replaceFinding = useCallback(
+    (id: number) => {
       dispatch({ type: "findingConflict", conflict: null });
-      if (result.status === "error") {
-        dispatch({ type: "panelNotice", notice: toFailure(result.error).summary });
-        return;
-      }
-      if (result.data === null) {
-        return;
-      }
-      dispatch({ type: "panel", panel: result.data.panel });
-      dispatch({ type: "drafts", drafts: result.data.drafts });
-    });
-  }, []);
+      applyFindingResult(commands.overwriteFinding(id), (data) => {
+        dispatch({ type: "panel", panel: data.panel });
+        dispatch({ type: "drafts", drafts: data.drafts });
+        if (data.disposition.outcome !== "Drafted") {
+          dispatch({
+            type: "panelNotice",
+            notice: "This finding is no longer waiting to be replaced.",
+          });
+        }
+      });
+    },
+    [applyFindingResult],
+  );
 
   /** Leaves the reviewer's draft and the finding both exactly as they were. */
   const keepFinding = useCallback(() => dispatch({ type: "findingConflict", conflict: null }), []);
@@ -360,17 +373,18 @@ export function useSession(description: string, isShowing: boolean) {
       }
       if (event.metaKey && event.shiftKey && key === "y") {
         event.preventDefault();
-        const id = selectedFindingId(current.panel);
-        if (id !== null) {
-          acceptFinding(id);
+        const finding = selectedFinding(current.panel);
+        // No summary editor yet, so a whole-change finding cannot be accepted.
+        if (finding !== null && finding.position !== null) {
+          acceptFinding(finding.id);
         }
         return;
       }
       if (event.metaKey && event.shiftKey && key === "d") {
         event.preventDefault();
-        const id = selectedFindingId(current.panel);
-        if (id !== null) {
-          dismissFinding(id);
+        const finding = selectedFinding(current.panel);
+        if (finding !== null) {
+          dismissFinding(finding.id);
         }
         return;
       }

--- a/apps/desktop/src/hooks/useSession.ts
+++ b/apps/desktop/src/hooks/useSession.ts
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useReducer, useRef } from "react";
 import { Channel } from "@tauri-apps/api/core";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
-import type { DiffSideDto, ReviewPanelDto } from "../bindings";
+import type { DiffSideDto, FindingLocationDto, ReviewPanelDto } from "../bindings";
 import { commands } from "../bindings";
 import { clamp } from "../lib/clamp";
 import { toFailure } from "../lib/failure";
-import { initialState, selectionRange, sessionReducer } from "./sessionReducer";
+import { initialState, selectedFindingId, selectionRange, sessionReducer } from "./sessionReducer";
 import { useDraftQueue } from "./useDraftQueue";
 
 /** What a command answering with the review panel hands back. */
@@ -161,6 +161,119 @@ export function useSession(description: string, isShowing: boolean) {
     [onPanel],
   );
 
+  /**
+   * Switches to a finding's file and selects its row, if it has one.
+   *
+   * A finding about the change as a whole has nowhere to scroll to, so the panel
+   * selection is the only thing that moves.
+   */
+  const applyLocation = useCallback((location: FindingLocationDto | null) => {
+    if (location === null) {
+      return;
+    }
+    const current = stateRef.current;
+    if (current.status === "ready" && current.file.index === location.file) {
+      dispatch({ type: "click", index: location.row });
+      return;
+    }
+    commands.selectFile(location.file).then((selected) => {
+      if (selected.status === "error") {
+        dispatch({ type: "panelNotice", notice: toFailure(selected.error).summary });
+        return;
+      }
+      dispatch({ type: "file", file: selected.data });
+      dispatch({ type: "click", index: location.row });
+    });
+  }, []);
+
+  /** Selects a finding, scrolling the diff to its anchor and selecting the row. */
+  const revealFinding = useCallback(
+    (id: number) => {
+      commands.revealFinding(id).then((result) => {
+        if (result.status === "error") {
+          dispatch({ type: "panelNotice", notice: toFailure(result.error).summary });
+          return;
+        }
+        if (result.data === null) {
+          return;
+        }
+        dispatch({ type: "panel", panel: result.data.panel });
+        applyLocation(result.data.location);
+      });
+    },
+    [applyLocation],
+  );
+
+  /** Moves the selection to the finding after the one selected, wrapping to the first. */
+  const selectNextFinding = useCallback(() => {
+    commands.selectNextFinding().then((result) => {
+      if (result.status === "error") {
+        dispatch({ type: "panelNotice", notice: toFailure(result.error).summary });
+        return;
+      }
+      if (result.data === null) {
+        return;
+      }
+      dispatch({ type: "panel", panel: result.data.panel });
+      applyLocation(result.data.location);
+    });
+  }, [applyLocation]);
+
+  /**
+   * Accepts a finding, turning it into a draft where the model allows it.
+   *
+   * When the anchor already holds the reviewer's own draft, neither text is
+   * written; the panel asks whether to replace it instead.
+   */
+  const acceptFinding = useCallback((id: number) => {
+    commands.acceptFinding(id).then((result) => {
+      if (result.status === "error") {
+        dispatch({ type: "panelNotice", notice: toFailure(result.error).summary });
+        return;
+      }
+      if (result.data === null) {
+        return;
+      }
+      const { panel, drafts, disposition } = result.data;
+      dispatch({ type: "panel", panel });
+      dispatch({ type: "drafts", drafts });
+      dispatch({
+        type: "findingConflict",
+        conflict:
+          disposition.outcome === "Occupied"
+            ? { id, existing: disposition.existing, proposed: disposition.proposed }
+            : null,
+      });
+    });
+  }, []);
+
+  const dismissFinding = useCallback(
+    (id: number) => {
+      dispatch({ type: "findingConflict", conflict: null });
+      onPanel(commands.dismissFinding(id));
+    },
+    [onPanel],
+  );
+
+  /** Forces a finding onto its anchor, overwriting the reviewer's own draft there. */
+  const replaceFinding = useCallback((id: number) => {
+    commands.overwriteFinding(id).then((result) => {
+      dispatch({ type: "findingConflict", conflict: null });
+      if (result.status === "error") {
+        dispatch({ type: "panelNotice", notice: toFailure(result.error).summary });
+        return;
+      }
+      if (result.data === null) {
+        return;
+      }
+      dispatch({ type: "panel", panel: result.data.panel });
+      dispatch({ type: "drafts", drafts: result.data.drafts });
+    });
+  }, []);
+
+  /** Leaves the reviewer's draft and the finding both exactly as they were. */
+  const keepFinding = useCallback(() => dispatch({ type: "findingConflict", conflict: null }), []);
+
   const clickRow = useCallback((index: number) => dispatch({ type: "click", index }), []);
 
   const openComposer = useCallback((index: number) => dispatch({ type: "openComposer", index }), []);
@@ -240,6 +353,27 @@ export function useSession(description: string, isShowing: boolean) {
         runReview();
         return;
       }
+      if (event.metaKey && event.shiftKey && key === "f") {
+        event.preventDefault();
+        selectNextFinding();
+        return;
+      }
+      if (event.metaKey && event.shiftKey && key === "y") {
+        event.preventDefault();
+        const id = selectedFindingId(current.panel);
+        if (id !== null) {
+          acceptFinding(id);
+        }
+        return;
+      }
+      if (event.metaKey && event.shiftKey && key === "d") {
+        event.preventDefault();
+        const id = selectedFindingId(current.panel);
+        if (id !== null) {
+          dismissFinding(id);
+        }
+        return;
+      }
       if (event.metaKey && !event.shiftKey && key === "c") {
         event.preventDefault();
         const [start, end] = selectionRange(current);
@@ -268,7 +402,16 @@ export function useSession(description: string, isShowing: boolean) {
 
     window.addEventListener("keydown", handleKeydown);
     return () => window.removeEventListener("keydown", handleKeydown);
-  }, [state.status, isShowing, selectFile, toggleViewed, runReview]);
+  }, [
+    state.status,
+    isShowing,
+    selectFile,
+    toggleViewed,
+    runReview,
+    selectNextFinding,
+    acceptFinding,
+    dismissFinding,
+  ]);
 
   return {
     state,
@@ -283,5 +426,10 @@ export function useSession(description: string, isShowing: boolean) {
     cancelReview,
     toggleGuidanceSection,
     toggleGuidanceFile,
+    revealFinding,
+    acceptFinding,
+    dismissFinding,
+    replaceFinding,
+    keepFinding,
   };
 }

--- a/apps/desktop/src/test/fixtures.ts
+++ b/apps/desktop/src/test/fixtures.ts
@@ -3,6 +3,7 @@ import type {
   DraftsDto,
   FileDetailDto,
   FileSummaryDto,
+  FindingDto,
   GuidanceDto,
   GuidanceEntryDto,
   HomeGroupDto,
@@ -129,6 +130,21 @@ export function makeGuidance(overrides: Partial<DiscoveredGuidance> = {}): Guida
   };
 }
 
+export function makeFinding(overrides: Partial<FindingDto> = {}): FindingDto {
+  return {
+    id: 1,
+    severity: "Warning",
+    confidence: 90,
+    title: "Unchecked index",
+    rationale: "This can panic on an empty slice.",
+    citations: ["AGENTS.md"],
+    origin: "claude-code",
+    position: "src/review_fixture_00.rs:2",
+    is_selected: false,
+    ...overrides,
+  };
+}
+
 export function makePanel(overrides: Partial<ReviewPanelDto> = {}): ReviewPanelDto {
   return {
     revision: 1,
@@ -139,6 +155,7 @@ export function makePanel(overrides: Partial<ReviewPanelDto> = {}): ReviewPanelD
       heading: "No review has been run.",
       detail: "Press Review to check this change against the repository's guidance.",
     },
+    findings: [],
     footer: null,
     ...overrides,
   };

--- a/apps/desktop/src/test/fixtures.ts
+++ b/apps/desktop/src/test/fixtures.ts
@@ -134,7 +134,7 @@ export function makeFinding(overrides: Partial<FindingDto> = {}): FindingDto {
   return {
     id: 1,
     severity: "Warning",
-    confidence: 90,
+    confidence_percent: 90,
     title: "Unchecked index",
     rationale: "This can panic on an empty slice.",
     citations: ["AGENTS.md"],

--- a/crates/app/src/review.rs
+++ b/crates/app/src/review.rs
@@ -85,6 +85,14 @@ pub struct ReviewModel {
     pub(crate) run: ReviewRunState,
     /// Which finding the reviewer is looking at.
     pub(crate) selected_finding: Option<FindingId>,
+    /// The finding accepting asked the reviewer to replace or keep, if one is
+    /// still waiting on an answer.
+    ///
+    /// A re-run reassigns finding ids from zero, so the id an earlier answer
+    /// names can come to mean an entirely different claim. Overwriting is
+    /// refused unless it matches this, which is cleared on every run
+    /// transition, every dismissal, and every fresh accept.
+    pub(crate) pending_replace: Option<FindingId>,
     /// Whether the guidance section is open.
     ///
     /// Open before the first run, because PLAN wants what will be sent seen before
@@ -109,6 +117,7 @@ impl ReviewModel {
             session,
             run: ReviewRunState::Idle,
             selected_finding: None,
+            pending_replace: None,
             guidance_expanded: true,
             revision: 0,
         }

--- a/crates/app/src/session.rs
+++ b/crates/app/src/session.rs
@@ -350,6 +350,9 @@ impl SessionModel {
             return None;
         };
         review.selected_finding = Some(id);
+        // The selection is part of what the panel shows: every finding's row
+        // reads its own highlight off it.
+        review.touch();
         review
             .session
             .findings()
@@ -971,6 +974,21 @@ mod tests {
         assert!(review(&model).session().drafts().is_empty());
     }
 
+    /// The selection a reveal moves is part of what the panel shows, so it has
+    /// to bump the revision the same as any other panel-visible change.
+    #[test]
+    fn revealing_a_finding_selects_it_and_bumps_the_revision() {
+        let mut model = ready_model(None);
+        let id = give_one_finding(&mut model, "unchecked index");
+        let revision = review(&model).revision();
+
+        let location = model.reveal_finding(id);
+
+        assert_eq!(location, Some(AnchorLocation { file: 0, row: 1 }));
+        assert_eq!(review(&model).selected_finding(), Some(id));
+        bumped(&model, revision, "revealing a finding");
+    }
+
     /// The reviewer's own words are never overwritten; both texts go to the
     /// composer instead, and nothing is saved until they commit.
     #[test]
@@ -1193,6 +1211,9 @@ mod tests {
 
         let id = give_one_finding(&mut model, "still risky");
         revision = bumped(&model, revision, "findings arriving again");
+
+        model.reveal_finding(id);
+        revision = bumped(&model, revision, "revealing a finding");
 
         assert_eq!(model.accept_finding(id), FindingDisposition::Drafted);
         revision = bumped(&model, revision, "accepting a finding");

--- a/crates/app/src/session.rs
+++ b/crates/app/src/session.rs
@@ -283,6 +283,10 @@ impl SessionModel {
             }
             FindingAcceptance::Unknown => FindingDisposition::Unknown,
         };
+        // Recomputed on every call, so a fresh accept always names the finding it
+        // just asked about, whatever an earlier call left behind.
+        review.pending_replace =
+            matches!(disposition, FindingDisposition::Composer { .. }).then_some(id);
         if !matches!(disposition, FindingDisposition::Unknown) {
             review.touch();
         }
@@ -293,30 +297,36 @@ impl SessionModel {
     /// there.
     ///
     /// Only reached after the reviewer has been asked and chosen to replace what
-    /// they wrote; `accept_finding` refuses this on its own. Reports whether a
-    /// pending finding still had that id.
-    pub fn overwrite_finding(&mut self, id: FindingId) -> bool {
+    /// they wrote; `accept_finding` refuses this on its own. Refuses any id
+    /// other than the one that was asked about: a re-run reassigns finding ids
+    /// from zero, so an answer given before a re-run could otherwise overwrite a
+    /// draft the reviewer was never asked about.
+    pub fn overwrite_finding(&mut self, id: FindingId) -> FindingDisposition {
         let Self {
             phase, review_sink, ..
         } = self;
         let SessionPhase::Ready(review) = phase else {
-            return false;
+            return FindingDisposition::Unknown;
         };
+        if review.pending_replace != Some(id) {
+            return FindingDisposition::Unknown;
+        }
         let Some((anchor, body)) = review.session.overwrite_finding(id) else {
-            return false;
+            return FindingDisposition::Unknown;
         };
         let provenance = review
             .session
             .drafts()
             .get(&anchor)
             .and_then(|draft| draft.provenance.clone());
+        review.pending_replace = None;
         review.reselect_finding();
         if let (Some(sink), Some(provenance)) = (review_sink.as_deref(), provenance) {
             sink.save(&anchor, &body);
             sink.save_provenance(&anchor, &provenance);
         }
         review.touch();
-        true
+        FindingDisposition::Drafted
     }
 
     /// Rejects a claim and remembers the decision, so a re-run does not offer it
@@ -331,6 +341,7 @@ impl SessionModel {
         let Some(fingerprint) = review.session.dismiss_finding(id) else {
             return false;
         };
+        review.pending_replace = None;
         review.reselect_finding();
         if let (Some(sink), Some(head_sha)) =
             (review_sink.as_deref(), review.session.source().head_sha())
@@ -344,20 +355,18 @@ impl SessionModel {
     /// Selects a finding, returning where the diff should scroll to show it.
     ///
     /// `None` for a finding about the change as a whole, which has nowhere to
-    /// scroll to.
+    /// scroll to, or for an id that no longer names a pending finding, which
+    /// selects nothing rather than pointing the panel at a finding that is gone.
     pub fn reveal_finding(&mut self, id: FindingId) -> Option<AnchorLocation> {
         let SessionPhase::Ready(review) = &mut self.phase else {
             return None;
         };
+        let finding = review.session.findings().get(id)?;
+        let location = finding.location;
         review.selected_finding = Some(id);
-        // The selection is part of what the panel shows: every finding's row
-        // reads its own highlight off it.
+        // The selection is part of what the panel shows, so this counts as a change.
         review.touch();
-        review
-            .session
-            .findings()
-            .get(id)
-            .and_then(|finding| finding.location)
+        location
     }
 
     /// The session a review would run against, when one can be started.
@@ -381,6 +390,10 @@ impl SessionModel {
             detail: "Starting...".to_owned(),
             cancel,
         };
+        // A run in flight will reassign every finding id when it lands, so any
+        // reply still awaited from before it started names a claim that may no
+        // longer be the one it was asked about.
+        review.pending_replace = None;
         review.touch();
     }
 
@@ -417,6 +430,7 @@ impl SessionModel {
         let rejected = findings.rejected().len();
         let suppressed = review.session.set_findings(findings);
         let accepted = review.session.findings().len();
+        review.pending_replace = None;
         review.reselect_finding();
         review.run = ReviewRunState::Complete {
             accepted,
@@ -439,6 +453,7 @@ impl SessionModel {
             summary: summary.into(),
             remediation,
         };
+        review.pending_replace = None;
         review.touch();
     }
 
@@ -989,6 +1004,22 @@ mod tests {
         bumped(&model, revision, "revealing a finding");
     }
 
+    /// A click can arrive for a row a re-run has already dropped. It must select
+    /// and publish nothing, not a finding that no longer exists.
+    #[test]
+    fn revealing_a_finding_that_no_longer_exists_changes_nothing() {
+        let mut model = ready_model(None);
+        let id = give_one_finding(&mut model, "unchecked index");
+        model.review_finished(Findings::default(), Vec::new());
+        let revision = review(&model).revision();
+
+        let location = model.reveal_finding(id);
+
+        assert_eq!(location, None);
+        assert_eq!(review(&model).selected_finding(), None);
+        assert_eq!(review(&model).revision(), revision, "nothing changed");
+    }
+
     /// The reviewer's own words are never overwritten; both texts go to the
     /// composer instead, and nothing is saved until they commit.
     #[test]
@@ -1017,17 +1048,21 @@ mod tests {
         assert_eq!(sink.calls().len(), before, "nothing was written");
     }
 
-    /// The desktop panel's alternative to the composer: overwrite rather than
-    /// merge, chosen only once the reviewer has been asked.
+    /// The desktop panel's alternative to the composer. Overwrites rather than
+    /// merging, chosen only once the reviewer has been asked.
     #[test]
     fn overwriting_a_findings_own_line_replaces_the_reviewers_draft() {
         let sink = RecordingSink::default();
         let mut model = ready_model(Some(Box::new(sink.clone())));
         assert!(model.draft_edited(1..=1, "mine".to_owned()));
         let id = give_one_finding(&mut model, "unchecked index");
+        assert!(matches!(
+            model.accept_finding(id),
+            FindingDisposition::Composer { .. }
+        ));
         let before = sink.calls().len();
 
-        assert!(model.overwrite_finding(id));
+        assert_eq!(model.overwrite_finding(id), FindingDisposition::Drafted);
 
         assert_eq!(
             &sink.calls()[before..],
@@ -1047,7 +1082,54 @@ mod tests {
     fn overwriting_an_unknown_finding_changes_nothing() {
         let mut model = ready_model(None);
 
-        assert!(!model.overwrite_finding(FindingId(7)));
+        assert_eq!(
+            model.overwrite_finding(FindingId(7)),
+            FindingDisposition::Unknown
+        );
+    }
+
+    /// The gate the whole design turns on: nothing may be overwritten unless
+    /// the reviewer was actually asked about that finding.
+    #[test]
+    fn overwriting_a_finding_that_was_never_asked_about_changes_nothing() {
+        let sink = RecordingSink::default();
+        let mut model = ready_model(Some(Box::new(sink.clone())));
+        assert!(model.draft_edited(1..=1, "mine".to_owned()));
+        let id = give_one_finding(&mut model, "unchecked index");
+        let before = sink.calls().len();
+
+        // No accept_finding call happened, so nothing is awaiting a replace answer.
+        assert_eq!(model.overwrite_finding(id), FindingDisposition::Unknown);
+
+        assert_eq!(sink.calls().len(), before, "nothing was written");
+        let session = review(&model).session();
+        assert_eq!(
+            session.draft_at(0, 1).map(|draft| draft.body.as_str()),
+            Some("mine")
+        );
+        assert_eq!(session.findings().len(), 1, "the finding is still pending");
+    }
+
+    /// The premise a re-run breaks otherwise: ids reset from zero every run, so
+    /// an id asked about before a re-run can come to name a different claim.
+    #[test]
+    fn a_re_run_clears_the_pending_replace_so_the_same_numeric_id_is_refused() {
+        let sink = RecordingSink::default();
+        let mut model = ready_model(Some(Box::new(sink.clone())));
+        assert!(model.draft_edited(1..=1, "mine".to_owned()));
+        let id = give_one_finding(&mut model, "unchecked index");
+        assert!(matches!(
+            model.accept_finding(id),
+            FindingDisposition::Composer { .. }
+        ));
+
+        let reran_id = give_one_finding(&mut model, "a different claim");
+        assert_eq!(reran_id, id, "ids reset each run");
+        let before = sink.calls().len();
+
+        assert_eq!(model.overwrite_finding(id), FindingDisposition::Unknown);
+
+        assert_eq!(sink.calls().len(), before, "nothing was written");
     }
 
     #[test]
@@ -1219,7 +1301,13 @@ mod tests {
         revision = bumped(&model, revision, "accepting a finding");
 
         let id = give_one_finding(&mut model, "occupying its own line");
-        assert!(model.overwrite_finding(id));
+        assert!(matches!(
+            model.accept_finding(id),
+            FindingDisposition::Composer { .. }
+        ));
+        revision = bumped(&model, revision, "asking about an occupied line");
+
+        assert_eq!(model.overwrite_finding(id), FindingDisposition::Drafted);
         bumped(&model, revision, "overwriting a finding");
     }
 

--- a/crates/app/src/session.rs
+++ b/crates/app/src/session.rs
@@ -289,6 +289,36 @@ impl SessionModel {
         disposition
     }
 
+    /// Forces a finding onto its anchor, overwriting the reviewer's own draft
+    /// there.
+    ///
+    /// Only reached after the reviewer has been asked and chosen to replace what
+    /// they wrote; `accept_finding` refuses this on its own. Reports whether a
+    /// pending finding still had that id.
+    pub fn overwrite_finding(&mut self, id: FindingId) -> bool {
+        let Self {
+            phase, review_sink, ..
+        } = self;
+        let SessionPhase::Ready(review) = phase else {
+            return false;
+        };
+        let Some((anchor, body)) = review.session.overwrite_finding(id) else {
+            return false;
+        };
+        let provenance = review
+            .session
+            .drafts()
+            .get(&anchor)
+            .and_then(|draft| draft.provenance.clone());
+        review.reselect_finding();
+        if let (Some(sink), Some(provenance)) = (review_sink.as_deref(), provenance) {
+            sink.save(&anchor, &body);
+            sink.save_provenance(&anchor, &provenance);
+        }
+        review.touch();
+        true
+    }
+
     /// Rejects a claim and remembers the decision, so a re-run does not offer it
     /// again.
     pub fn dismiss_finding(&mut self, id: FindingId) -> bool {
@@ -969,6 +999,39 @@ mod tests {
         assert_eq!(sink.calls().len(), before, "nothing was written");
     }
 
+    /// The desktop panel's alternative to the composer: overwrite rather than
+    /// merge, chosen only once the reviewer has been asked.
+    #[test]
+    fn overwriting_a_findings_own_line_replaces_the_reviewers_draft() {
+        let sink = RecordingSink::default();
+        let mut model = ready_model(Some(Box::new(sink.clone())));
+        assert!(model.draft_edited(1..=1, "mine".to_owned()));
+        let id = give_one_finding(&mut model, "unchecked index");
+        let before = sink.calls().len();
+
+        assert!(model.overwrite_finding(id));
+
+        assert_eq!(
+            &sink.calls()[before..],
+            [
+                "save src/review.rs 2 Handle the failure here.".to_owned(),
+                "provenance src/review.rs 2 claude-code".to_owned(),
+            ]
+        );
+        let session = review(&model).session();
+        assert!(session.findings().is_empty(), "acted on");
+        let draft = session.draft_at(0, 1).expect("the draft is there");
+        assert_eq!(draft.body, "Handle the failure here.");
+        assert!(draft.is_proposed());
+    }
+
+    #[test]
+    fn overwriting_an_unknown_finding_changes_nothing() {
+        let mut model = ready_model(None);
+
+        assert!(!model.overwrite_finding(FindingId(7)));
+    }
+
     #[test]
     fn a_finding_about_the_whole_change_goes_into_the_summary() {
         let sink = RecordingSink::default();
@@ -1132,7 +1195,11 @@ mod tests {
         revision = bumped(&model, revision, "findings arriving again");
 
         assert_eq!(model.accept_finding(id), FindingDisposition::Drafted);
-        bumped(&model, revision, "accepting a finding");
+        revision = bumped(&model, revision, "accepting a finding");
+
+        let id = give_one_finding(&mut model, "occupying its own line");
+        assert!(model.overwrite_finding(id));
+        bumped(&model, revision, "overwriting a finding");
     }
 
     /// The panel shows the latest line, so a report that arrives once the run is

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -1328,8 +1328,8 @@ mod tests {
         );
     }
 
-    /// The reviewer's alternative to `retire_finding` by hand: overwrite rather
-    /// than merge.
+    /// The reviewer's alternative to `retire_finding` by hand. Overwrites rather
+    /// than merging.
     #[test]
     fn overwriting_an_occupied_anchor_replaces_the_reviewers_draft_and_keeps_provenance() {
         let mut session = anchored_session();

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -734,6 +734,32 @@ impl ReviewSession {
         FindingAcceptance::Drafted { anchor, body }
     }
 
+    /// Forces a finding's proposed comment onto its anchor, overwriting whatever
+    /// the reviewer wrote there.
+    ///
+    /// Used only after the reviewer has explicitly chosen to replace their own
+    /// words with a finding [`accept_finding`] refused to write over. Returns
+    /// `None` for an id that no longer names a pending finding, or a finding with
+    /// nowhere to anchor, and changes nothing in either case.
+    ///
+    /// [`accept_finding`]: Self::accept_finding
+    pub fn overwrite_finding(&mut self, id: FindingId) -> Option<(DiffAnchor, String)> {
+        let finding = self.findings.get(id)?;
+        let anchor = finding.anchor.clone()?;
+        let location = finding.location?;
+        let provenance = finding.provenance();
+        let body = finding.proposed_comment.clone();
+        Arc::make_mut(&mut self.drafts).insert_with(
+            anchor.clone(),
+            body.clone(),
+            Some(provenance),
+            location.file,
+            location.row,
+        );
+        self.findings.take(id);
+        Some((anchor, body))
+    }
+
     /// Dismisses a finding and remembers the decision.
     ///
     /// Returns the fingerprint to persist, so the same claim is not offered again on
@@ -1299,6 +1325,40 @@ mod tests {
         assert_eq!(
             session.draft_at(0, 6).map(|draft| draft.body.as_str()),
             Some("mine, and also: handle the failure")
+        );
+    }
+
+    /// The reviewer's alternative to `retire_finding` by hand: overwrite rather
+    /// than merge.
+    #[test]
+    fn overwriting_an_occupied_anchor_replaces_the_reviewers_draft_and_keeps_provenance() {
+        let mut session = anchored_session();
+        session.set_draft(0, 6, "I already said something here");
+        let raw = raw_finding(&session, 6, "unchecked index");
+        with_findings(&mut session, vec![raw]);
+        let id = session.findings().accepted()[0].id;
+
+        let (anchor, body) = session
+            .overwrite_finding(id)
+            .expect("the finding is pending");
+
+        assert_eq!(body, "Handle the failure here.");
+        let draft = session.drafts().get(&anchor).expect("the draft is there");
+        assert_eq!(draft.body, "Handle the failure here.");
+        assert!(draft.is_proposed());
+        assert!(session.findings().is_empty(), "acted on");
+    }
+
+    #[test]
+    fn overwriting_an_unknown_finding_changes_nothing() {
+        let mut session = anchored_session();
+        session.set_draft(0, 6, "mine");
+
+        assert!(session.overwrite_finding(FindingId(7)).is_none());
+
+        assert_eq!(
+            session.draft_at(0, 6).map(|draft| draft.body.as_str()),
+            Some("mine")
         );
     }
 


### PR DESCRIPTION
Closes #29

A review run could complete but the desktop had no way to act on what it proposed. This is the second half of migration stage 4 and completes guided review in the Tauri app.

What changed:
- Findings render below the Guidance section with severity, confidence, position, rationale, the Guidance they cite, and the backend that proposed them in the reserved violet
- Cmd-Shift-F moves the selection, Cmd-Shift-Y accepts, Cmd-Shift-D dismisses, all inert in the composer and behind Home
- Accepting drafts the proposal at its anchor with provenance, so the diff shows the proposal mark, and the finding leaves the list
- Accepting onto a line that already holds the reviewer's comment shows both texts and asks whether to replace, after revealing the row
- Dismissing records the decision so a later run suppresses the claim and counts it as suppressed
- Clicking a finding scrolls the diff to its anchor and selects the row

Notes:
Start with the accept and overwrite paths in the session model. Finding ids are per-run indices, so a pending replace question is refused unless it names the finding actually asked about, and it is cleared on every run, dismissal, and fresh accept. A finding about the whole change offers no Accept until there is a summary editor to show the result, which arrives in the next stage. Two limitations inherited from the GPUI app are filed separately as #30 and #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189um4LrckqAAq5fgnixT1p
