### PR TITLE
Keep a review run alive behind Home

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -33,6 +33,7 @@ pub fn specta_builder() -> tauri_specta::Builder<tauri::Wry> {
         remove_repository,
         toggle_repositories_footer,
         open_row,
+        open_row_cancelling_run,
         return_to_home,
         return_to_session,
         open_session,
@@ -916,7 +917,7 @@ pub fn open_row(
     state: tauri::State<'_, AppRoot>,
     repository: String,
     number: u32,
-) -> Result<dto::WindowDto, dto::SessionFailureDto> {
+) -> Result<dto::OpenRowOutcomeDto, dto::SessionFailureDto> {
     open_row_on_root(&state, &repository, u64::from(number))
 }
 
@@ -924,7 +925,7 @@ fn open_row_on_root(
     root: &AppRoot,
     repository: &str,
     number: u64,
-) -> Result<dto::WindowDto, dto::SessionFailureDto> {
+) -> Result<dto::OpenRowOutcomeDto, dto::SessionFailureDto> {
     // Looked up before the window is touched, so a row that cannot be opened
     // costs the reviewer nothing of the Session they were reading.
     let clone_root = configured_clone(&root.home, repository)?;
@@ -934,7 +935,50 @@ fn open_row_on_root(
         number,
     };
     match window.open(pull_request, clone_root) {
-        Opened::Returned | Opened::Loading => Ok(describe(&window)),
+        Opened::Returned | Opened::Loading => Ok(dto::OpenRowOutcomeDto::Opened {
+            window: describe(&window),
+        }),
+        Opened::Blocked => Ok(dto::OpenRowOutcomeDto::Blocked),
+        Opened::Refused => Err(dto::command_failure(
+            "this window has no Home to open a row from",
+        )),
+    }
+}
+
+/// Opens the pull request a Home row names, first cancelling the run the
+/// Session alive was running.
+///
+/// Reached only once the reviewer has answered the confirmation `open_row`
+/// asked for by answering [`dto::OpenRowOutcomeDto::Blocked`].
+///
+/// # Errors
+///
+/// Returns a failure when no configured clone resolves to `repository`, which
+/// leaves the Session that was alive exactly as it was.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn open_row_cancelling_run(
+    state: tauri::State<'_, AppRoot>,
+    repository: String,
+    number: u32,
+) -> Result<dto::WindowDto, dto::SessionFailureDto> {
+    open_row_cancelling_run_on_root(&state, &repository, u64::from(number))
+}
+
+fn open_row_cancelling_run_on_root(
+    root: &AppRoot,
+    repository: &str,
+    number: u64,
+) -> Result<dto::WindowDto, dto::SessionFailureDto> {
+    let clone_root = configured_clone(&root.home, repository)?;
+    let mut window = lock(&root.window);
+    let pull_request = PullRequestId {
+        repository: repository.to_owned(),
+        number,
+    };
+    match window.open_cancelling_run(pull_request, clone_root) {
+        Opened::Returned | Opened::Loading | Opened::Blocked => Ok(describe(&window)),
         Opened::Refused => Err(dto::command_failure(
             "this window has no Home to open a row from",
         )),
@@ -1648,6 +1692,17 @@ mod tests {
         home_root(home)
     }
 
+    /// The window `open_row_on_root` showed, panicking if it asked for a
+    /// confirmation instead.
+    fn opened_window(root: &AppRoot, repository: &str, number: u64) -> dto::WindowDto {
+        match open_row_on_root(root, repository, number).expect("the clone is configured") {
+            dto::OpenRowOutcomeDto::Opened { window } => window,
+            dto::OpenRowOutcomeDto::Blocked => {
+                panic!("no live run was expected to block this open")
+            }
+        }
+    }
+
     /// Writes `stage` on the Session the window holds.
     ///
     /// A Session kept alive keeps whatever it had reached; one loaded in its
@@ -1692,7 +1747,7 @@ mod tests {
         let settings_path = directory.path().join("settings.toml");
         let root = home_root_listing(&clone, &settings_path);
 
-        let shown = open_row_on_root(&root, "acme/widgets", 412).expect("the clone is configured");
+        let shown = opened_window(&root, "acme/widgets", 412);
 
         assert_eq!(
             shown,
@@ -1763,6 +1818,78 @@ mod tests {
         );
     }
 
+    /// Puts the Session the window holds into a running review, with no coding
+    /// agent behind it, and hands back the flag that would cancel it.
+    fn start_a_run(root: &AppRoot) -> Arc<AtomicBool> {
+        let window = lock(&root.window);
+        let session = window.session.as_ref().expect("a session is open");
+        let mut guard = lock(&session.model);
+        guard.finish(Ok(domain::LoadedSession {
+            session: domain::ReviewSession::new(
+                domain::SessionSource::Demo,
+                vec![domain::DiffFile::demo(8)].into(),
+            )
+            .expect("the fixture has files"),
+            review_sink: None,
+            submitter: None,
+        }));
+        let cancel = Arc::new(AtomicBool::new(false));
+        guard.review_started(Arc::clone(&cancel));
+        cancel
+    }
+
+    /// A live run is in the way of dropping the Session silently, so opening a
+    /// different row asks for confirmation and starts nothing.
+    #[test]
+    fn opening_another_row_with_a_live_run_is_blocked() {
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = directory.path().join("settings.toml");
+        let root = home_root_listing(&clone, &settings_path);
+        open_row_on_root(&root, "acme/widgets", 412).expect("the clone is configured");
+        start_a_run(&root);
+
+        let outcome =
+            open_row_on_root(&root, "acme/widgets", 398).expect("the clone is configured");
+
+        assert_eq!(outcome, dto::OpenRowOutcomeDto::Blocked);
+        assert_eq!(
+            open_request(&root),
+            SessionRequest::PullRequest {
+                repository: clone.path().canonicalize().unwrap(),
+                selector: github::PullRequestSelector::Number(412),
+            },
+            "the Session with the live run is still the one alive",
+        );
+    }
+
+    /// Confirming past the block cancels the run in the way and opens the row.
+    #[test]
+    fn opening_another_row_cancelling_the_run_ends_it_and_opens_the_new_session() {
+        let clone = clone_of("acme/widgets");
+        let directory = TempDir::new().unwrap();
+        let settings_path = directory.path().join("settings.toml");
+        let root = home_root_listing(&clone, &settings_path);
+        open_row_on_root(&root, "acme/widgets", 412).expect("the clone is configured");
+        let cancel = start_a_run(&root);
+
+        open_row_cancelling_run_on_root(&root, "acme/widgets", 398)
+            .expect("the clone is configured");
+
+        assert!(
+            cancel.load(Ordering::Relaxed),
+            "the run in the way was cancelled"
+        );
+        assert_eq!(
+            open_request(&root),
+            SessionRequest::PullRequest {
+                repository: clone.path().canonicalize().unwrap(),
+                selector: github::PullRequestSelector::Number(398),
+            },
+            "the new row's Session is the one alive now",
+        );
+    }
+
     #[test]
     fn going_back_shows_home_and_reports_the_session_still_alive_behind_it() {
         let clone = clone_of("acme/widgets");
@@ -1799,7 +1926,7 @@ mod tests {
         let directory = TempDir::new().unwrap();
         let settings_path = directory.path().join("settings.toml");
         let root = home_root_listing(&clone, &settings_path);
-        let opened = open_row_on_root(&root, "acme/widgets", 412).expect("the clone is configured");
+        let opened = opened_window(&root, "acme/widgets", 412);
         return_to_home_on_root(&root).expect("there is a Home behind it");
 
         let shown = return_to_session_on_root(&root).expect("a session is alive");

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -78,6 +78,18 @@ pub enum WindowDto {
     Session { session: OpenSessionDto },
 }
 
+/// What opening a row answered with.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, specta::Type)]
+#[serde(tag = "outcome")]
+pub enum OpenRowOutcomeDto {
+    /// The row opened, or the Session already alive on it was shown again.
+    Opened { window: WindowDto },
+    /// The Session alive behind Home has a live run in the way. Nothing was
+    /// touched; the frontend asks the reviewer to cancel the run and continue,
+    /// or stay.
+    Blocked,
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, specta::Type)]
 pub enum DiffSideDto {
     Left,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -5,7 +5,7 @@ use std::{
     sync::{Arc, Mutex, atomic::AtomicBool},
 };
 
-use app::{HomeModel, Opened, PullRequestId, SessionModel, SessionSlot};
+use app::{HomeModel, Opened, PullRequestId, SessionModel, SessionSlot, lock};
 use github::{GithubClient, PullRequestSelector};
 use session::{ReviewStorage, SessionRequest};
 
@@ -113,14 +113,44 @@ impl Window {
     /// Opens `pull_request` from a Home row, out of the clone at `clone_root`.
     ///
     /// The Session already alive on this pull request is shown again rather
-    /// than loaded a second time, which is what makes coming back instant. Any
-    /// other Session is dropped, silently, because Drafts already persist. A
-    /// window with no Home refuses the row and keeps what it holds.
+    /// than loaded a second time, which is what makes coming back instant. A
+    /// different Session with no live run is dropped, silently, because Drafts
+    /// already persist. A different Session with a live run is left alone and
+    /// answered with [`Opened::Blocked`], so the caller can ask the reviewer
+    /// before touching it; [`Self::open_cancelling_run`] is the confirmed path
+    /// past that. A window with no Home refuses the row and keeps what it holds.
     pub(crate) fn open(&mut self, pull_request: PullRequestId, clone_root: PathBuf) -> Opened {
+        let run_is_live = self.hidden_run_is_live();
+        self.open_asking(pull_request, clone_root, run_is_live)
+    }
+
+    /// Opens `pull_request`, cancelling the run the Session alive was running
+    /// first.
+    ///
+    /// Only reached once the reviewer has answered the confirmation
+    /// [`Opened::Blocked`] asked, so the live run is no longer in the way of
+    /// dropping that Session.
+    pub(crate) fn open_cancelling_run(
+        &mut self,
+        pull_request: PullRequestId,
+        clone_root: PathBuf,
+    ) -> Opened {
+        if let Some(session) = &self.session {
+            lock(&session.model).cancel_review();
+        }
+        self.open_asking(pull_request, clone_root, false)
+    }
+
+    fn open_asking(
+        &mut self,
+        pull_request: PullRequestId,
+        clone_root: PathBuf,
+        run_is_live: bool,
+    ) -> Opened {
         let number = pull_request.number;
-        let opened = self.slot.open(pull_request);
+        let opened = self.slot.open(pull_request, run_is_live);
         match opened {
-            Opened::Returned | Opened::Refused => {}
+            Opened::Returned | Opened::Refused | Opened::Blocked => {}
             Opened::Loading => {
                 self.session = Some(ManagedSession::new(
                     SessionRequest::PullRequest {
@@ -132,6 +162,16 @@ impl Window {
             }
         }
         opened
+    }
+
+    /// Whether the Session alive behind Home, if there is one, has a review run
+    /// in flight.
+    fn hidden_run_is_live(&self) -> bool {
+        self.session.as_ref().is_some_and(|session| {
+            lock(&session.model)
+                .review()
+                .is_some_and(|review| review.run().is_running())
+        })
     }
 }
 

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -3,6 +3,7 @@ import type { OpenSessionDto, SessionFailureDto, WindowDto } from "./bindings";
 import { commands } from "./bindings";
 import { FailureScreen } from "./components/FailureScreen";
 import { HomeScreen } from "./components/HomeScreen";
+import type { OpenRowResult } from "./hooks/useHome";
 import { toFailure } from "./lib/failure";
 import { SessionApp } from "./SessionApp";
 import "./App.css";
@@ -30,6 +31,10 @@ function currentScreen(shown: WindowDto): Screen {
 export default function App() {
   const [shown, setShown] = useState<WindowDto | null>(null);
   const [failure, setFailure] = useState<SessionFailureDto | null>(null);
+  // Told by the Session behind Home whenever its run's state changes, so the
+  // header slot follows a run it cannot see. Reset by the fresh `useSession`
+  // a new Session mounts with, whether by a row opening one or replacing one.
+  const [isReviewRunning, setIsReviewRunning] = useState(false);
 
   useEffect(() => {
     commands
@@ -56,8 +61,32 @@ export default function App() {
       .catch((error: unknown) => toFailure(error));
   }, []);
 
-  const openRow = useCallback(
-    (repository: string, number: number) => navigate(commands.openRow(repository, number)),
+  /**
+   * Opens `repository#number`, answering with whether it opened, whether a
+   * live run behind Home blocked it, or a refusal.
+   *
+   * A block is not a failure and is not shown here: Home renders the
+   * confirmation and asks again through `cancelRunAndOpenRow`.
+   */
+  const openRow = useCallback((repository: string, number: number): Promise<OpenRowResult> => {
+    return commands
+      .openRow(repository, number)
+      .then((result) => {
+        if (result.status === "error") {
+          return { status: "error" as const, error: toFailure(result.error) };
+        }
+        if (result.data.outcome === "Blocked") {
+          return { status: "blocked" as const };
+        }
+        setShown(result.data.window);
+        return { status: "opened" as const };
+      })
+      .catch((error: unknown) => ({ status: "error" as const, error: toFailure(error) }));
+  }, []);
+  /** Cancels the run in the way, then opens the row, once Home has confirmed. */
+  const cancelRunAndOpenRow = useCallback(
+    (repository: string, number: number) =>
+      navigate(commands.openRowCancellingRun(repository, number)),
     [navigate],
   );
   const returnToSession = useCallback(() => navigate(commands.returnToSession()), [navigate]);
@@ -110,7 +139,9 @@ export default function App() {
           <HomeScreen
             isShowing={isShowingHome}
             aliveIdentity={session?.row_identity ?? null}
+            isReviewRunning={isReviewRunning}
             onOpenRow={openRow}
+            onCancelRunAndOpenRow={cancelRunAndOpenRow}
             onReturnToSession={returnToSession}
           />
         </div>
@@ -124,6 +155,7 @@ export default function App() {
             description={session.description}
             isShowing={!isShowingHome}
             onBack={canGoBack ? returnToHome : null}
+            onRunningChange={setIsReviewRunning}
           />
         </div>
       )}

--- a/apps/desktop/src/Navigation.test.tsx
+++ b/apps/desktop/src/Navigation.test.tsx
@@ -21,6 +21,7 @@ import {
 
 const describeWindow = vi.fn();
 const openRow = vi.fn();
+const openRowCancellingRun = vi.fn();
 const returnToHome = vi.fn();
 const returnToSession = vi.fn();
 const refreshHome = vi.fn();
@@ -36,6 +37,7 @@ const discardDraft = vi.fn();
 const reanchorDraft = vi.fn();
 const reviewPanel = vi.fn();
 const runReview = vi.fn();
+const cancelReview = vi.fn();
 const selectNextFinding = vi.fn();
 const acceptFinding = vi.fn();
 const dismissFinding = vi.fn();
@@ -44,6 +46,8 @@ vi.mock("./bindings", () => ({
   commands: {
     describeWindow: () => describeWindow(),
     openRow: (repository: unknown, number: unknown) => openRow(repository, number),
+    openRowCancellingRun: (repository: unknown, number: unknown) =>
+      openRowCancellingRun(repository, number),
     returnToHome: () => returnToHome(),
     returnToSession: () => returnToSession(),
     refreshHome: (onProgress: unknown) => refreshHome(onProgress),
@@ -59,6 +63,7 @@ vi.mock("./bindings", () => ({
     reanchorDraft: (...args: unknown[]) => reanchorDraft(...args),
     reviewPanel: () => reviewPanel(),
     runReview: (channel: unknown) => runReview(channel),
+    cancelReview: () => cancelReview(),
     selectNextFinding: () => selectNextFinding(),
     acceptFinding: (id: unknown) => acceptFinding(id),
     dismissFinding: (id: unknown) => dismissFinding(id),
@@ -100,6 +105,14 @@ function showingHome(session: OpenSessionDto | null = null): WindowDto {
 function showingSession(session: OpenSessionDto = alive()): WindowDto {
   return { Session: { session } };
 }
+
+/** What `openRow` answers with once the row opened, wrapping `window`. */
+function opened(window: WindowDto) {
+  return { outcome: "Opened" as const, window };
+}
+
+/** What `openRow` answers with when a live run behind Home is in the way. */
+const blocked = { outcome: "Blocked" as const };
 
 /** Two rows to review, one of which the alive Session was opened from. */
 function listed(): HomeSnapshotDto {
@@ -159,7 +172,9 @@ beforeEach(() => {
   describeWindow.mockReset();
   describeWindow.mockResolvedValue(showingHome());
   openRow.mockReset();
-  openRow.mockResolvedValue(ok(showingSession()));
+  openRow.mockResolvedValue(ok(opened(showingSession())));
+  openRowCancellingRun.mockReset();
+  openRowCancellingRun.mockResolvedValue(ok(showingSession()));
   returnToHome.mockReset();
   returnToHome.mockResolvedValue(ok(showingHome(alive())));
   returnToSession.mockReset();
@@ -184,6 +199,8 @@ beforeEach(() => {
   discardDraft.mockReset();
   reanchorDraft.mockReset();
   reviewPanel.mockReset();
+  cancelReview.mockReset();
+  cancelReview.mockResolvedValue(ok(null));
   selectNextFinding.mockReset();
   acceptFinding.mockReset();
   dismissFinding.mockReset();
@@ -327,6 +344,56 @@ describe("the Session kept alive behind Home", () => {
     expect(runReview).toHaveBeenCalledOnce();
   });
 
+  /// A run keeps going once Home is in front, and its Findings wait for the
+  /// reviewer's return rather than being lost or reset.
+  it("keeps a review run going behind Home and shows it still running on return", async () => {
+    reviewPanel.mockResolvedValue(ok(makePanel()));
+    let deliver: ((panel: unknown) => void) | null = null;
+    runReview.mockImplementation((channel: { onmessage: (panel: unknown) => void }) => {
+      deliver = (panel: unknown) => channel.onmessage(panel);
+      return new Promise(() => {
+        // Never settles: the run is still going when Home comes in front.
+      });
+    });
+    await openTheCursorRow();
+    fireEvent.keyDown(window, { key: "r", metaKey: true, shiftKey: true });
+    act(() => deliver?.(makePanel({ run: { state: "Running", detail: "Reading src/main.rs" } })));
+    await waitFor(() => expect(screen.getByText("Reading src/main.rs")).toBeTruthy());
+
+    fireEvent.keyDown(window, { key: "[", metaKey: true });
+    await waitFor(() => expect(screen.getByText("Retry webhook deliveries")).toBeTruthy());
+
+    await userEvent.setup().click(screen.getByRole("button", { name: /acme\/widgets#412/ }));
+
+    await waitFor(() => expect(screen.getByText("Reading src/main.rs")).toBeTruthy());
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+    expect(cancelReview).not.toHaveBeenCalled();
+  });
+
+  it("shows review running in the header slot while the hidden Session's run is live, and drops it once the run ends", async () => {
+    reviewPanel.mockResolvedValue(ok(makePanel()));
+    let settleRun: ((result: unknown) => void) | null = null;
+    runReview.mockImplementation((channel: { onmessage: (panel: unknown) => void }) => {
+      channel.onmessage(makePanel({ run: { state: "Running", detail: "Starting..." } }));
+      return new Promise((resolve) => {
+        settleRun = resolve;
+      });
+    });
+    await openTheCursorRow();
+    fireEvent.keyDown(window, { key: "r", metaKey: true, shiftKey: true });
+    await waitFor(() => expect(screen.getByText("Starting...")).toBeTruthy());
+
+    fireEvent.keyDown(window, { key: "[", metaKey: true });
+
+    await waitFor(() => expect(screen.getByText("review running")).toBeTruthy());
+
+    act(() =>
+      settleRun?.(ok(makePanel({ run: { state: "Complete", accepted: 0, rejected: 0, suppressed: 0 } }))),
+    );
+
+    await waitFor(() => expect(screen.queryByText("review running")).toBeNull());
+  });
+
   it("leaves the finding shortcuts alone once Home is in front of the Session", async () => {
     // A selected finding, so accept and dismiss have something to act on and
     // the assertions below can only pass because Home has the keys.
@@ -447,6 +514,57 @@ describe("the Session kept alive behind Home", () => {
 
     await waitFor(() => expect(openRow).toHaveBeenCalledWith("acme/widgets", 398));
     expect(returnToSession).not.toHaveBeenCalled();
+  });
+
+  it("asks for confirmation before opening a different row with a live run behind it, and stay leaves everything untouched", async () => {
+    const user = userEvent.setup();
+    describeWindow.mockResolvedValue(showingHome(alive()));
+    refreshHome.mockResolvedValue(ok(withAliveRow()));
+    openRow.mockResolvedValue(ok(blocked));
+    await openHome();
+
+    await user.click(screen.getByText("Split the invoice renderer"));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Cancel it and open acme\/widgets#398/)).toBeTruthy(),
+    );
+    expect(openRowCancellingRun).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Stay" }));
+
+    expect(screen.queryByRole("button", { name: "Cancel run and continue" })).toBeNull();
+    expect(openRowCancellingRun).not.toHaveBeenCalled();
+    expect(screen.getByText("Retry webhook deliveries")).toBeTruthy();
+  });
+
+  it("cancels the run and opens the new row when the confirmation is answered cancel and continue", async () => {
+    const user = userEvent.setup();
+    describeWindow.mockResolvedValue(showingHome(alive()));
+    refreshHome.mockResolvedValue(ok(withAliveRow()));
+    openRow.mockResolvedValue(ok(blocked));
+    await openHome();
+    await user.click(screen.getByText("Split the invoice renderer"));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Cancel run and continue" })).toBeTruthy(),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Cancel run and continue" }));
+
+    await waitFor(() => expect(openRowCancellingRun).toHaveBeenCalledWith("acme/widgets", 398));
+    await waitFor(() => expect(screen.getByText("first")).toBeTruthy());
+  });
+
+  it("opens a different row with no confirmation when the hidden Session has no live run", async () => {
+    const user = userEvent.setup();
+    describeWindow.mockResolvedValue(showingHome(alive()));
+    refreshHome.mockResolvedValue(ok(withAliveRow()));
+    await openHome();
+
+    await user.click(screen.getByText("Split the invoice renderer"));
+
+    await waitFor(() => expect(screen.getByText("first")).toBeTruthy());
+    expect(screen.queryByRole("button", { name: "Cancel run and continue" })).toBeNull();
+    expect(openRowCancellingRun).not.toHaveBeenCalled();
   });
 
   it("reaches a Session whose pull request has no row through the slot alone", async () => {

--- a/apps/desktop/src/SessionApp.tsx
+++ b/apps/desktop/src/SessionApp.tsx
@@ -7,12 +7,15 @@ export function SessionApp({
   description,
   isShowing,
   onBack,
+  onRunningChange,
 }: {
   description: string;
   /** False while Home is in front, which is when this Session yields the keyboard. */
   isShowing: boolean;
   /** Absent for a Session with no Home behind it, which offers no way back. */
   onBack: (() => void) | null;
+  /** Told whenever the review run's state changes, shown or hidden. */
+  onRunningChange: (running: boolean) => void;
 }) {
   const {
     state,
@@ -32,7 +35,7 @@ export function SessionApp({
     dismissFinding,
     replaceFinding,
     keepFinding,
-  } = useSession(description, isShowing);
+  } = useSession(description, isShowing, onRunningChange);
 
   switch (state.status) {
     case "loading":

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -67,7 +67,20 @@ export const commands = {
 	 *  Returns a failure when no configured clone resolves to `repository`, which
 	 *  leaves the Session that was alive exactly as it was.
 	 */
-	openRow: (repository: string, number: number) => typedError<WindowDto, SessionFailureDto>(__TAURI_INVOKE("open_row", { repository, number })),
+	openRow: (repository: string, number: number) => typedError<OpenRowOutcomeDto, SessionFailureDto>(__TAURI_INVOKE("open_row", { repository, number })),
+	/**
+	 *  Opens the pull request a Home row names, first cancelling the run the
+	 *  Session alive was running.
+	 * 
+	 *  Reached only once the reviewer has answered the confirmation `open_row`
+	 *  asked for by answering [`dto::OpenRowOutcomeDto::Blocked`].
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns a failure when no configured clone resolves to `repository`, which
+	 *  leaves the Session that was alive exactly as it was.
+	 */
+	openRowCancellingRun: (repository: string, number: number) => typedError<WindowDto, SessionFailureDto>(__TAURI_INVOKE("open_row_cancelling_run", { repository, number })),
 	/**
 	 *  Shows Home again, leaving the Session alive behind it.
 	 * 
@@ -577,6 +590,17 @@ export type HomeSnapshotDto = {
 	 */
 	drafts_failure: SessionFailureDto | null,
 };
+
+/**  What opening a row answered with. */
+export type OpenRowOutcomeDto = 
+/**  The row opened, or the Session already alive on it was shown again. */
+{ outcome: "Opened"; window: WindowDto } | 
+/**
+ *  The Session alive behind Home has a live run in the way. Nothing was
+ *  touched; the frontend asks the reviewer to cancel the run and continue,
+ *  or stay.
+ */
+{ outcome: "Blocked" };
 
 /**  The one Session the window holds, in front of Home or alive behind it. */
 export type OpenSessionDto = {

--- a/apps/desktop/src/components/HomeScreen.css
+++ b/apps/desktop/src/components/HomeScreen.css
@@ -64,6 +64,40 @@
   color: var(--accent-text);
 }
 
+/* Shown beside the slot's identity while that Session's review is running. */
+.home__slot-status {
+  padding-left: 6px;
+  border-left: 1px solid var(--accent-base);
+  font-family: var(--font-mono);
+  font-size: var(--size-label);
+  color: var(--accent-text);
+}
+
+/* The confirmation opening a different row asks for while a live run behind
+   Home is in the way. */
+.home__confirm {
+  flex-shrink: 0;
+  padding: 10px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid var(--border-default);
+  background: var(--surface-raised);
+}
+
+.home__confirm-text {
+  font-family: var(--font-sans);
+  font-size: var(--size-body);
+  color: var(--text-primary);
+}
+
+.home__confirm-actions {
+  flex-shrink: 0;
+  display: flex;
+  gap: 8px;
+}
+
 .home__stamp {
   display: flex;
   align-items: center;

--- a/apps/desktop/src/components/HomeScreen.tsx
+++ b/apps/desktop/src/components/HomeScreen.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import type { HomeRowDto, HomeSnapshotDto, RefreshStateDto, SessionFailureDto } from "../bindings";
+import type { OpenRowResult } from "../hooks/useHome";
 import { useHome } from "../hooks/useHome";
 import { useNow } from "../hooks/useNow";
 import { refreshedStamp, shortAge } from "../lib/relativeTime";
@@ -26,18 +27,33 @@ function stampText(refresh: RefreshStateDto, nowMs: number): string | null {
 export function HomeScreen({
   isShowing,
   aliveIdentity,
+  isReviewRunning,
   onOpenRow,
+  onCancelRunAndOpenRow,
   onReturnToSession,
 }: {
   /** False while a Session is in front, which is when Home goes quiet. */
   isShowing: boolean;
   /** `owner/name#number` of the Session alive behind Home, if one is. */
   aliveIdentity: string | null;
-  onOpenRow: (repository: string, number: number) => Promise<SessionFailureDto | null>;
+  /** Whether that Session has a review run in flight. */
+  isReviewRunning: boolean;
+  onOpenRow: (repository: string, number: number) => Promise<OpenRowResult>;
+  onCancelRunAndOpenRow: (repository: string, number: number) => Promise<SessionFailureDto | null>;
   onReturnToSession: () => Promise<SessionFailureDto | null>;
 }) {
-  const { snapshot, failure, openFailure, toggleFooter, addRepositories, removeRepository, openRow } =
-    useHome({ isShowing, onOpenRow, onReturnToSession });
+  const {
+    snapshot,
+    failure,
+    openFailure,
+    toggleFooter,
+    addRepositories,
+    removeRepository,
+    openRow,
+    runConfirmation,
+    cancelRunAndOpenRow,
+    stayOnHome,
+  } = useHome({ isShowing, onOpenRow, onCancelRunAndOpenRow, onReturnToSession });
   const nowMs = useNow();
 
   // A command that never answered leaves nothing worth trusting on screen.
@@ -57,8 +73,16 @@ export function HomeScreen({
         countLine={snapshot.count_line}
         stamp={stamp}
         aliveIdentity={aliveIdentity}
+        isReviewRunning={isReviewRunning}
         onReturnToSession={onReturnToSession}
       />
+      {runConfirmation !== null && (
+        <RunConfirmation
+          row={runConfirmation}
+          onCancelAndContinue={cancelRunAndOpenRow}
+          onStay={stayOnHome}
+        />
+      )}
       <HomeBody
         snapshot={snapshot}
         openFailure={openFailure}
@@ -106,11 +130,13 @@ function Header({
   countLine,
   stamp,
   aliveIdentity,
+  isReviewRunning,
   onReturnToSession,
 }: {
   countLine: string | null;
   stamp: string | null;
   aliveIdentity: string | null;
+  isReviewRunning: boolean;
   onReturnToSession: () => void;
 }) {
   return (
@@ -124,6 +150,7 @@ function Header({
         {aliveIdentity !== null && (
           <button className="home__slot" type="button" onClick={onReturnToSession}>
             <span className="home__slot-identity">{aliveIdentity}</span>
+            {isReviewRunning && <span className="home__slot-status">review running</span>}
             <span className="home__keycap">cmd-[</span>
           </button>
         )}
@@ -135,6 +162,40 @@ function Header({
         )}
       </div>
     </header>
+  );
+}
+
+/**
+ * The confirmation opening a different row asks for while the Session behind
+ * Home has a live run in the way. Exactly two choices, no third way out.
+ */
+function RunConfirmation({
+  row,
+  onCancelAndContinue,
+  onStay,
+}: {
+  row: HomeRowDto;
+  onCancelAndContinue: () => void;
+  onStay: () => void;
+}) {
+  return (
+    <div className="home__confirm" role="alertdialog" aria-label="A review is running">
+      <span className="home__confirm-text">
+        The Session behind Home is still reviewing. Cancel it and open {row.identity}?
+      </span>
+      <div className="home__confirm-actions">
+        <button className="home__button" type="button" onClick={onStay}>
+          Stay
+        </button>
+        <button
+          className="home__button home__button--primary"
+          type="button"
+          onClick={onCancelAndContinue}
+        >
+          Cancel run and continue
+        </button>
+      </div>
+    </div>
   );
 }
 

--- a/apps/desktop/src/hooks/useHome.ts
+++ b/apps/desktop/src/hooks/useHome.ts
@@ -11,6 +11,15 @@ type HomeResult =
   | { status: "ok"; data: HomeSnapshotDto }
   | { status: "error"; error: SessionFailureDto };
 
+/**
+ * What opening a row answered with: it opened, a live run behind Home blocked
+ * it and the reviewer must be asked, or it was refused outright.
+ */
+export type OpenRowResult =
+  | { status: "opened" }
+  | { status: "blocked" }
+  | { status: "error"; error: SessionFailureDto };
+
 /** Whether a keystroke belongs to something the reviewer is typing into. */
 function isTyping(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) {
@@ -28,15 +37,20 @@ function isTyping(target: EventTarget | null): boolean {
 export function useHome({
   isShowing,
   onOpenRow,
+  onCancelRunAndOpenRow,
   onReturnToSession,
 }: {
   isShowing: boolean;
-  onOpenRow: (repository: string, number: number) => Promise<SessionFailureDto | null>;
+  onOpenRow: (repository: string, number: number) => Promise<OpenRowResult>;
+  onCancelRunAndOpenRow: (repository: string, number: number) => Promise<SessionFailureDto | null>;
   onReturnToSession: () => Promise<SessionFailureDto | null>;
 }) {
   const [snapshot, setSnapshot] = useState<HomeSnapshotDto | null>(null);
   const [failure, setFailure] = useState<SessionFailureDto | null>(null);
   const [openFailure, setOpenFailure] = useState<SessionFailureDto | null>(null);
+  // The row a live run behind Home is blocking, waiting on the reviewer's
+  // answer to the confirmation: cancel the run and continue, or stay.
+  const [runConfirmation, setRunConfirmation] = useState<HomeRowDto | null>(null);
   const refreshing = useRef(false);
   // Read by the key handler, which is attached once and must still see the
   // list as it stands rather than as it was when it was attached.
@@ -191,15 +205,42 @@ export function useHome({
    * alive behind Home.
    *
    * Returning never reloads, which is what keeps a half-finished review whole.
-   * A refusal stays on Home, which is where the reviewer can act on it.
+   * A refusal stays on Home, which is where the reviewer can act on it. A live
+   * run behind Home in the way of dropping that Session opens the
+   * confirmation instead of touching anything.
    */
   const openRow = useCallback(
     (row: HomeRowDto) => {
-      const navigated = row.is_alive ? onReturnToSession() : onOpenRow(row.repository, row.number);
-      navigated.then(setOpenFailure);
+      if (row.is_alive) {
+        onReturnToSession().then(setOpenFailure);
+        return;
+      }
+      onOpenRow(row.repository, row.number).then((result) => {
+        if (result.status === "error") {
+          setOpenFailure(result.error);
+          return;
+        }
+        setOpenFailure(null);
+        if (result.status === "blocked") {
+          setRunConfirmation(row);
+        }
+      });
     },
     [onOpenRow, onReturnToSession],
   );
+
+  /** Cancels the run in the way and opens the row it was asked about. */
+  const cancelRunAndOpenRow = useCallback(() => {
+    const row = runConfirmation;
+    if (row === null) {
+      return;
+    }
+    setRunConfirmation(null);
+    onCancelRunAndOpenRow(row.repository, row.number).then(setOpenFailure);
+  }, [runConfirmation, onCancelRunAndOpenRow]);
+
+  /** Leaves the run and the Session it belongs to exactly as they were. */
+  const stayOnHome = useCallback(() => setRunConfirmation(null), []);
 
   const openCursorRow = useCallback(() => {
     const listed = shown.current;
@@ -267,5 +308,8 @@ export function useHome({
     addRepositories,
     removeRepository,
     openRow,
+    runConfirmation,
+    cancelRunAndOpenRow,
+    stayOnHome,
   };
 }

--- a/apps/desktop/src/hooks/useSession.ts
+++ b/apps/desktop/src/hooks/useSession.ts
@@ -18,9 +18,15 @@ type PanelResult = CommandResult<ReviewPanelDto>;
  * Loads one session and exposes every action the UI can take on it.
  *
  * `isShowing` is false while Home is in front of this session, which keeps its
- * hidden tree from answering keystrokes meant for the list.
+ * hidden tree from answering keystrokes meant for the list. `onRunningChange`
+ * is told whenever the review run's state changes, whether or not this session
+ * is showing, which is how Home's header slot follows a run it cannot see.
  */
-export function useSession(description: string, isShowing: boolean) {
+export function useSession(
+  description: string,
+  isShowing: boolean,
+  onRunningChange: (running: boolean) => void,
+) {
   const [state, dispatch] = useReducer(sessionReducer, initialState);
   const stateRef = useRef(state);
   stateRef.current = state;
@@ -29,6 +35,11 @@ export function useSession(description: string, isShowing: boolean) {
   // Held here rather than read off the panel, because a second trigger can arrive
   // before the first run's own "Running" panel has come back over the channel.
   const isRunning = useRef(false);
+
+  const isReviewRunning = state.status === "ready" && state.panel?.run.state === "Running";
+  useEffect(() => {
+    onRunningChange(isReviewRunning);
+  }, [isReviewRunning, onRunningChange]);
 
   useEffect(() => {
     if (hasOpened.current) {

--- a/crates/app/src/window.rs
+++ b/crates/app/src/window.rs
@@ -72,6 +72,10 @@ pub enum Opened {
     /// This window has no Home to open a row from, so nothing was opened. Only
     /// the command line opens such a window, and it never lists a row.
     Refused,
+    /// A different pull request's Session is alive with a live run, which is in
+    /// the way of dropping it silently. Nothing was touched; the reviewer must
+    /// be asked to cancel the run and continue, or stay.
+    Blocked,
 }
 
 /// Which screen the window shows, and the one Session it holds.
@@ -116,16 +120,21 @@ impl SessionSlot {
     /// Opens `pull_request` from a row, showing its Session.
     ///
     /// The Session already alive on this pull request is shown again rather
-    /// than loaded a second time. Any other is dropped, silently, because
-    /// Drafts already persist. A window with no Home refuses the row instead,
-    /// rather than growing a Home it never had.
-    pub fn open(&mut self, pull_request: PullRequestId) -> Opened {
+    /// than loaded a second time, whether or not it has a live run: returning
+    /// to a Session's own row never asks anything. A different Session with no
+    /// live run (`run_is_live` false) is dropped silently, because Drafts
+    /// already persist. A different Session with a live run is left alone and
+    /// answered with [`Opened::Blocked`] instead, so the reviewer can be asked
+    /// to cancel the run and continue, or stay. A window with no Home refuses
+    /// the row instead, rather than growing a Home it never had.
+    pub fn open(&mut self, pull_request: PullRequestId, run_is_live: bool) -> Opened {
         match &self.session {
             Some(OpenSession::FromCommandLine) => return Opened::Refused,
             Some(OpenSession::FromRow(open)) if open.is_same_pull_request(&pull_request) => {
                 self.showing = Showing::Session;
                 return Opened::Returned;
             }
+            Some(OpenSession::FromRow(_)) if run_is_live => return Opened::Blocked,
             Some(OpenSession::FromRow(_)) | None => {}
         }
         self.showing = Showing::Session;
@@ -185,7 +194,7 @@ mod tests {
     fn opening_a_row_shows_its_session_and_leaves_it_alive() {
         let mut slot = SessionSlot::home();
 
-        assert_eq!(slot.open(pull_request(412)), Opened::Loading);
+        assert_eq!(slot.open(pull_request(412), false), Opened::Loading);
 
         assert_eq!(slot.showing(), Showing::Session);
         assert_eq!(
@@ -199,10 +208,10 @@ mod tests {
     #[test]
     fn opening_the_pull_request_already_alive_returns_to_it_unloaded() {
         let mut slot = SessionSlot::home();
-        let _opened = slot.open(pull_request(412));
+        let _opened = slot.open(pull_request(412), false);
         assert!(slot.back_to_home());
 
-        assert_eq!(slot.open(pull_request(412)), Opened::Returned);
+        assert_eq!(slot.open(pull_request(412), false), Opened::Returned);
 
         assert_eq!(slot.showing(), Showing::Session);
     }
@@ -212,14 +221,14 @@ mod tests {
     #[test]
     fn a_repository_cased_differently_still_names_the_session_already_alive() {
         let mut slot = SessionSlot::home();
-        let _opened = slot.open(pull_request(412));
+        let _opened = slot.open(pull_request(412), false);
 
         let differently_cased = PullRequestId {
             repository: "ACME/Widgets".to_owned(),
             number: 412,
         };
 
-        assert_eq!(slot.open(differently_cased), Opened::Returned);
+        assert_eq!(slot.open(differently_cased, false), Opened::Returned);
     }
 
     /// Drafts already persist, so the Session that goes is not carrying
@@ -227,9 +236,9 @@ mod tests {
     #[test]
     fn opening_a_different_pull_request_drops_the_one_that_was_alive() {
         let mut slot = SessionSlot::home();
-        let _opened = slot.open(pull_request(412));
+        let _opened = slot.open(pull_request(412), false);
 
-        assert_eq!(slot.open(pull_request(398)), Opened::Loading);
+        assert_eq!(slot.open(pull_request(398), false), Opened::Loading);
 
         assert_eq!(
             slot.session(),
@@ -238,12 +247,41 @@ mod tests {
         );
     }
 
+    /// A live run is in the way of dropping the Session silently, so nothing is
+    /// touched until the reviewer answers the confirmation.
+    #[test]
+    fn opening_a_different_pull_request_with_a_live_run_is_blocked() {
+        let mut slot = SessionSlot::home();
+        let _opened = slot.open(pull_request(412), false);
+
+        assert_eq!(slot.open(pull_request(398), true), Opened::Blocked);
+
+        assert_eq!(
+            slot.session(),
+            Some(&OpenSession::FromRow(pull_request(412))),
+            "the Session with the live run is still the one alive",
+        );
+        assert_eq!(slot.showing(), Showing::Session);
+    }
+
+    /// Returning to the Session's own row never asks anything, live run or not.
+    #[test]
+    fn opening_the_pull_request_already_alive_returns_to_it_even_with_a_live_run() {
+        let mut slot = SessionSlot::home();
+        let _opened = slot.open(pull_request(412), false);
+        assert!(slot.back_to_home());
+
+        assert_eq!(slot.open(pull_request(412), true), Opened::Returned);
+
+        assert_eq!(slot.showing(), Showing::Session);
+    }
+
     /// Back is a navigation rather than a close, which is what makes returning
     /// to a half-finished review instant.
     #[test]
     fn back_shows_home_and_leaves_the_session_alive_behind_it() {
         let mut slot = SessionSlot::home();
-        let _opened = slot.open(pull_request(412));
+        let _opened = slot.open(pull_request(412), false);
 
         assert!(slot.back_to_home());
 
@@ -257,7 +295,7 @@ mod tests {
     #[test]
     fn the_header_slot_returns_to_the_session_alive_behind_home() {
         let mut slot = SessionSlot::home();
-        let _opened = slot.open(pull_request(412));
+        let _opened = slot.open(pull_request(412), false);
         assert!(slot.back_to_home());
 
         assert!(slot.return_to_session());
@@ -280,7 +318,7 @@ mod tests {
     fn a_window_the_command_line_opened_refuses_to_open_a_row() {
         let mut slot = SessionSlot::command_line();
 
-        assert_eq!(slot.open(pull_request(412)), Opened::Refused);
+        assert_eq!(slot.open(pull_request(412), false), Opened::Refused);
 
         assert_eq!(slot.session(), Some(&OpenSession::FromCommandLine));
         assert_eq!(slot.showing(), Showing::Session);


### PR DESCRIPTION
Closes #19

Going back to Home during a review run left the reviewer with no sign the run was still going, and opening another pull request would have dropped it silently. This is the last piece of the Home map.

What changed:
- A run keeps going while its Session is hidden behind Home, and returning shows its progress or its findings
- Home's header slot reads review running beside the Session's identity while the run is live, and drops the phrase the moment it ends, without the reviewer doing anything
- Opening a different row while a run is live asks once, with two choices, stay or cancel the run and continue
- Opening a different row with no live run still opens silently

Notes:
Start with the slot's open path in the window module, where the live-run outcome sits beside the one-Session-alive rule. The desktop crate asks the model whether a run is live rather than deciding for itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189um4LrckqAAq5fgnixT1p
