### PR TITLE
Submit a review from the desktop Session

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -474,7 +474,7 @@ fn reanchor_draft_on_model(
 /// Stores the review summary, which the store keys by pull request and head.
 ///
 /// Called on every keystroke, like a draft edit, because that is what makes the
-/// text survive a crash. Answers with nothing: the editor already holds what it
+/// text survive a crash. Answers with nothing. The editor already holds what it
 /// just sent, and echoing it back would fight the cursor.
 fn edit_summary_on_model(
     model: &Mutex<app::SessionModel>,
@@ -528,7 +528,7 @@ fn cancel_submission_on_model(
 /// Posts the confirmed review, then records what the forge said.
 ///
 /// The model refuses to post for itself, so this is where the hop happens. No
-/// lock is held across the send: the forge takes as long as it takes, and
+/// lock is held across the send. The forge takes as long as it takes, and
 /// nothing else about the Session may stall behind it. Local drafts are
 /// forgotten only once the review has landed, because until then the local copy
 /// is the only copy.

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -4051,6 +4051,40 @@ mod tests {
         assert!(draft.is_proposed);
     }
 
+    /// A finding about the change as a whole has nowhere to anchor, so it belongs
+    /// in the summary, joined onto whatever the reviewer had already written.
+    #[test]
+    fn accepting_a_whole_change_finding_lands_in_the_summary_and_retires_it() {
+        let repository = temporary_repository();
+        let model = local_model(&local_request(&repository), &ReviewStorage::Disabled);
+        edit_summary_on_model(&model, "Mostly good.".to_owned()).expect("session is ready");
+        let backend = FakeBackend::new(
+            Vec::new(),
+            Ok(vec![domain::RawFinding {
+                location: None,
+                ..raw_finding_on(2, "no tests at all")
+            }]),
+        );
+        let (finished, _) = run_with(&model, &backend);
+        let id = finished.expect("the session can be reviewed").findings[0].id;
+
+        let outcome = accept_finding_on_model(&model, id).expect("the session can be reviewed");
+
+        let dto::AcceptDispositionDto::Summary { body } = outcome.disposition else {
+            panic!(
+                "a whole-change finding belongs in the summary, got {:?}",
+                outcome.disposition
+            );
+        };
+        assert_eq!(body, "Mostly good.\n\nHandle the failure here.");
+        assert!(outcome.panel.findings.is_empty(), "the finding retires");
+        let guard = lock(&model);
+        let SessionPhase::Ready(review) = guard.phase() else {
+            panic!("session should be ready");
+        };
+        assert_eq!(review.session().summary(), body);
+    }
+
     /// Acceptance must never overwrite; the panel is asked instead.
     #[test]
     fn accepting_onto_an_occupied_line_asks_before_overwriting() {

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -467,6 +467,26 @@ fn reanchor_draft_on_model(
     Ok(drafts_snapshot(&guard, selected))
 }
 
+/// Stores the review summary, which the store keys by pull request and head.
+///
+/// Called on every keystroke, like a draft edit, because that is what makes the
+/// text survive a crash. Answers with nothing: the editor already holds what it
+/// just sent, and echoing it back would fight the cursor.
+fn edit_summary_on_model(
+    model: &Mutex<app::SessionModel>,
+    body: String,
+) -> Result<(), dto::SessionFailureDto> {
+    let mut guard = lock(model);
+    match guard.phase() {
+        SessionPhase::Ready(_) => {}
+        SessionPhase::Loading { .. } | SessionPhase::Failed(_) => {
+            return Err(dto::command_failure("the session is not ready"));
+        }
+    }
+    guard.summary_edited(body);
+    Ok(())
+}
+
 /// Publishes a run's progress into the model and out to whoever asked for it, and
 /// tells the backend when the reviewer has abandoned the run.
 struct RunEvents<'a> {
@@ -2860,6 +2880,55 @@ mod tests {
         assert_eq!(draft.body, "worth keeping");
         assert!(!draft.is_stale);
         assert!(review.session().warnings().is_empty());
+    }
+
+    #[test]
+    fn edit_summary_on_model_persists_and_restores_against_the_same_head() {
+        let repository = temporary_repository();
+        let data = TempDir::new().unwrap();
+        let storage = ReviewStorage::At(data.path().join("review-data.sqlite3"));
+
+        {
+            let model = local_model(&local_request(&repository), &storage);
+            edit_summary_on_model(&model, "Two notes.".to_owned()).expect("session is ready");
+            // Dropping joins the writer thread, so the write has landed.
+        }
+
+        let model = local_model(&local_request(&repository), &storage);
+        let guard = lock(&model);
+        let SessionPhase::Ready(review) = guard.phase() else {
+            panic!("session should be ready");
+        };
+        assert_eq!(review.session().summary(), "Two notes.");
+    }
+
+    /// The summary is pinned to the head it was written against, so a pushed-to
+    /// branch starts the editor empty rather than showing words about old code.
+    #[test]
+    fn a_summary_written_against_another_head_is_not_restored() {
+        let repository = temporary_repository();
+        let data = TempDir::new().unwrap();
+        let storage = ReviewStorage::At(data.path().join("review-data.sqlite3"));
+
+        {
+            let model = local_model(&local_request(&repository), &storage);
+            edit_summary_on_model(&model, "about the old head".to_owned())
+                .expect("session is ready");
+        }
+
+        let path = repository.path();
+        git(path, ["checkout", "--quiet", "feature"]);
+        std::fs::write(path.join("other.txt"), "unrelated\n").unwrap();
+        git(path, ["add", "."]);
+        git(path, ["commit", "--quiet", "-m", "advance"]);
+        git(path, ["checkout", "--quiet", "main"]);
+
+        let model = local_model(&local_request(&repository), &storage);
+        let guard = lock(&model);
+        let SessionPhase::Ready(review) = guard.phase() else {
+            panic!("session should be ready");
+        };
+        assert_eq!(review.session().summary(), "");
     }
 
     /// Advancing the branch's head, without touching the file the draft is on,

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -474,12 +474,16 @@ fn reanchor_draft_on_model(
 /// Stores the review summary, which the store keys by pull request and head.
 ///
 /// Called on every keystroke, like a draft edit, because that is what makes the
-/// text survive a crash. Answers with nothing. The editor already holds what it
-/// just sent, and echoing it back would fight the cursor.
+/// text survive a crash. The text itself is not echoed back. The editor already
+/// holds what it just sent, and returning it would fight the cursor.
+///
+/// Answers instead with what is stopping writes reaching storage, if anything
+/// is. A reviewer writing only a summary touches no draft, so this is the only
+/// answer that can tell them their words are being lost as they type.
 fn edit_summary_on_model(
     model: &Mutex<app::SessionModel>,
     body: String,
-) -> Result<(), dto::SessionFailureDto> {
+) -> Result<Option<String>, dto::SessionFailureDto> {
     let mut guard = lock(model);
     match guard.phase() {
         SessionPhase::Ready(_) => {}
@@ -488,7 +492,7 @@ fn edit_summary_on_model(
         }
     }
     guard.summary_edited(body);
-    Ok(())
+    Ok(guard.draft_write_failure())
 }
 
 /// Assembles what submitting would post and holds it for approval.
@@ -569,6 +573,25 @@ fn send_submission_on_model(
     let mut guard = lock(model);
     guard.complete_send(&submission, posted);
     Ok(send_outcome(&guard))
+}
+
+/// Records a send whose task never reported back, so one can be tried again.
+///
+/// Reached only when the blocking task did not finish, which leaves the model
+/// on its sending state with nothing left to move it off. Ignored by the model
+/// if the outcome was in fact recorded before the task died.
+///
+/// # Panics
+///
+/// Panics if the model is not `Ready`. Only a model that reached `Ready` can
+/// have had a send handed out of it, and the phase cannot regress.
+fn abandon_send_on_model(
+    model: &Mutex<app::SessionModel>,
+    failure: domain::SessionFailure,
+) -> dto::SendOutcomeDto {
+    let mut guard = lock(model);
+    guard.abandon_send(failure);
+    send_outcome(&guard)
 }
 
 /// How far the submission has got, with what the Session must redraw after it.
@@ -1487,7 +1510,9 @@ pub fn select_next_finding(
 /// Stores the review summary, keyed by pull request and head.
 ///
 /// Called on every keystroke, like a draft edit. That is what makes the text
-/// survive a crash, and what a later Session restores it from.
+/// survive a crash, and what a later Session restores it from. Answers with
+/// what is stopping writes landing, if anything is, which for a reviewer
+/// writing only a summary is the one place that can say so.
 ///
 /// # Errors
 ///
@@ -1498,7 +1523,7 @@ pub fn select_next_finding(
 pub fn edit_summary(
     state: tauri::State<'_, AppRoot>,
     body: String,
-) -> Result<(), dto::SessionFailureDto> {
+) -> Result<Option<String>, dto::SessionFailureDto> {
     let model = session_model(&state)?;
     edit_summary_on_model(&model, body)
 }
@@ -1544,7 +1569,8 @@ pub fn cancel_submission(
 /// stops offering a confirmation the moment one is acted on. The model is taken
 /// out of the window as its own handle, so a Session dropped or a window closed
 /// mid-send leaves the post finishing into a model nobody reads rather than
-/// panicking. A second call while the first is in flight posts nothing more.
+/// panicking. A second call while the first is in flight posts nothing more, and
+/// a task that dies without reporting leaves a submission that can be retried.
 ///
 /// # Errors
 ///
@@ -1558,13 +1584,29 @@ pub async fn send_submission(
     on_sending: Channel<dto::SubmissionDto>,
 ) -> Result<dto::SendOutcomeDto, dto::SessionFailureDto> {
     let model = session_model(&state)?;
-    tauri::async_runtime::spawn_blocking(move || {
+    let abandoned = Arc::clone(&model);
+    let posted = tauri::async_runtime::spawn_blocking(move || {
         send_submission_on_model(&model, &|submission| {
+            // A closed channel means the window is gone, which the post itself
+            // does not depend on, so the send carries on regardless.
             let _ = on_sending.send(submission);
         })
     })
-    .await
-    .map_err(|error| dto::command_failure(format!("the review was not sent: {error}")))?
+    .await;
+    match posted {
+        Ok(outcome) => outcome,
+        // The task did not finish, so nothing will ever record an outcome and the
+        // submission would sit on sending for the rest of the sitting, refusing
+        // every retry. Whether the review reached GitHub is genuinely unknown
+        // here, and the reviewer is told exactly that.
+        Err(error) => Ok(abandon_send_on_model(
+            &abandoned,
+            domain::SessionFailure::from_error("The review was not sent", &error)
+                .with_remediation(
+                    "ZReview could not tell whether it reached GitHub. Check the pull request there before submitting again.",
+                ),
+        )),
+    }
 }
 
 #[cfg(test)]
@@ -3195,6 +3237,31 @@ mod tests {
         assert_eq!(review.session().summary(), "");
     }
 
+    /// A reviewer writing only a summary touches no draft, so the write failure
+    /// has to ride back on the summary's own answer or they are never told their
+    /// words are being lost as they type.
+    #[test]
+    fn edit_summary_on_model_carries_the_sinks_write_failure() {
+        let repository = temporary_repository();
+        let loaded = session::load(
+            &local_request(&repository),
+            &ReviewStorage::Disabled,
+            &|_| {},
+        )
+        .expect("the repository loads");
+        let model = Mutex::new(app::SessionModel::loading("test"));
+        lock(&model).finish(Ok(domain::LoadedSession {
+            session: loaded.session,
+            review_sink: Some(Box::new(FailingSink)),
+            submitter: None,
+        }));
+
+        let write_failure =
+            edit_summary_on_model(&model, "Two notes.".to_owned()).expect("session is ready");
+
+        assert_eq!(write_failure.as_deref(), Some("disk is full"));
+    }
+
     /// Advancing the branch's head, without touching the file the draft is on,
     /// still invalidates it. A draft's anchor is pinned to the exact head it was
     /// written against, not merely to a line number.
@@ -3882,7 +3949,7 @@ mod tests {
     fn a_review_that_cannot_be_assembled_explains_itself_without_posting() {
         let repository = temporary_repository();
         let submitter = RecordingSubmitter::default();
-        // A comment review with a draft but no summary: GitHub requires a body.
+        // A comment review with a draft but no summary. GitHub requires a body.
         let model = submittable_model(
             &local_request(&repository),
             &ReviewStorage::Disabled,
@@ -4001,6 +4068,76 @@ mod tests {
         assert_eq!(sent.summary, "Two notes.", "the summary is still here");
         assert_eq!(sent.drafts.anchored.len(), 1, "so is the draft");
         assert_eq!(sent.drafts.ready_count, 1);
+    }
+
+    /// A send whose task died never records an outcome, so without this the
+    /// panel would sit on "Submitting the review..." for the rest of the sitting
+    /// with every action refused.
+    #[test]
+    fn a_send_that_never_reported_back_answers_with_something_retryable() {
+        let repository = temporary_repository();
+        let submitter = RecordingSubmitter::default();
+        let model = model_with_a_review(&repository, &submitter);
+        request_submission_on_model(&model, dto::ReviewEventDto::Comment)
+            .expect("session is ready");
+        // Taking the send and dropping it is what a task that died looks like.
+        drop(lock(&model).begin_send().expect("the review is confirmed"));
+
+        let abandoned = abandon_send_on_model(
+            &model,
+            domain::SessionFailure::new("The review was not sent")
+                .with_remediation("Check the pull request on GitHub before submitting again."),
+        );
+
+        let dto::SubmissionPhaseDto::Failed { failure } = &abandoned.submission.phase else {
+            panic!(
+                "an abandoned send should be shown as failed, got {:?}",
+                abandoned.submission.phase
+            );
+        };
+        assert_eq!(failure.summary, "The review was not sent");
+        assert_eq!(abandoned.summary, "Two notes.", "nothing was forgotten");
+        assert_eq!(abandoned.drafts.ready_count, 1);
+        assert!(submitter.posted().is_empty());
+        // And the reviewer can try again.
+        let retried = request_submission_on_model(&model, dto::ReviewEventDto::Comment)
+            .expect("session is ready");
+        assert!(matches!(
+            retried.phase,
+            dto::SubmissionPhaseDto::Confirming { .. }
+        ));
+    }
+
+    /// Several submission commands can be in flight at once, so what the front
+    /// end reads has to say which of two answers was read later.
+    #[test]
+    fn every_submission_answer_carries_a_higher_revision_than_the_last() {
+        let repository = temporary_repository();
+        let submitter = RecordingSubmitter::default();
+        let model = model_with_a_review(&repository, &submitter);
+
+        let confirming = request_submission_on_model(&model, dto::ReviewEventDto::Comment)
+            .expect("session is ready");
+        let cancelled = cancel_submission_on_model(&model).expect("session is ready");
+        request_submission_on_model(&model, dto::ReviewEventDto::Approve)
+            .expect("session is ready");
+        let reported = Mutex::new(Vec::new());
+        let sent = send_submission_on_model(&model, &|submission| {
+            lock(&reported).push(submission);
+        })
+        .expect("session is ready");
+        let sending = reported
+            .into_inner()
+            .unwrap()
+            .pop()
+            .expect("the send reports itself before it starts");
+
+        assert!(cancelled.revision > confirming.revision, "cancel is later");
+        assert!(sending.revision > cancelled.revision, "sending is later");
+        assert!(
+            sent.submission.revision > sending.revision,
+            "the outcome is later still",
+        );
     }
 
     /// A raw finding on `line` of feature.txt, which `temporary_repository` makes

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -52,6 +52,10 @@ pub fn specta_builder() -> tauri_specta::Builder<tauri::Wry> {
         dismiss_finding,
         reveal_finding,
         select_next_finding,
+        edit_summary,
+        request_submission,
+        cancel_submission,
+        send_submission,
     ])
 }
 
@@ -487,6 +491,97 @@ fn edit_summary_on_model(
     Ok(())
 }
 
+/// Assembles what submitting would post and holds it for approval.
+///
+/// Posts nothing. The model builds the exact request and stops there, because
+/// nothing may leave the machine without a person confirming it.
+fn request_submission_on_model(
+    model: &Mutex<app::SessionModel>,
+    event: dto::ReviewEventDto,
+) -> Result<dto::SubmissionDto, dto::SessionFailureDto> {
+    let mut guard = lock(model);
+    match guard.phase() {
+        SessionPhase::Ready(_) => {}
+        SessionPhase::Loading { .. } | SessionPhase::Failed(_) => {
+            return Err(dto::command_failure("the session is not ready"));
+        }
+    }
+    guard.request_submission(event.into());
+    Ok(dto::project_submission(&guard))
+}
+
+/// Puts the confirmation away, leaving every draft and the summary as they were.
+fn cancel_submission_on_model(
+    model: &Mutex<app::SessionModel>,
+) -> Result<dto::SubmissionDto, dto::SessionFailureDto> {
+    let mut guard = lock(model);
+    match guard.phase() {
+        SessionPhase::Ready(_) => {}
+        SessionPhase::Loading { .. } | SessionPhase::Failed(_) => {
+            return Err(dto::command_failure("the session is not ready"));
+        }
+    }
+    guard.cancel_submission();
+    Ok(dto::project_submission(&guard))
+}
+
+/// Posts the confirmed review, then records what the forge said.
+///
+/// The model refuses to post for itself, so this is where the hop happens. No
+/// lock is held across the send: the forge takes as long as it takes, and
+/// nothing else about the Session may stall behind it. Local drafts are
+/// forgotten only once the review has landed, because until then the local copy
+/// is the only copy.
+///
+/// A call with nothing confirmed, or one arriving while a send is already in
+/// flight, posts nothing and answers with the state that says so.
+fn send_submission_on_model(
+    model: &Mutex<app::SessionModel>,
+) -> Result<dto::SendOutcomeDto, dto::SessionFailureDto> {
+    let pending = {
+        let mut guard = lock(model);
+        match guard.phase() {
+            SessionPhase::Ready(_) => {}
+            SessionPhase::Loading { .. } | SessionPhase::Failed(_) => {
+                return Err(dto::command_failure("the session is not ready"));
+            }
+        }
+        guard.begin_send()
+    };
+    let Some(app::PendingSend {
+        submission,
+        submitter,
+    }) = pending
+    else {
+        return Ok(send_outcome(&lock(model)));
+    };
+
+    let posted = submitter.submit(&submission);
+
+    let mut guard = lock(model);
+    guard.complete_send(&submission, posted);
+    Ok(send_outcome(&guard))
+}
+
+/// How far the submission has got, with what the Session must redraw after it.
+///
+/// # Panics
+///
+/// Panics if the model is not `Ready`. Every caller has just checked that under
+/// the same lock, and the phase cannot regress.
+fn send_outcome(model: &app::SessionModel) -> dto::SendOutcomeDto {
+    let SessionPhase::Ready(review) = model.phase() else {
+        unreachable!("checked Ready under the same lock")
+    };
+    let selected = review.session().selected_file_index();
+    let summary = review.session().summary().to_owned();
+    dto::SendOutcomeDto {
+        submission: dto::project_submission(model),
+        drafts: drafts_snapshot(model, selected),
+        summary,
+    }
+}
+
 /// Publishes a run's progress into the model and out to whoever asked for it, and
 /// tells the backend when the reviewer has abandoned the run.
 struct RunEvents<'a> {
@@ -779,7 +874,10 @@ pub async fn open_session(
 
     let guard = lock(&model);
     match guard.phase() {
-        SessionPhase::Ready(review) => Ok(dto::project_snapshot(review.session())),
+        SessionPhase::Ready(review) => Ok(dto::project_snapshot(
+            review.session(),
+            guard.is_submittable(),
+        )),
         SessionPhase::Failed(failure) => Err(failure.into()),
         SessionPhase::Loading { .. } => {
             unreachable!("finish() always leaves the model Ready or Failed")
@@ -1378,6 +1476,83 @@ pub fn select_next_finding(
     Ok(select_next_finding_on_model(&model))
 }
 
+/// Stores the review summary, keyed by pull request and head.
+///
+/// Called on every keystroke, like a draft edit. That is what makes the text
+/// survive a crash, and what a later Session restores it from.
+///
+/// # Errors
+///
+/// Returns a failure when no session is open, or the session is not ready.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn edit_summary(
+    state: tauri::State<'_, AppRoot>,
+    body: String,
+) -> Result<(), dto::SessionFailureDto> {
+    let model = session_model(&state)?;
+    edit_summary_on_model(&model, body)
+}
+
+/// Assembles what submitting would post and holds it for approval.
+///
+/// Posts nothing. What comes back is the exact request that would be sent, so
+/// what the reviewer approves is what leaves the machine.
+///
+/// # Errors
+///
+/// Returns a failure when no session is open, or the session is not ready.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn request_submission(
+    state: tauri::State<'_, AppRoot>,
+    event: dto::ReviewEventDto,
+) -> Result<dto::SubmissionDto, dto::SessionFailureDto> {
+    let model = session_model(&state)?;
+    request_submission_on_model(&model, event)
+}
+
+/// Puts the confirmation away, leaving every draft and the summary as they were.
+///
+/// # Errors
+///
+/// Returns a failure when no session is open, or the session is not ready.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub fn cancel_submission(
+    state: tauri::State<'_, AppRoot>,
+) -> Result<dto::SubmissionDto, dto::SessionFailureDto> {
+    let model = session_model(&state)?;
+    cancel_submission_on_model(&model)
+}
+
+/// Posts the confirmed review on a background thread, then reports what the
+/// forge said.
+///
+/// The model is taken out of the window as its own handle, so a Session dropped
+/// or a window closed mid-send leaves the post finishing into a model nobody
+/// reads rather than panicking. A second call while the first is in flight posts
+/// nothing more.
+///
+/// # Errors
+///
+/// Returns a failure when no session is open, the session is not ready, or the
+/// task doing the posting does not finish.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)]
+pub async fn send_submission(
+    state: tauri::State<'_, AppRoot>,
+) -> Result<dto::SendOutcomeDto, dto::SessionFailureDto> {
+    let model = session_model(&state)?;
+    tauri::async_runtime::spawn_blocking(move || send_submission_on_model(&model))
+        .await
+        .map_err(|error| dto::command_failure(format!("the review was not sent: {error}")))?
+}
+
 #[cfg(test)]
 mod tests {
     use std::{ffi::OsStr, path::Path, process::Command, sync::Arc, thread};
@@ -1405,6 +1580,81 @@ mod tests {
         fn failure(&self) -> Option<String> {
             Some("disk is full".to_owned())
         }
+    }
+
+    /// Records every submission attempt, so a test can prove one did not happen.
+    ///
+    /// Nothing in this module's tests ever reaches GitHub; this stands in for the
+    /// real submitter everywhere a send is exercised.
+    #[derive(Clone, Default)]
+    struct RecordingSubmitter {
+        posted: Arc<Mutex<Vec<domain::ReviewSubmission>>>,
+        failure: Option<domain::SessionFailure>,
+    }
+
+    impl RecordingSubmitter {
+        fn posted(&self) -> Vec<domain::ReviewSubmission> {
+            lock(&self.posted).clone()
+        }
+    }
+
+    impl domain::ReviewSubmitter for RecordingSubmitter {
+        fn submit(
+            &self,
+            submission: &domain::ReviewSubmission,
+        ) -> Result<domain::SubmissionOutcome, domain::SessionFailure> {
+            lock(&self.posted).push(submission.clone());
+            self.failure.clone().map_or_else(
+                || {
+                    Ok(domain::SubmissionOutcome {
+                        state: "COMMENTED".to_owned(),
+                        url: "https://github.com/acme/widgets/pull/42".to_owned(),
+                        comment_count: submission.comments.len(),
+                    })
+                },
+                Err,
+            )
+        }
+    }
+
+    /// A local comparison with a fake submitter attached, which is the one thing
+    /// a local comparison never has of its own.
+    fn submittable_model(
+        request: &SessionRequest,
+        storage: &ReviewStorage,
+        submitter: Arc<dyn domain::ReviewSubmitter>,
+    ) -> Mutex<app::SessionModel> {
+        let model = Mutex::new(app::SessionModel::loading(request.description()));
+        let loaded = session::load(request, storage, &|_stage| {}).expect("the comparison loads");
+        lock(&model).finish(Ok(domain::LoadedSession {
+            submitter: Some(submitter),
+            ..loaded
+        }));
+        model
+    }
+
+    /// A session holding one draft and a summary, ready to be submitted.
+    fn model_with_a_review(
+        repository: &TempDir,
+        submitter: &RecordingSubmitter,
+    ) -> Mutex<app::SessionModel> {
+        let model = submittable_model(
+            &local_request(repository),
+            &ReviewStorage::Disabled,
+            Arc::new(submitter.clone()),
+        );
+        edit_draft_on_model(&model, 0, 1, 1, "needs a test".to_owned()).expect("session is ready");
+        edit_summary_on_model(&model, "Two notes.".to_owned()).expect("session is ready");
+        model
+    }
+
+    /// The confirmation a submission is waiting on, or a panic saying what it
+    /// was showing instead.
+    fn confirmation(submission: &dto::SubmissionDto) -> &dto::SubmissionRequestDto {
+        let dto::SubmissionPhaseDto::Confirming { request } = &submission.phase else {
+            panic!("expected a confirmation, got {:?}", submission.phase);
+        };
+        request
     }
 
     fn loaded_model() -> Mutex<app::SessionModel> {
@@ -3514,6 +3764,229 @@ mod tests {
             .note
             .expect("the failure is what the panel has to say");
         assert_eq!(note.heading, "claude is not installed");
+    }
+
+    /// The property the whole design turns on: choosing an action posts nothing.
+    #[test]
+    fn each_action_opens_a_confirmation_holding_what_would_be_posted() {
+        let repository = temporary_repository();
+        let submitter = RecordingSubmitter::default();
+        let model = model_with_a_review(&repository, &submitter);
+
+        for (event, verdict) in [
+            (dto::ReviewEventDto::Comment, "Comment"),
+            (dto::ReviewEventDto::Approve, "Approve"),
+            (dto::ReviewEventDto::RequestChanges, "Request changes"),
+        ] {
+            let submission = request_submission_on_model(&model, event).expect("session is ready");
+            let request = confirmation(&submission);
+
+            assert_eq!(request.heading, format!("{verdict} with 1 inline comment"));
+            assert_eq!(request.body, "Two notes.");
+            assert_eq!(request.comments.len(), 1);
+            assert_eq!(request.comments[0].position, "feature.txt RIGHT line 2");
+            assert_eq!(request.comments[0].body, "needs a test");
+            assert!(request.excluded.is_empty());
+            assert!(request.excluded_heading.is_none());
+            assert!(request.pinned.starts_with("pinned to "));
+        }
+
+        assert!(
+            submitter.posted().is_empty(),
+            "nothing may be posted before confirmation",
+        );
+    }
+
+    /// Every draft that will not be posted is named, with why, or a reviewer
+    /// would believe they had submitted something they had not.
+    #[test]
+    fn a_confirmation_names_every_draft_it_would_leave_behind() {
+        let repository = temporary_repository();
+        let data = TempDir::new().unwrap();
+        let storage = ReviewStorage::At(data.path().join("review-data.sqlite3"));
+        {
+            let model = local_model(&local_request(&repository), &storage);
+            edit_draft_on_model(&model, 0, 0, 0, "about the old head".to_owned()).unwrap();
+        }
+        let path = repository.path();
+        git(path, ["checkout", "--quiet", "feature"]);
+        std::fs::write(path.join("other.txt"), "unrelated\n").unwrap();
+        git(path, ["add", "."]);
+        git(path, ["commit", "--quiet", "-m", "advance"]);
+        git(path, ["checkout", "--quiet", "main"]);
+
+        let submitter = RecordingSubmitter::default();
+        let model = submittable_model(
+            &local_request(&repository),
+            &storage,
+            Arc::new(submitter.clone()),
+        );
+        edit_summary_on_model(&model, "Two notes.".to_owned()).expect("session is ready");
+
+        let submission = request_submission_on_model(&model, dto::ReviewEventDto::Comment)
+            .expect("session is ready");
+        let request = confirmation(&submission);
+
+        assert_eq!(request.excluded.len(), 1);
+        assert_eq!(request.excluded[0].body, "about the old head");
+        assert_eq!(
+            request.excluded[0].reason,
+            "not on a line in the current diff",
+        );
+        assert_eq!(
+            request.excluded_heading.as_deref(),
+            Some("1 draft will NOT be posted"),
+        );
+        assert!(submitter.posted().is_empty());
+    }
+
+    /// Cancelling returns the Session exactly as it was, drafts and summary and
+    /// all, and posts nothing.
+    #[test]
+    fn cancelling_a_confirmation_posts_nothing_and_keeps_everything() {
+        let repository = temporary_repository();
+        let submitter = RecordingSubmitter::default();
+        let model = model_with_a_review(&repository, &submitter);
+        request_submission_on_model(&model, dto::ReviewEventDto::Approve)
+            .expect("session is ready");
+
+        let submission = cancel_submission_on_model(&model).expect("session is ready");
+
+        assert!(matches!(submission.phase, dto::SubmissionPhaseDto::Idle));
+        assert!(submitter.posted().is_empty());
+        let guard = lock(&model);
+        let SessionPhase::Ready(review) = guard.phase() else {
+            panic!("session should be ready");
+        };
+        assert_eq!(review.session().summary(), "Two notes.");
+        assert_eq!(review.session().drafts().len(), 1);
+    }
+
+    /// A review that cannot be assembled says why, in the place the confirmation
+    /// would have been, and still posts nothing.
+    #[test]
+    fn a_review_that_cannot_be_assembled_explains_itself_without_posting() {
+        let repository = temporary_repository();
+        let submitter = RecordingSubmitter::default();
+        // A comment review with a draft but no summary: GitHub requires a body.
+        let model = submittable_model(
+            &local_request(&repository),
+            &ReviewStorage::Disabled,
+            Arc::new(submitter.clone()),
+        );
+        edit_draft_on_model(&model, 0, 1, 1, "needs a test".to_owned()).expect("session is ready");
+
+        let submission = request_submission_on_model(&model, dto::ReviewEventDto::Comment)
+            .expect("session is ready");
+
+        let dto::SubmissionPhaseDto::Failed { failure } = submission.phase else {
+            panic!("the review should be refused");
+        };
+        assert!(
+            failure
+                .remediation
+                .as_deref()
+                .is_some_and(|text| text.contains("needs a summary")),
+            "unexpected remediation: {:?}",
+            failure.remediation,
+        );
+        assert!(submitter.posted().is_empty());
+    }
+
+    #[test]
+    fn confirming_posts_the_review_once_and_forgets_what_it_sent() {
+        let repository = temporary_repository();
+        let submitter = RecordingSubmitter::default();
+        let model = model_with_a_review(&repository, &submitter);
+        request_submission_on_model(&model, dto::ReviewEventDto::Comment)
+            .expect("session is ready");
+
+        let sent = send_submission_on_model(&model).expect("session is ready");
+
+        let posted = submitter.posted();
+        assert_eq!(posted.len(), 1, "posted exactly once");
+        assert_eq!(posted[0].comments.len(), 1);
+        assert_eq!(posted[0].body, "Two notes.");
+        let dto::SubmissionPhaseDto::Sent { outcome } = &sent.submission.phase else {
+            panic!("expected a sent outcome, got {:?}", sent.submission.phase);
+        };
+        assert_eq!(
+            outcome.heading,
+            "Submitted as COMMENTED with 1 inline comment",
+        );
+        assert_eq!(outcome.url, "https://github.com/acme/widgets/pull/42");
+        // Forgotten only once the forge had accepted them.
+        assert_eq!(sent.summary, "");
+        assert!(sent.drafts.anchored.is_empty());
+        assert_eq!(sent.drafts.ready_count, 0);
+    }
+
+    /// A double click must not post twice, and neither must anything after a
+    /// review has already landed.
+    #[test]
+    fn a_second_confirmation_posts_nothing_more() {
+        let repository = temporary_repository();
+        let submitter = RecordingSubmitter::default();
+        let model = model_with_a_review(&repository, &submitter);
+        request_submission_on_model(&model, dto::ReviewEventDto::Comment)
+            .expect("session is ready");
+        send_submission_on_model(&model).expect("session is ready");
+
+        let again = send_submission_on_model(&model).expect("session is ready");
+
+        assert_eq!(submitter.posted().len(), 1, "still posted exactly once");
+        assert!(
+            matches!(again.submission.phase, dto::SubmissionPhaseDto::Sent { .. }),
+            "a session that has sent cannot silently resend, got {:?}",
+            again.submission.phase,
+        );
+    }
+
+    /// Sending without a confirmation posts nothing at all.
+    #[test]
+    fn sending_with_nothing_confirmed_posts_nothing() {
+        let repository = temporary_repository();
+        let submitter = RecordingSubmitter::default();
+        let model = model_with_a_review(&repository, &submitter);
+
+        let sent = send_submission_on_model(&model).expect("session is ready");
+
+        assert!(submitter.posted().is_empty());
+        assert!(matches!(
+            sent.submission.phase,
+            dto::SubmissionPhaseDto::Idle
+        ));
+        assert_eq!(sent.summary, "Two notes.");
+    }
+
+    /// A failed send must leave every draft and every word exactly where it was.
+    #[test]
+    fn a_failed_send_keeps_every_draft_and_the_summary() {
+        let repository = temporary_repository();
+        let submitter = RecordingSubmitter {
+            failure: Some(
+                domain::SessionFailure::new("The pull request moved on")
+                    .with_remediation("Your drafts are unchanged."),
+            ),
+            ..RecordingSubmitter::default()
+        };
+        let model = model_with_a_review(&repository, &submitter);
+        request_submission_on_model(&model, dto::ReviewEventDto::Comment)
+            .expect("session is ready");
+
+        let sent = send_submission_on_model(&model).expect("session is ready");
+
+        let dto::SubmissionPhaseDto::Failed { failure } = &sent.submission.phase else {
+            panic!("expected a failure, got {:?}", sent.submission.phase);
+        };
+        assert_eq!(failure.summary, "The pull request moved on");
+        assert_eq!(
+            failure.remediation.as_deref(),
+            Some("Your drafts are unchanged.")
+        );
+        assert_eq!(sent.summary, "Two notes.", "the summary is still here");
+        assert_eq!(sent.drafts.anchored.len(), 1, "so is the draft");
+        assert_eq!(sent.drafts.ready_count, 1);
     }
 
     /// A raw finding on `line` of feature.txt, which `temporary_repository` makes

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -535,10 +535,16 @@ fn cancel_submission_on_model(
 ///
 /// A call with nothing confirmed, or one arriving while a send is already in
 /// flight, posts nothing and answers with the state that says so.
+///
+/// `report` is handed the sending state before the post starts, so the panel
+/// says so at once rather than holding a live confirmation for the whole of a
+/// network call. Taken as a plain callback so it can be tested without a Tauri
+/// channel.
 fn send_submission_on_model(
     model: &Mutex<app::SessionModel>,
+    report: &dyn Fn(dto::SubmissionDto),
 ) -> Result<dto::SendOutcomeDto, dto::SessionFailureDto> {
-    let pending = {
+    let (pending, started) = {
         let mut guard = lock(model);
         match guard.phase() {
             SessionPhase::Ready(_) => {}
@@ -546,7 +552,8 @@ fn send_submission_on_model(
                 return Err(dto::command_failure("the session is not ready"));
             }
         }
-        guard.begin_send()
+        let pending = guard.begin_send();
+        (pending, dto::project_submission(&guard))
     };
     let Some(app::PendingSend {
         submission,
@@ -555,6 +562,7 @@ fn send_submission_on_model(
     else {
         return Ok(send_outcome(&lock(model)));
     };
+    report(started);
 
     let posted = submitter.submit(&submission);
 
@@ -1532,10 +1540,11 @@ pub fn cancel_submission(
 /// Posts the confirmed review on a background thread, then reports what the
 /// forge said.
 ///
-/// The model is taken out of the window as its own handle, so a Session dropped
-/// or a window closed mid-send leaves the post finishing into a model nobody
-/// reads rather than panicking. A second call while the first is in flight posts
-/// nothing more.
+/// The sending state goes to `on_sending` before the post starts, so the panel
+/// stops offering a confirmation the moment one is acted on. The model is taken
+/// out of the window as its own handle, so a Session dropped or a window closed
+/// mid-send leaves the post finishing into a model nobody reads rather than
+/// panicking. A second call while the first is in flight posts nothing more.
 ///
 /// # Errors
 ///
@@ -1546,11 +1555,16 @@ pub fn cancel_submission(
 #[allow(clippy::needless_pass_by_value)]
 pub async fn send_submission(
     state: tauri::State<'_, AppRoot>,
+    on_sending: Channel<dto::SubmissionDto>,
 ) -> Result<dto::SendOutcomeDto, dto::SessionFailureDto> {
     let model = session_model(&state)?;
-    tauri::async_runtime::spawn_blocking(move || send_submission_on_model(&model))
-        .await
-        .map_err(|error| dto::command_failure(format!("the review was not sent: {error}")))?
+    tauri::async_runtime::spawn_blocking(move || {
+        send_submission_on_model(&model, &|submission| {
+            let _ = on_sending.send(submission);
+        })
+    })
+    .await
+    .map_err(|error| dto::command_failure(format!("the review was not sent: {error}")))?
 }
 
 #[cfg(test)]
@@ -3901,7 +3915,7 @@ mod tests {
         request_submission_on_model(&model, dto::ReviewEventDto::Comment)
             .expect("session is ready");
 
-        let sent = send_submission_on_model(&model).expect("session is ready");
+        let sent = send_submission_on_model(&model, &|_sending| {}).expect("session is ready");
 
         let posted = submitter.posted();
         assert_eq!(posted.len(), 1, "posted exactly once");
@@ -3930,9 +3944,9 @@ mod tests {
         let model = model_with_a_review(&repository, &submitter);
         request_submission_on_model(&model, dto::ReviewEventDto::Comment)
             .expect("session is ready");
-        send_submission_on_model(&model).expect("session is ready");
+        send_submission_on_model(&model, &|_sending| {}).expect("session is ready");
 
-        let again = send_submission_on_model(&model).expect("session is ready");
+        let again = send_submission_on_model(&model, &|_sending| {}).expect("session is ready");
 
         assert_eq!(submitter.posted().len(), 1, "still posted exactly once");
         assert!(
@@ -3949,7 +3963,7 @@ mod tests {
         let submitter = RecordingSubmitter::default();
         let model = model_with_a_review(&repository, &submitter);
 
-        let sent = send_submission_on_model(&model).expect("session is ready");
+        let sent = send_submission_on_model(&model, &|_sending| {}).expect("session is ready");
 
         assert!(submitter.posted().is_empty());
         assert!(matches!(
@@ -3974,7 +3988,7 @@ mod tests {
         request_submission_on_model(&model, dto::ReviewEventDto::Comment)
             .expect("session is ready");
 
-        let sent = send_submission_on_model(&model).expect("session is ready");
+        let sent = send_submission_on_model(&model, &|_sending| {}).expect("session is ready");
 
         let dto::SubmissionPhaseDto::Failed { failure } = &sent.submission.phase else {
             panic!("expected a failure, got {:?}", sent.submission.phase);

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -580,18 +580,21 @@ fn send_submission_on_model(
 /// Reached only when the blocking task did not finish, which leaves the model
 /// on its sending state with nothing left to move it off. Ignored by the model
 /// if the outcome was in fact recorded before the task died.
-///
-/// # Panics
-///
-/// Panics if the model is not `Ready`. Only a model that reached `Ready` can
-/// have had a send handed out of it, and the phase cannot regress.
 fn abandon_send_on_model(
     model: &Mutex<app::SessionModel>,
     failure: domain::SessionFailure,
-) -> dto::SendOutcomeDto {
+) -> Result<dto::SendOutcomeDto, dto::SessionFailureDto> {
     let mut guard = lock(model);
+    match guard.phase() {
+        SessionPhase::Ready(_) => {}
+        // A task that died before the session was ready never held a send, so
+        // there is no submission to put back and nothing to draw around it.
+        SessionPhase::Loading { .. } | SessionPhase::Failed(_) => {
+            return Err((&failure).into());
+        }
+    }
     guard.abandon_send(failure);
-    send_outcome(&guard)
+    Ok(send_outcome(&guard))
 }
 
 /// How far the submission has got, with what the Session must redraw after it.
@@ -1599,13 +1602,13 @@ pub async fn send_submission(
         // submission would sit on sending for the rest of the sitting, refusing
         // every retry. Whether the review reached GitHub is genuinely unknown
         // here, and the reviewer is told exactly that.
-        Err(error) => Ok(abandon_send_on_model(
+        Err(error) => abandon_send_on_model(
             &abandoned,
             domain::SessionFailure::from_error("The review was not sent", &error)
                 .with_remediation(
                     "ZReview could not tell whether it reached GitHub. Check the pull request there before submitting again.",
                 ),
-        )),
+        ),
     }
 }
 
@@ -4087,7 +4090,8 @@ mod tests {
             &model,
             domain::SessionFailure::new("The review was not sent")
                 .with_remediation("Check the pull request on GitHub before submitting again."),
-        );
+        )
+        .expect("session is ready");
 
         let dto::SubmissionPhaseDto::Failed { failure } = &abandoned.submission.phase else {
             panic!(

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -4,10 +4,13 @@
 //! `&SessionFailure`) and returns a value, which is what keeps them testable
 //! without a running app.
 
-use app::{FindingDisposition, PullRequestId, ReviewModel, ReviewRunState};
+use app::{
+    FindingDisposition, PullRequestId, ReviewModel, ReviewRunState, SessionModel, SubmissionState,
+};
 use domain::{
-    AnchorLocation, DiffFile, DiffLineKind, DiffSide, EmptyDiffReason, FileStatus, Finding,
-    GuidanceSelection, ReviewSession, SessionFailure, SessionSource, Severity,
+    AnchorLocation, DiffFile, DiffLineKind, DiffSide, EmptyDiffReason, ExcludedDraft, FileStatus,
+    Finding, GuidanceSelection, ReviewEvent, ReviewSession, ReviewSubmission, SessionFailure,
+    SessionSource, Severity, SubmissionOutcome,
 };
 use serde::{Deserialize, Serialize};
 
@@ -141,6 +144,13 @@ pub struct SessionSnapshotDto {
     pub subtitle: String,
     pub sidebar: SidebarDto,
     pub warnings: Vec<SessionFailureDto>,
+    /// Whether this Session has somewhere to post a review, which is what decides
+    /// if the submit bar is there at all. False for the generated fixture and a
+    /// local comparison, neither of which is a pull request.
+    pub can_submit: bool,
+    /// What the summary editor seeds from, restored from storage on a fresh load
+    /// of the same pull request and head.
+    pub summary: String,
 }
 
 #[derive(Clone, Debug, Serialize, specta::Type)]
@@ -186,6 +196,12 @@ pub struct DraftsDto {
     pub anchored: Vec<AnchoredDraftDto>,
     pub stale: Vec<StaleDraftDto>,
     pub file_draft_count: u32,
+    /// Every draft in the session that would be posted, not just this file's,
+    /// which is the count the submit bar leads with.
+    pub ready_count: u32,
+    /// Every draft in the session whose anchor no longer resolves. Counted apart
+    /// because a submission leaves these behind.
+    pub not_anchored_count: u32,
     pub write_failure: Option<String>,
 }
 
@@ -385,8 +401,10 @@ pub enum AcceptDispositionDto {
         proposed: String,
         location: FindingLocationDto,
     },
-    /// The finding was about the change as a whole, so it went into the summary.
-    Summary,
+    /// The finding was about the change as a whole, so its proposal went into the
+    /// summary. `body` is what the editor should now hold, the reviewer's own
+    /// text and the proposal together.
+    Summary { body: String },
     /// No pending finding had that id.
     Unknown,
 }
@@ -414,7 +432,9 @@ pub fn project_disposition(
                 location: location.into(),
             }
         }
-        FindingDisposition::Summary { .. } => AcceptDispositionDto::Summary,
+        FindingDisposition::Summary { body } => {
+            AcceptDispositionDto::Summary { body: body.clone() }
+        }
         FindingDisposition::Unknown => AcceptDispositionDto::Unknown,
     }
 }
@@ -435,6 +455,181 @@ pub struct RevealOutcomeDto {
     /// Absent for a finding about the change as a whole, which has nowhere to
     /// scroll to.
     pub location: Option<FindingLocationDto>,
+}
+
+/// What submitting the review asserts about it.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, specta::Type)]
+pub enum ReviewEventDto {
+    Comment,
+    Approve,
+    RequestChanges,
+}
+
+impl From<ReviewEventDto> for ReviewEvent {
+    fn from(event: ReviewEventDto) -> Self {
+        match event {
+            ReviewEventDto::Comment => Self::Comment,
+            ReviewEventDto::Approve => Self::Approve,
+            ReviewEventDto::RequestChanges => Self::RequestChanges,
+        }
+    }
+}
+
+/// One inline comment, at the position the forge will be given for it.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct SubmittableCommentDto {
+    /// "path SIDE line N", which is the position itself, not a paraphrase of it.
+    pub position: String,
+    pub body: String,
+}
+
+/// A draft the submission leaves behind, and why.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct ExcludedDraftDto {
+    /// "path line N", where the draft still claims to be.
+    pub position: String,
+    /// Why it will not be posted, e.g. "not on a line in the current diff".
+    pub reason: String,
+    pub body: String,
+}
+
+/// The exact request a confirmed submission would post.
+///
+/// Mirrors the GPUI confirmation in `crates/ui`: what the reviewer approves is
+/// what leaves the machine, so every part of it is shown rather than summarised.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct SubmissionRequestDto {
+    /// The verdict and how many inline comments go with it, e.g. "Comment with
+    /// 1 inline comment".
+    pub heading: String,
+    /// "pinned to abc1234". Shown because it is what the forge can still reject
+    /// the review for.
+    pub pinned: String,
+    pub body: String,
+    pub comments: Vec<SubmittableCommentDto>,
+    /// Shown, never hidden: a reviewer must not believe these were posted.
+    pub excluded: Vec<ExcludedDraftDto>,
+    /// "1 draft will NOT be posted", absent when nothing is excluded.
+    pub excluded_heading: Option<String>,
+}
+
+/// A review the forge accepted.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct SubmissionOutcomeDto {
+    /// What it was recorded as and how much went with it, e.g. "Submitted as
+    /// COMMENTED with 1 inline comment".
+    pub heading: String,
+    /// Where to read it.
+    pub url: String,
+}
+
+/// How far the submission has got.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+#[serde(tag = "state")]
+pub enum SubmissionPhaseDto {
+    Idle,
+    /// Holding the exact request, waiting on a person. Nothing has been posted.
+    Confirming {
+        request: SubmissionRequestDto,
+    },
+    Sending,
+    Sent {
+        outcome: SubmissionOutcomeDto,
+    },
+    /// The forge refused it, or it could not be assembled at all. Every draft
+    /// and the summary are still exactly where they were.
+    Failed {
+        failure: SessionFailureDto,
+    },
+}
+
+/// The submission, and how many times it has changed.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct SubmissionDto {
+    /// So a snapshot read before a change can be told from one that carries it.
+    /// Several submission commands can be in flight at once.
+    pub revision: u32,
+    pub phase: SubmissionPhaseDto,
+}
+
+/// What a send answers with once the forge has replied.
+#[derive(Clone, Debug, Serialize, specta::Type)]
+pub struct SendOutcomeDto {
+    pub submission: SubmissionDto,
+    /// The selected file's drafts, emptied of whatever was posted.
+    pub drafts: DraftsDto,
+    /// What the summary editor should now hold, which a successful send empties.
+    pub summary: String,
+}
+
+/// How far the submission has got, read off the model that decides it.
+#[must_use]
+pub fn project_submission(model: &SessionModel) -> SubmissionDto {
+    SubmissionDto {
+        revision: model.submission_revision(),
+        phase: match model.submission() {
+            SubmissionState::Idle => SubmissionPhaseDto::Idle,
+            SubmissionState::Confirming(submission) => SubmissionPhaseDto::Confirming {
+                request: project_submission_request(submission),
+            },
+            SubmissionState::Sending => SubmissionPhaseDto::Sending,
+            SubmissionState::Sent(outcome) => SubmissionPhaseDto::Sent {
+                outcome: project_submission_outcome(outcome),
+            },
+            SubmissionState::Failed(failure) => SubmissionPhaseDto::Failed {
+                failure: failure.into(),
+            },
+        },
+    }
+}
+
+fn project_submission_request(submission: &ReviewSubmission) -> SubmissionRequestDto {
+    let excluded_count = submission.excluded.len();
+    SubmissionRequestDto {
+        heading: format!(
+            "{} with {} inline comment{}",
+            submission.event.label(),
+            submission.comments.len(),
+            plural(submission.comments.len()),
+        ),
+        pinned: format!("pinned to {}", short_sha(&submission.head_sha)),
+        body: submission.body.clone(),
+        comments: submission
+            .comments
+            .iter()
+            .map(|comment| SubmittableCommentDto {
+                position: format!("{} {} line {}", comment.path, comment.side, comment.line),
+                body: comment.body.clone(),
+            })
+            .collect(),
+        excluded: submission
+            .excluded
+            .iter()
+            .map(|ExcludedDraft { draft, reason }| ExcludedDraftDto {
+                position: format!("{} line {}", draft.anchor.path, draft.anchor.line),
+                reason: reason.to_string(),
+                body: draft.body.clone(),
+            })
+            .collect(),
+        excluded_heading: (excluded_count > 0).then(|| {
+            format!(
+                "{excluded_count} draft{} will NOT be posted",
+                plural(excluded_count),
+            )
+        }),
+    }
+}
+
+fn project_submission_outcome(outcome: &SubmissionOutcome) -> SubmissionOutcomeDto {
+    SubmissionOutcomeDto {
+        heading: format!(
+            "Submitted as {} with {} inline comment{}",
+            outcome.state,
+            outcome.comment_count,
+            plural(outcome.comment_count),
+        ),
+        url: outcome.url.clone(),
+    }
 }
 
 #[derive(Clone, Debug, Serialize, specta::Type)]
@@ -764,14 +959,20 @@ fn short_sha(sha: &str) -> &str {
     }
 }
 
+/// Everything the Session shows once, from a model that has finished loading.
+///
+/// `can_submit` comes off the model rather than the session because only the
+/// model knows whether there is anywhere to post to.
 #[must_use]
-pub fn project_snapshot(session: &ReviewSession) -> SessionSnapshotDto {
+pub fn project_snapshot(session: &ReviewSession, can_submit: bool) -> SessionSnapshotDto {
     let (title, subtitle) = source_header(session.source());
     SessionSnapshotDto {
         title,
         subtitle,
         sidebar: project_sidebar(session),
         warnings: session.warnings().iter().map(Into::into).collect(),
+        can_submit,
+        summary: session.summary().to_owned(),
     }
 }
 
@@ -868,11 +1069,14 @@ pub fn project_drafts(session: &ReviewSession, file_index: usize) -> DraftsDto {
     }
     anchored.sort_by_key(|draft| draft.row);
     let file_draft_count = as_u32(anchored.len() + stale.len());
+    let not_anchored_count = session.drafts().stale_count();
     DraftsDto {
         file_index: as_u32(file_index),
         anchored,
         stale,
         file_draft_count,
+        ready_count: as_u32(session.drafts().len() - not_anchored_count),
+        not_anchored_count: as_u32(not_anchored_count),
         write_failure: None,
     }
 }
@@ -1146,7 +1350,7 @@ mod tests {
     #[test]
     fn snapshot_shows_the_pull_requests_identity_and_title() {
         let session = pull_request_session();
-        let snapshot = project_snapshot(&session);
+        let snapshot = project_snapshot(&session, false);
 
         assert_eq!(snapshot.title, "acme/widgets \u{00B7} PR #42");
         assert_eq!(snapshot.subtitle, "Add the widget factory");
@@ -1155,7 +1359,7 @@ mod tests {
     #[test]
     fn snapshot_projects_the_demo_sidebar() {
         let session = demo_session();
-        let snapshot = project_snapshot(&session);
+        let snapshot = project_snapshot(&session, false);
 
         assert_eq!(snapshot.title, "Generated fixture");
         assert_eq!(snapshot.subtitle, "Diff virtualization demo");
@@ -1459,7 +1663,7 @@ mod tests {
         let mut session = demo_session();
         session.push_warning(SessionFailure::new("drafts are not being saved"));
 
-        let snapshot = project_snapshot(&session);
+        let snapshot = project_snapshot(&session, false);
 
         assert_eq!(snapshot.warnings.len(), 1);
         assert_eq!(snapshot.warnings[0].summary, "drafts are not being saved");

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -507,7 +507,7 @@ pub struct SubmissionRequestDto {
     pub pinned: String,
     pub body: String,
     pub comments: Vec<SubmittableCommentDto>,
-    /// Shown, never hidden: a reviewer must not believe these were posted.
+    /// Always shown. A reviewer must not believe these were posted.
     pub excluded: Vec<ExcludedDraftDto>,
     /// "1 draft will NOT be posted", absent when nothing is excluded.
     pub excluded_heading: Option<String>,

--- a/apps/desktop/src/SessionApp.tsx
+++ b/apps/desktop/src/SessionApp.tsx
@@ -35,6 +35,10 @@ export function SessionApp({
     dismissFinding,
     replaceFinding,
     keepFinding,
+    summaryChange,
+    submit,
+    cancelSubmission,
+    sendSubmission,
   } = useSession(description, isShowing, onRunningChange);
 
   switch (state.status) {
@@ -64,6 +68,10 @@ export function SessionApp({
           onDismissFinding={dismissFinding}
           onReplaceFinding={replaceFinding}
           onKeepFinding={keepFinding}
+          onSummaryChange={summaryChange}
+          onSubmit={submit}
+          onCancelSubmission={cancelSubmission}
+          onSendSubmission={sendSubmission}
         />
       );
   }

--- a/apps/desktop/src/Submission.test.tsx
+++ b/apps/desktop/src/Submission.test.tsx
@@ -1,14 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import type { Channel } from "@tauri-apps/api/core";
+import type { SubmissionDto } from "./bindings";
+import userEvent from "@testing-library/user-event";
 import App from "./App";
 import {
   makeDrafts,
   makeFile,
   makeFileSummary,
+  makeFinding,
   makePanel,
   makeRow,
   makeSidebar,
   makeSnapshot,
+  makeSubmission,
+  makeSubmissionRequest,
 } from "./test/fixtures";
 
 const describeWindow = vi.fn();
@@ -55,7 +61,7 @@ vi.mock("./bindings", () => ({
     editSummary: (body: unknown) => editSummary(body),
     requestSubmission: (event: unknown) => requestSubmission(event),
     cancelSubmission: () => cancelSubmission(),
-    sendSubmission: () => sendSubmission(),
+    sendSubmission: (channel: unknown) => sendSubmission(channel),
   },
 }));
 
@@ -120,6 +126,291 @@ function submitBar() {
   }
   return within(bar as HTMLElement);
 }
+
+/** The summary editor's CodeMirror content, once it has mounted. */
+async function summaryField() {
+  return await waitFor(() => {
+    const field = document.querySelector("[data-summary-editor] .cm-content");
+    if (!field) {
+      throw new Error("the summary editor is not mounted yet");
+    }
+    return field as HTMLElement;
+  });
+}
+
+/** Opens the confirmation for `event` and waits for it to be on screen. */
+async function confirm(user: ReturnType<typeof userEvent.setup>, action: string) {
+  await user.click(submitBar().getByRole("button", { name: action }));
+  await waitFor(() =>
+    expect(screen.getByRole("button", { name: "Post this review to GitHub" })).toBeTruthy(),
+  );
+}
+
+describe("the summary editor", () => {
+  it("writes what is typed through on every keystroke", async () => {
+    const user = userEvent.setup();
+    await openSubmitBar();
+    const field = await summaryField();
+
+    await user.click(field);
+    await user.keyboard("ok");
+
+    await waitFor(() => expect(editSummary).toHaveBeenCalledWith("ok"));
+  });
+
+  it("restores what the snapshot brought back from storage", async () => {
+    openSession.mockResolvedValue({
+      status: "ok",
+      data: makeSnapshot({
+        sidebar: makeSidebar([makeFileSummary()]),
+        can_submit: true,
+        summary: "written last week",
+      }),
+    });
+    await openSubmitBar();
+
+    const field = await summaryField();
+    expect(field.textContent).toContain("written last week");
+    // Restoring is not typing, so nothing is written back.
+    expect(editSummary).not.toHaveBeenCalled();
+  });
+});
+
+describe("the confirmation", () => {
+  it("shows the verdict, the summary, and every draft with its file and line", async () => {
+    const user = userEvent.setup();
+    requestSubmission.mockResolvedValue({
+      status: "ok",
+      data: makeSubmission({ state: "Confirming", request: makeSubmissionRequest() }),
+    });
+    await openSubmitBar();
+
+    await confirm(user, "Comment");
+
+    expect(screen.getByText("Comment with 1 inline comment")).toBeTruthy();
+    expect(screen.getByText("pinned to abc1234")).toBeTruthy();
+    expect(screen.getByText("Two notes.")).toBeTruthy();
+    expect(screen.getByText("src/review_fixture_00.rs RIGHT line 2")).toBeTruthy();
+    expect(screen.getByText("needs a test")).toBeTruthy();
+    expect(requestSubmission).toHaveBeenCalledWith("Comment");
+    expect(sendSubmission).not.toHaveBeenCalled();
+  });
+
+  it("names the drafts it would leave behind, with why", async () => {
+    const user = userEvent.setup();
+    requestSubmission.mockResolvedValue({
+      status: "ok",
+      data: makeSubmission({
+        state: "Confirming",
+        request: makeSubmissionRequest({
+          excluded: [
+            {
+              position: "src/gone.rs line 12",
+              reason: "not on a line in the current diff",
+              body: "about the old head",
+            },
+          ],
+          excluded_heading: "1 draft will NOT be posted",
+        }),
+      }),
+    });
+    await openSubmitBar();
+
+    await confirm(user, "Approve");
+
+    expect(screen.getByText("1 draft will NOT be posted")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "src/gone.rs line 12 (not on a line in the current diff): about the old head",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("returns to the Session on Cancel, having posted nothing", async () => {
+    const user = userEvent.setup();
+    requestSubmission.mockResolvedValue({
+      status: "ok",
+      data: makeSubmission({ state: "Confirming", request: makeSubmissionRequest() }),
+    });
+    cancelSubmission.mockResolvedValue({ status: "ok", data: makeSubmission({ state: "Idle" }, 2) });
+    await openSubmitBar();
+    await confirm(user, "Comment");
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Post this review to GitHub" })).toBeNull(),
+    );
+    expect(sendSubmission).not.toHaveBeenCalled();
+    // The diff and the counts are exactly as they were.
+    expect(screen.getByText("first")).toBeTruthy();
+    expect(screen.getByText("2 to submit")).toBeTruthy();
+  });
+
+  it("shows what a review that cannot be assembled says, and posts nothing", async () => {
+    const user = userEvent.setup();
+    requestSubmission.mockResolvedValue({
+      status: "ok",
+      data: makeSubmission({
+        state: "Failed",
+        failure: {
+          summary: "This review cannot be submitted yet",
+          detail: null,
+          remediation: "a comment review needs a summary",
+        },
+      }),
+    });
+    await openSubmitBar();
+
+    await user.click(submitBar().getByRole("button", { name: "Comment" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("This review cannot be submitted yet")).toBeTruthy(),
+    );
+    expect(screen.getByText("a comment review needs a summary")).toBeTruthy();
+    expect(sendSubmission).not.toHaveBeenCalled();
+  });
+});
+
+describe("sending the review", () => {
+  it("reports what was posted and leaves no way to send it again", async () => {
+    const user = userEvent.setup();
+    requestSubmission.mockResolvedValue({
+      status: "ok",
+      data: makeSubmission({ state: "Confirming", request: makeSubmissionRequest() }),
+    });
+    sendSubmission.mockResolvedValue({
+      status: "ok",
+      data: {
+        submission: makeSubmission(
+          {
+            state: "Sent",
+            outcome: {
+              heading: "Submitted as COMMENTED with 1 inline comment",
+              url: "https://github.com/acme/widgets/pull/42",
+            },
+          },
+          3,
+        ),
+        drafts: makeDrafts({ ready_count: 0, not_anchored_count: 0 }),
+        summary: "",
+      },
+    });
+    await openSubmitBar();
+    await confirm(user, "Comment");
+
+    await user.click(screen.getByRole("button", { name: "Post this review to GitHub" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Submitted as COMMENTED with 1 inline comment")).toBeTruthy(),
+    );
+    expect(screen.getByText("https://github.com/acme/widgets/pull/42")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Post this review to GitHub" })).toBeNull();
+    expect(screen.getByText("0 to submit")).toBeTruthy();
+    // The editor is emptied only once the forge has accepted it.
+    const field = await summaryField();
+    expect(field.textContent).toBe("");
+  });
+
+  it("keeps every draft and the summary when the send fails", async () => {
+    const user = userEvent.setup();
+    openSession.mockResolvedValue({
+      status: "ok",
+      data: makeSnapshot({
+        sidebar: makeSidebar([makeFileSummary()]),
+        can_submit: true,
+        summary: "Two notes.",
+      }),
+    });
+    requestSubmission.mockResolvedValue({
+      status: "ok",
+      data: makeSubmission({ state: "Confirming", request: makeSubmissionRequest() }),
+    });
+    sendSubmission.mockResolvedValue({
+      status: "ok",
+      data: {
+        submission: makeSubmission(
+          {
+            state: "Failed",
+            failure: {
+              summary: "The pull request moved on",
+              detail: "422 Unprocessable Entity",
+              remediation: "Your drafts are unchanged.",
+            },
+          },
+          3,
+        ),
+        drafts: makeDrafts({ ready_count: 2, not_anchored_count: 0 }),
+        summary: "Two notes.",
+      },
+    });
+    await openSubmitBar();
+    await confirm(user, "Comment");
+
+    await user.click(screen.getByRole("button", { name: "Post this review to GitHub" }));
+
+    await waitFor(() => expect(screen.getByText("The pull request moved on")).toBeTruthy());
+    expect(screen.getByText("Your drafts are unchanged.")).toBeTruthy();
+    expect(screen.getByText("422 Unprocessable Entity")).toBeTruthy();
+    expect(screen.getByText("2 to submit")).toBeTruthy();
+    const field = await summaryField();
+    expect(field.textContent).toContain("Two notes.");
+  });
+
+  it("says it is sending, and a second confirm sends nothing more", async () => {
+    const user = userEvent.setup();
+    requestSubmission.mockResolvedValue({
+      status: "ok",
+      data: makeSubmission({ state: "Confirming", request: makeSubmissionRequest() }),
+    });
+    let channel: Channel<SubmissionDto> | undefined;
+    // Never settles, so the panel stays on the send it already started.
+    sendSubmission.mockImplementation((given: Channel<SubmissionDto>) => {
+      channel = given;
+      return new Promise(() => {});
+    });
+    await openSubmitBar();
+    await confirm(user, "Comment");
+
+    const send = screen.getByRole("button", { name: "Post this review to GitHub" });
+    await user.click(send);
+    act(() => channel?.onmessage(makeSubmission({ state: "Sending" }, 2)));
+
+    await waitFor(() => expect(screen.getByText("Submitting the review...")).toBeTruthy());
+    // The confirmation is gone, so there is nothing left to press twice.
+    expect(screen.queryByRole("button", { name: "Post this review to GitHub" })).toBeNull();
+    await user.click(send);
+    expect(sendSubmission).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("a finding about the whole change", () => {
+  it("puts its proposal in the summary editor and retires the finding", async () => {
+    const user = userEvent.setup();
+    reviewPanel.mockResolvedValue({
+      status: "ok",
+      data: makePanel({
+        findings: [makeFinding({ id: 7, position: null, title: "no tests anywhere" })],
+      }),
+    });
+    acceptFinding.mockResolvedValue({
+      status: "ok",
+      data: {
+        panel: makePanel({ revision: 2, findings: [] }),
+        drafts: makeDrafts({ ready_count: 2 }),
+        disposition: { outcome: "Summary", body: "Add tests for the new branch." },
+      },
+    });
+    await openSubmitBar();
+
+    await user.click(screen.getByRole("button", { name: "Accept" }));
+
+    expect(acceptFinding).toHaveBeenCalledWith(7);
+    await waitFor(() => expect(screen.queryByText("no tests anywhere")).toBeNull());
+    const field = await summaryField();
+    expect(field.textContent).toContain("Add tests for the new branch.");
+  });
+});
 
 describe("the submit bar", () => {
   it("shows the ready count and the three actions", async () => {

--- a/apps/desktop/src/Submission.test.tsx
+++ b/apps/desktop/src/Submission.test.tsx
@@ -158,6 +158,19 @@ describe("the summary editor", () => {
     await waitFor(() => expect(editSummary).toHaveBeenCalledWith("ok"));
   });
 
+  it("keeps the diff shortcuts out of the editor while it has focus", async () => {
+    const user = userEvent.setup();
+    await openSubmitBar();
+    const field = await summaryField();
+
+    await user.click(field);
+    // c opens a composer, j and k move the cursor, when the diff has the keyboard.
+    await user.keyboard("cjk");
+
+    await waitFor(() => expect(editSummary).toHaveBeenCalledWith("cjk"));
+    expect(document.querySelector("[data-composer]")).toBeNull();
+  });
+
   it("restores what the snapshot brought back from storage", async () => {
     openSession.mockResolvedValue({
       status: "ok",

--- a/apps/desktop/src/Submission.test.tsx
+++ b/apps/desktop/src/Submission.test.tsx
@@ -171,6 +171,17 @@ describe("the summary editor", () => {
     expect(document.querySelector("[data-composer]")).toBeNull();
   });
 
+  it("says so when the summary is not reaching storage, with no draft to carry it", async () => {
+    const user = userEvent.setup();
+    editSummary.mockResolvedValue({ status: "ok", data: "disk is full" });
+    await openSubmitBar();
+
+    await user.click(await summaryField());
+    await user.keyboard("ok");
+
+    await waitFor(() => expect(screen.getByText(/disk is full/)).toBeTruthy());
+  });
+
   it("restores what the snapshot brought back from storage", async () => {
     openSession.mockResolvedValue({
       status: "ok",
@@ -323,6 +334,50 @@ describe("sending the review", () => {
     // The editor is emptied only once the forge has accepted it.
     const field = await summaryField();
     expect(field.textContent).toBe("");
+  });
+
+  it("empties the editor once the review has landed, so nothing writes it back", async () => {
+    const user = userEvent.setup();
+    requestSubmission.mockResolvedValue({
+      status: "ok",
+      data: makeSubmission({ state: "Confirming", request: makeSubmissionRequest() }),
+    });
+    sendSubmission.mockResolvedValue({
+      status: "ok",
+      data: {
+        submission: makeSubmission(
+          {
+            state: "Sent",
+            outcome: {
+              heading: "Submitted as COMMENTED with 1 inline comment",
+              url: "https://github.com/acme/widgets/pull/42",
+            },
+          },
+          3,
+        ),
+        drafts: makeDrafts({ ready_count: 0, not_anchored_count: 0 }),
+        summary: "",
+      },
+    });
+    await openSubmitBar();
+    await user.click(await summaryField());
+    await user.keyboard("Two notes.");
+    await waitFor(() => expect(editSummary).toHaveBeenCalledWith("Two notes."));
+
+    await confirm(user, "Comment");
+    await user.click(screen.getByRole("button", { name: "Post this review to GitHub" }));
+    await waitFor(() =>
+      expect(screen.getByText("Submitted as COMMENTED with 1 inline comment")).toBeTruthy(),
+    );
+
+    expect((await summaryField()).textContent).toBe("");
+    // A keystroke now must not write the posted summary back into the store,
+    // which would restore a review already on GitHub the next time this opens.
+    editSummary.mockClear();
+    await user.click(await summaryField());
+    await user.keyboard("x");
+    await waitFor(() => expect(editSummary).toHaveBeenCalledWith("x"));
+    expect(editSummary).not.toHaveBeenCalledWith(expect.stringContaining("Two notes."));
   });
 
   it("keeps every draft and the summary when the send fails", async () => {

--- a/apps/desktop/src/Submission.test.tsx
+++ b/apps/desktop/src/Submission.test.tsx
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import App from "./App";
+import {
+  makeDrafts,
+  makeFile,
+  makeFileSummary,
+  makePanel,
+  makeRow,
+  makeSidebar,
+  makeSnapshot,
+} from "./test/fixtures";
+
+const describeWindow = vi.fn();
+const openSession = vi.fn();
+const selectFile = vi.fn();
+const toggleViewed = vi.fn();
+const editDraft = vi.fn();
+const discardDraft = vi.fn();
+const reanchorDraft = vi.fn();
+const reviewPanel = vi.fn();
+const runReview = vi.fn();
+const cancelReview = vi.fn();
+const toggleGuidancePanel = vi.fn();
+const toggleGuidance = vi.fn();
+const acceptFinding = vi.fn();
+const overwriteFinding = vi.fn();
+const dismissFinding = vi.fn();
+const revealFinding = vi.fn();
+const selectNextFinding = vi.fn();
+const editSummary = vi.fn();
+const requestSubmission = vi.fn();
+const cancelSubmission = vi.fn();
+const sendSubmission = vi.fn();
+
+vi.mock("./bindings", () => ({
+  commands: {
+    describeWindow: () => describeWindow(),
+    openSession: (channel: unknown) => openSession(channel),
+    selectFile: (index: unknown) => selectFile(index),
+    toggleViewed: () => toggleViewed(),
+    editDraft: (...args: unknown[]) => editDraft(...args),
+    discardDraft: (...args: unknown[]) => discardDraft(...args),
+    reanchorDraft: (...args: unknown[]) => reanchorDraft(...args),
+    reviewPanel: () => reviewPanel(),
+    runReview: (channel: unknown) => runReview(channel),
+    cancelReview: () => cancelReview(),
+    toggleGuidancePanel: () => toggleGuidancePanel(),
+    toggleGuidance: (path: unknown) => toggleGuidance(path),
+    acceptFinding: (id: unknown) => acceptFinding(id),
+    overwriteFinding: (id: unknown) => overwriteFinding(id),
+    dismissFinding: (id: unknown) => dismissFinding(id),
+    revealFinding: (id: unknown) => revealFinding(id),
+    selectNextFinding: () => selectNextFinding(),
+    editSummary: (body: unknown) => editSummary(body),
+    requestSubmission: (event: unknown) => requestSubmission(event),
+    cancelSubmission: () => cancelSubmission(),
+    sendSubmission: () => sendSubmission(),
+  },
+}));
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({ writeText: () => Promise.resolve() }));
+
+beforeEach(() => {
+  describeWindow.mockReset();
+  describeWindow.mockResolvedValue({
+    Session: { session: { description: "pull request #42", row_identity: "acme/widgets#42" } },
+  });
+  openSession.mockReset();
+  openSession.mockResolvedValue({
+    status: "ok",
+    data: makeSnapshot({
+      sidebar: makeSidebar([makeFileSummary()]),
+      can_submit: true,
+      summary: "",
+    }),
+  });
+  selectFile.mockReset();
+  selectFile.mockResolvedValue({
+    status: "ok",
+    data: makeFile({
+      rows: [makeRow({ text: "first" }), makeRow({ text: "second" })],
+      drafts: makeDrafts({ ready_count: 2, not_anchored_count: 0 }),
+    }),
+  });
+  toggleViewed.mockReset();
+  editDraft.mockReset();
+  discardDraft.mockReset();
+  reanchorDraft.mockReset();
+  reviewPanel.mockReset();
+  reviewPanel.mockResolvedValue({ status: "ok", data: makePanel() });
+  runReview.mockReset();
+  runReview.mockReturnValue(new Promise(() => {}));
+  cancelReview.mockReset();
+  toggleGuidancePanel.mockReset();
+  toggleGuidance.mockReset();
+  acceptFinding.mockReset();
+  overwriteFinding.mockReset();
+  dismissFinding.mockReset();
+  revealFinding.mockReset();
+  selectNextFinding.mockReset();
+  editSummary.mockReset();
+  editSummary.mockResolvedValue({ status: "ok", data: null });
+  requestSubmission.mockReset();
+  cancelSubmission.mockReset();
+  sendSubmission.mockReset();
+});
+
+/** Renders the Session and waits for the submit bar to appear. */
+async function openSubmitBar() {
+  render(<App />);
+  await waitFor(() => expect(screen.getByRole("button", { name: "Approve" })).toBeTruthy());
+}
+
+/** The submit bar itself, so its Comment action is told from a diff row's own. */
+function submitBar() {
+  const bar = document.querySelector(".submit-bar");
+  if (!bar) {
+    throw new Error("the submit bar is not on screen");
+  }
+  return within(bar as HTMLElement);
+}
+
+describe("the submit bar", () => {
+  it("shows the ready count and the three actions", async () => {
+    await openSubmitBar();
+
+    expect(screen.getByText("2 to submit")).toBeTruthy();
+    expect(submitBar().getByRole("button", { name: "Comment" })).toBeTruthy();
+    expect(submitBar().getByRole("button", { name: "Approve" })).toBeTruthy();
+    expect(submitBar().getByRole("button", { name: "Request changes" })).toBeTruthy();
+  });
+
+  it("names the drafts that are no longer anchored, and only when there are some", async () => {
+    selectFile.mockResolvedValue({
+      status: "ok",
+      data: makeFile({
+        rows: [makeRow({ text: "first" })],
+        drafts: makeDrafts({ ready_count: 1, not_anchored_count: 3 }),
+      }),
+    });
+    await openSubmitBar();
+
+    expect(screen.getByText("1 to submit")).toBeTruthy();
+    expect(screen.getByText("3 not anchored")).toBeTruthy();
+  });
+
+  it("shows no not-anchored line when every draft still anchors", async () => {
+    await openSubmitBar();
+
+    expect(screen.queryByText(/not anchored/)).toBeNull();
+  });
+
+  it("offers no submit bar at all for a Session that cannot be submitted", async () => {
+    openSession.mockResolvedValue({
+      status: "ok",
+      data: makeSnapshot({ sidebar: makeSidebar([makeFileSummary()]), can_submit: false }),
+    });
+
+    render(<App />);
+    await waitFor(() => expect(screen.getByText("first")).toBeTruthy());
+
+    expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
+    expect(screen.queryByText(/to submit/)).toBeNull();
+  });
+});

--- a/apps/desktop/src/Submission.test.tsx
+++ b/apps/desktop/src/Submission.test.tsx
@@ -440,15 +440,18 @@ describe("sending the review", () => {
     await openSubmitBar();
     await confirm(user, "Comment");
 
+    // Both presses land while the confirmation is still up and the button live,
+    // which is the whole window a double press has.
     const send = screen.getByRole("button", { name: "Post this review to GitHub" });
     await user.click(send);
+    await user.click(send);
+
+    expect(sendSubmission).toHaveBeenCalledTimes(1);
+
     act(() => channel?.onmessage(makeSubmission({ state: "Sending" }, 2)));
 
     await waitFor(() => expect(screen.getByText("Submitting the review...")).toBeTruthy());
-    // The confirmation is gone, so there is nothing left to press twice.
     expect(screen.queryByRole("button", { name: "Post this review to GitHub" })).toBeNull();
-    await user.click(send);
-    expect(sendSubmission).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -477,6 +480,50 @@ describe("a finding about the whole change", () => {
     await waitFor(() => expect(screen.queryByText("no tests anywhere")).toBeNull());
     const field = await summaryField();
     expect(field.textContent).toContain("Add tests for the new branch.");
+  });
+
+  /**
+   * The finding retires whatever happens, so a summary write still in flight
+   * overtaking the merge would lose the proposal for good.
+   */
+  it("waits for a summary write already in flight before merging the proposal", async () => {
+    const user = userEvent.setup();
+    reviewPanel.mockResolvedValue({
+      status: "ok",
+      data: makePanel({
+        findings: [makeFinding({ id: 7, position: null, title: "no tests anywhere" })],
+      }),
+    });
+    let settleWrite: (answer: unknown) => void = () => {};
+    editSummary.mockReturnValue(
+      new Promise((resolve) => {
+        settleWrite = resolve;
+      }),
+    );
+    acceptFinding.mockResolvedValue({
+      status: "ok",
+      data: {
+        panel: makePanel({ revision: 2, findings: [] }),
+        drafts: makeDrafts({ ready_count: 2 }),
+        disposition: { outcome: "Summary", body: "Mostly good.\n\nAdd tests." },
+      },
+    });
+    await openSubmitBar();
+    await user.click(await summaryField());
+    await user.keyboard("Mostly good.");
+    await waitFor(() => expect(editSummary).toHaveBeenCalled());
+
+    await user.click(screen.getByRole("button", { name: "Accept" }));
+
+    expect(acceptFinding).not.toHaveBeenCalled();
+
+    settleWrite({ status: "ok", data: null });
+
+    await waitFor(() => expect(acceptFinding).toHaveBeenCalledWith(7));
+    await waitFor(() =>
+      expect((document.querySelector("[data-summary-editor] .cm-content") as HTMLElement).textContent)
+        .toContain("Add tests."),
+    );
   });
 });
 
@@ -510,7 +557,11 @@ describe("the submit bar", () => {
     expect(screen.queryByText(/not anchored/)).toBeNull();
   });
 
-  it("offers no submit bar at all for a Session that cannot be submitted", async () => {
+  /**
+   * A local comparison has no forge to post to, but it still has a summary,
+   * which a whole-change finding can be accepted into and a reviewer can read.
+   */
+  it("keeps the counts and the editor but offers no verdicts when there is nowhere to post", async () => {
     openSession.mockResolvedValue({
       status: "ok",
       data: makeSnapshot({ sidebar: makeSidebar([makeFileSummary()]), can_submit: false }),
@@ -519,7 +570,9 @@ describe("the submit bar", () => {
     render(<App />);
     await waitFor(() => expect(screen.getByText("first")).toBeTruthy());
 
+    expect(screen.getByText("2 to submit")).toBeTruthy();
+    expect(document.querySelector("[data-summary-editor]")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
-    expect(screen.queryByText(/to submit/)).toBeNull();
+    expect(screen.queryByRole("button", { name: "Request changes" })).toBeNull();
   });
 });

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -395,17 +395,18 @@ export const commands = {
 	 *  Posts the confirmed review on a background thread, then reports what the
 	 *  forge said.
 	 * 
-	 *  The model is taken out of the window as its own handle, so a Session dropped
-	 *  or a window closed mid-send leaves the post finishing into a model nobody
-	 *  reads rather than panicking. A second call while the first is in flight posts
-	 *  nothing more.
+	 *  The sending state goes to `on_sending` before the post starts, so the panel
+	 *  stops offering a confirmation the moment one is acted on. The model is taken
+	 *  out of the window as its own handle, so a Session dropped or a window closed
+	 *  mid-send leaves the post finishing into a model nobody reads rather than
+	 *  panicking. A second call while the first is in flight posts nothing more.
 	 * 
 	 *  # Errors
 	 * 
 	 *  Returns a failure when no session is open, the session is not ready, or the
 	 *  task doing the posting does not finish.
 	 */
-	sendSubmission: () => typedError<SendOutcomeDto, SessionFailureDto>(__TAURI_INVOKE("send_submission")),
+	sendSubmission: (onSending: Channel<SubmissionDto>) => typedError<SendOutcomeDto, SessionFailureDto>(__TAURI_INVOKE("send_submission", { onSending })),
 };
 
 /* Types */

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -361,6 +361,51 @@ export const commands = {
 	 */
 	location: FindingLocationDto | null,
 } | null, SessionFailureDto>(__TAURI_INVOKE("select_next_finding")),
+	/**
+	 *  Stores the review summary, keyed by pull request and head.
+	 * 
+	 *  Called on every keystroke, like a draft edit. That is what makes the text
+	 *  survive a crash, and what a later Session restores it from.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns a failure when no session is open, or the session is not ready.
+	 */
+	editSummary: (body: string) => typedError<null, SessionFailureDto>(__TAURI_INVOKE("edit_summary", { body })),
+	/**
+	 *  Assembles what submitting would post and holds it for approval.
+	 * 
+	 *  Posts nothing. What comes back is the exact request that would be sent, so
+	 *  what the reviewer approves is what leaves the machine.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns a failure when no session is open, or the session is not ready.
+	 */
+	requestSubmission: (event: ReviewEventDto) => typedError<SubmissionDto, SessionFailureDto>(__TAURI_INVOKE("request_submission", { event })),
+	/**
+	 *  Puts the confirmation away, leaving every draft and the summary as they were.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns a failure when no session is open, or the session is not ready.
+	 */
+	cancelSubmission: () => typedError<SubmissionDto, SessionFailureDto>(__TAURI_INVOKE("cancel_submission")),
+	/**
+	 *  Posts the confirmed review on a background thread, then reports what the
+	 *  forge said.
+	 * 
+	 *  The model is taken out of the window as its own handle, so a Session dropped
+	 *  or a window closed mid-send leaves the post finishing into a model nobody
+	 *  reads rather than panicking. A second call while the first is in flight posts
+	 *  nothing more.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns a failure when no session is open, the session is not ready, or the
+	 *  task doing the posting does not finish.
+	 */
+	sendSubmission: () => typedError<SendOutcomeDto, SessionFailureDto>(__TAURI_INVOKE("send_submission")),
 };
 
 /* Types */
@@ -374,8 +419,12 @@ export type AcceptDispositionDto =
  *  accepting it should first reveal, as the GPUI composer path does.
  */
 { outcome: "Occupied"; existing: string; proposed: string; location: FindingLocationDto } | 
-/**  The finding was about the change as a whole, so it went into the summary. */
-{ outcome: "Summary" } | 
+/**
+ *  The finding was about the change as a whole, so its proposal went into the
+ *  summary. `body` is what the editor should now hold, the reviewer's own
+ *  text and the proposal together.
+ */
+{ outcome: "Summary"; body: string } | 
 /**  No pending finding had that id. */
 { outcome: "Unknown" };
 
@@ -418,6 +467,16 @@ export type DraftsDto = {
 	anchored: AnchoredDraftDto[],
 	stale: StaleDraftDto[],
 	file_draft_count: number,
+	/**
+	 *  Every draft in the session that would be posted, not just this file's,
+	 *  which is the count the submit bar leads with.
+	 */
+	ready_count: number,
+	/**
+	 *  Every draft in the session whose anchor no longer resolves. Counted apart
+	 *  because a submission leaves these behind.
+	 */
+	not_anchored_count: number,
 	write_failure: string | null,
 };
 
@@ -425,6 +484,15 @@ export type DraftsDto = {
 export type EmptyReasonDto = {
 	label: string,
 	detail: string,
+};
+
+/**  A draft the submission leaves behind, and why. */
+export type ExcludedDraftDto = {
+	/**  "path line N", where the draft still claims to be. */
+	position: string,
+	/**  Why it will not be posted, e.g. "not on a line in the current diff". */
+	reason: string,
+	body: string,
 };
 
 /**  One configured repository whose pull requests could not be fetched. */
@@ -667,6 +735,9 @@ export type RevealOutcomeDto = {
 	location: FindingLocationDto | null,
 };
 
+/**  What submitting the review asserts about it. */
+export type ReviewEventDto = "Comment" | "Approve" | "RequestChanges";
+
 /**
  *  The Session's right-hand panel: what a review is held to, and how far the run
  *  that populates it has got.
@@ -715,6 +786,15 @@ export type RowStatusDto = {
 	tone: StatusToneDto,
 };
 
+/**  What a send answers with once the forge has replied. */
+export type SendOutcomeDto = {
+	submission: SubmissionDto,
+	/**  The selected file's drafts, emptied of whatever was posted. */
+	drafts: DraftsDto,
+	/**  What the summary editor should now hold, which a successful send empties. */
+	summary: string,
+};
+
 export type SessionFailureDto = {
 	summary: string,
 	detail: string | null,
@@ -726,6 +806,17 @@ export type SessionSnapshotDto = {
 	subtitle: string,
 	sidebar: SidebarDto,
 	warnings: SessionFailureDto[],
+	/**
+	 *  Whether this Session has somewhere to post a review, which is what decides
+	 *  if the submit bar is there at all. False for the generated fixture and a
+	 *  local comparison, neither of which is a pull request.
+	 */
+	can_submit: boolean,
+	/**
+	 *  What the summary editor seeds from, restored from storage on a fresh load
+	 *  of the same pull request and head.
+	 */
+	summary: string,
 };
 
 /**  How much a finding claims to matter. */
@@ -755,6 +846,69 @@ export type StaleDraftDto = {
  *  sheet that owns them.
  */
 export type StatusToneDto = "Success" | "Error" | "Warning" | "Muted";
+
+/**  The submission, and how many times it has changed. */
+export type SubmissionDto = {
+	/**
+	 *  So a snapshot read before a change can be told from one that carries it.
+	 *  Several submission commands can be in flight at once.
+	 */
+	revision: number,
+	phase: SubmissionPhaseDto,
+};
+
+/**  A review the forge accepted. */
+export type SubmissionOutcomeDto = {
+	/**
+	 *  What it was recorded as and how much went with it, e.g. "Submitted as
+	 *  COMMENTED with 1 inline comment".
+	 */
+	heading: string,
+	/**  Where to read it. */
+	url: string,
+};
+
+/**  How far the submission has got. */
+export type SubmissionPhaseDto = { state: "Idle" } | 
+/**  Holding the exact request, waiting on a person. Nothing has been posted. */
+{ state: "Confirming"; request: SubmissionRequestDto } | { state: "Sending" } | { state: "Sent"; outcome: SubmissionOutcomeDto } | 
+/**
+ *  The forge refused it, or it could not be assembled at all. Every draft
+ *  and the summary are still exactly where they were.
+ */
+{ state: "Failed"; failure: SessionFailureDto };
+
+/**
+ *  The exact request a confirmed submission would post.
+ * 
+ *  Mirrors the GPUI confirmation in `crates/ui`: what the reviewer approves is
+ *  what leaves the machine, so every part of it is shown rather than summarised.
+ */
+export type SubmissionRequestDto = {
+	/**
+	 *  The verdict and how many inline comments go with it, e.g. "Comment with
+	 *  1 inline comment".
+	 */
+	heading: string,
+	/**
+	 *  "pinned to abc1234". Shown because it is what the forge can still reject
+	 *  the review for.
+	 */
+	pinned: string,
+	body: string,
+	comments: SubmittableCommentDto[],
+	/**  Shown, never hidden: a reviewer must not believe these were posted. */
+	excluded: ExcludedDraftDto[],
+	/**  "1 draft will NOT be posted", absent when nothing is excluded. */
+	excluded_heading: string | null,
+};
+
+/**  One inline comment, at the position the forge will be given for it. */
+export type SubmittableCommentDto = {
+	/**  "path SIDE line N", which is the position itself, not a paraphrase of it. */
+	position: string,
+	body: string,
+};
 
 /**  Which screen the window shows, and the Session it is holding. */
 export type WindowDto = 

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -365,13 +365,15 @@ export const commands = {
 	 *  Stores the review summary, keyed by pull request and head.
 	 * 
 	 *  Called on every keystroke, like a draft edit. That is what makes the text
-	 *  survive a crash, and what a later Session restores it from.
+	 *  survive a crash, and what a later Session restores it from. Answers with
+	 *  what is stopping writes landing, if anything is, which for a reviewer
+	 *  writing only a summary is the one place that can say so.
 	 * 
 	 *  # Errors
 	 * 
 	 *  Returns a failure when no session is open, or the session is not ready.
 	 */
-	editSummary: (body: string) => typedError<null, SessionFailureDto>(__TAURI_INVOKE("edit_summary", { body })),
+	editSummary: (body: string) => typedError<string | null, SessionFailureDto>(__TAURI_INVOKE("edit_summary", { body })),
 	/**
 	 *  Assembles what submitting would post and holds it for approval.
 	 * 
@@ -399,7 +401,8 @@ export const commands = {
 	 *  stops offering a confirmation the moment one is acted on. The model is taken
 	 *  out of the window as its own handle, so a Session dropped or a window closed
 	 *  mid-send leaves the post finishing into a model nobody reads rather than
-	 *  panicking. A second call while the first is in flight posts nothing more.
+	 *  panicking. A second call while the first is in flight posts nothing more, and
+	 *  a task that dies without reporting leaves a submission that can be retried.
 	 * 
 	 *  # Errors
 	 * 
@@ -898,7 +901,7 @@ export type SubmissionRequestDto = {
 	pinned: string,
 	body: string,
 	comments: SubmittableCommentDto[],
-	/**  Shown, never hidden: a reviewer must not believe these were posted. */
+	/**  Always shown. A reviewer must not believe these were posted. */
 	excluded: ExcludedDraftDto[],
 	/**  "1 draft will NOT be posted", absent when nothing is excluded. */
 	excluded_heading: string | null,

--- a/apps/desktop/src/components/ReviewPanel.test.tsx
+++ b/apps/desktop/src/components/ReviewPanel.test.tsx
@@ -244,7 +244,7 @@ describe("ReviewPanel", () => {
     expect(screen.queryByText("No review has been run.")).toBeNull();
   });
 
-  it("shows a finding about the whole change as such, offering no Accept", () => {
+  it("shows a finding about the whole change as such, and offers Accept for it", () => {
     render(
       <ReviewPanel
         panel={makePanel({ findings: [makeFinding({ position: null, title: "no tests anywhere" })] })}
@@ -253,9 +253,8 @@ describe("ReviewPanel", () => {
     );
 
     expect(screen.getByText("whole change")).toBeTruthy();
-    // The desktop has no summary editor yet, so accepting a whole-change
-    // finding would write to storage the reviewer would never see.
-    expect(screen.queryByRole("button", { name: "Accept" })).toBeNull();
+    // There is a summary editor now, so its proposal has somewhere to land.
+    expect(screen.getByRole("button", { name: "Accept" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Dismiss" })).toBeTruthy();
   });
 

--- a/apps/desktop/src/components/ReviewPanel.tsx
+++ b/apps/desktop/src/components/ReviewPanel.tsx
@@ -287,19 +287,16 @@ function FindingCard({
         </div>
       ) : (
         <div className="review-panel__finding-actions">
-          {/* No summary editor yet, so a whole-change finding can only be dismissed. */}
-          {finding.position !== null && (
-            <button
-              type="button"
-              className="review-panel__finding-accept"
-              onClick={(event) => {
-                event.stopPropagation();
-                onAccept();
-              }}
-            >
-              Accept
-            </button>
-          )}
+          <button
+            type="button"
+            className="review-panel__finding-accept"
+            onClick={(event) => {
+              event.stopPropagation();
+              onAccept();
+            }}
+          >
+            Accept
+          </button>
           <button
             type="button"
             className="review-panel__finding-dismiss"

--- a/apps/desktop/src/components/SessionShell.css
+++ b/apps/desktop/src/components/SessionShell.css
@@ -1,4 +1,18 @@
 .session-shell {
   height: 100%;
   display: flex;
+  flex-direction: column;
+}
+
+.session-shell__body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+.session-shell__main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
 }

--- a/apps/desktop/src/components/SessionShell.test.tsx
+++ b/apps/desktop/src/components/SessionShell.test.tsx
@@ -25,6 +25,10 @@ function baseHandlers() {
     onDismissFinding: () => {},
     onReplaceFinding: () => {},
     onKeepFinding: () => {},
+    onSummaryChange: () => {},
+    onSubmit: () => {},
+    onCancelSubmission: () => {},
+    onSendSubmission: () => {},
   };
 }
 
@@ -40,6 +44,8 @@ function readyState(overrides: Partial<ReadyState["file"]> = {}): ReadyState {
     panel: null,
     panelNotice: null,
     findingConflict: null,
+    submission: { revision: 0, phase: { state: "Idle" } },
+    summary: "",
   };
 }
 

--- a/apps/desktop/src/components/SessionShell.test.tsx
+++ b/apps/desktop/src/components/SessionShell.test.tsx
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
 import type { ReadyState } from "../hooks/sessionReducer";
-import { makeFile, makeFileSummary, makeRow, makeSidebar, makeSnapshot } from "../test/fixtures";
+import {
+  makeFile,
+  makeFileSummary,
+  makeRow,
+  makeSidebar,
+  makeSnapshot,
+  makeSubmission,
+} from "../test/fixtures";
 import { SessionShell } from "./SessionShell";
 
 /** Every prop SessionShell needs beyond the ones a test wants to vary. */
@@ -44,8 +51,8 @@ function readyState(overrides: Partial<ReadyState["file"]> = {}): ReadyState {
     panel: null,
     panelNotice: null,
     findingConflict: null,
-    submission: { revision: 0, phase: { state: "Idle" } },
-    summary: "",
+    submission: makeSubmission({ state: "Idle" }, 0),
+    summary: { body: "", loads: 0 },
   };
 }
 

--- a/apps/desktop/src/components/SessionShell.tsx
+++ b/apps/desktop/src/components/SessionShell.tsx
@@ -64,9 +64,11 @@ export function SessionShell({
   const { empty_reason: emptyReason, rows } = state.file;
   const isEmpty = emptyReason !== null || rows.length === 0;
   const { phase } = state.submission;
-  // Only an idle submission may start another, so a double press cannot post
-  // twice and a landed review cannot silently resend.
-  const isSubmitting = phase.state !== "Idle";
+  // Nothing new may be asked for while one is in flight, which is what stops a
+  // second confirmation being built over a send that has not come back. A
+  // failure leaves the actions live, because retrying is exactly what it asks
+  // the reviewer to do.
+  const isSending = phase.state === "Sending";
 
   return (
     <div className="session-shell">
@@ -118,7 +120,7 @@ export function SessionShell({
             readyCount={state.drafts.ready_count}
             notAnchoredCount={state.drafts.not_anchored_count}
             summary={state.summary}
-            isSubmitting={isSubmitting}
+            isSending={isSending}
             onSummaryChange={onSummaryChange}
             onSubmit={onSubmit}
           />

--- a/apps/desktop/src/components/SessionShell.tsx
+++ b/apps/desktop/src/components/SessionShell.tsx
@@ -1,10 +1,12 @@
-import type { DiffSideDto } from "../bindings";
+import type { DiffSideDto, ReviewEventDto } from "../bindings";
 import type { ReadyState } from "../hooks/sessionReducer";
 import { composerPrefill, selectionRange } from "../hooks/sessionReducer";
 import { DiffList } from "./DiffList";
 import { EmptyDiffPane } from "./EmptyDiffPane";
 import { FileSidebar } from "./FileSidebar";
 import { ReviewPanel } from "./ReviewPanel";
+import { SubmissionPanel } from "./SubmissionPanel";
+import { SubmitBar } from "./SubmitBar";
 import "./SessionShell.css";
 
 export function SessionShell({
@@ -27,6 +29,10 @@ export function SessionShell({
   onDismissFinding,
   onReplaceFinding,
   onKeepFinding,
+  onSummaryChange,
+  onSubmit,
+  onCancelSubmission,
+  onSendSubmission,
 }: {
   state: ReadyState;
   /** False while Home is in front, which is when this Session has no screen. */
@@ -49,13 +55,27 @@ export function SessionShell({
   onDismissFinding: (id: number) => void;
   onReplaceFinding: (id: number) => void;
   onKeepFinding: () => void;
+  onSummaryChange: (body: string) => void;
+  onSubmit: (event: ReviewEventDto) => void;
+  onCancelSubmission: () => void;
+  onSendSubmission: () => void;
 }) {
   const [selectionStart, selectionEnd] = selectionRange(state);
   const { empty_reason: emptyReason, rows } = state.file;
   const isEmpty = emptyReason !== null || rows.length === 0;
+  const { phase } = state.submission;
+  // Only an idle submission may start another, so a double press cannot post
+  // twice and a landed review cannot silently resend.
+  const isSubmitting = phase.state !== "Idle";
 
   return (
     <div className="session-shell">
+      <SubmissionPanel
+        phase={phase}
+        onCancel={onCancelSubmission}
+        onSend={onSendSubmission}
+      />
+      <div className="session-shell__body">
       <FileSidebar
         onBack={onBack}
         title={state.snapshot.title}
@@ -69,29 +89,41 @@ export function SessionShell({
         onSelect={onSelectFile}
         onReanchorDraft={onReanchorDraft}
       />
-      {isEmpty ? (
-        <EmptyDiffPane
-          label={emptyReason?.label ?? "No lines to show"}
-          detail={emptyReason?.detail ?? "This file has nothing to display."}
-        />
-      ) : (
-        <DiffList
-          rows={rows}
-          isShowing={isShowing}
-          fileIndex={state.file.index}
-          cursor={state.cursor}
-          selectionStart={selectionStart}
-          selectionEnd={selectionEnd}
-          drafts={state.drafts}
-          composer={state.composer}
-          composerPrefill={composerPrefill(state)}
-          onRowClick={onRowClick}
-          onOpenComposer={onOpenComposer}
-          onComposerChange={onComposerChange}
-          onComposerClose={onComposerClose}
-          onComposerDiscard={onComposerDiscard}
-        />
-      )}
+      <div className="session-shell__main">
+        {isEmpty ? (
+          <EmptyDiffPane
+            label={emptyReason?.label ?? "No lines to show"}
+            detail={emptyReason?.detail ?? "This file has nothing to display."}
+          />
+        ) : (
+          <DiffList
+            rows={rows}
+            isShowing={isShowing}
+            fileIndex={state.file.index}
+            cursor={state.cursor}
+            selectionStart={selectionStart}
+            selectionEnd={selectionEnd}
+            drafts={state.drafts}
+            composer={state.composer}
+            composerPrefill={composerPrefill(state)}
+            onRowClick={onRowClick}
+            onOpenComposer={onOpenComposer}
+            onComposerChange={onComposerChange}
+            onComposerClose={onComposerClose}
+            onComposerDiscard={onComposerDiscard}
+          />
+        )}
+        {state.snapshot.can_submit && (
+          <SubmitBar
+            readyCount={state.drafts.ready_count}
+            notAnchoredCount={state.drafts.not_anchored_count}
+            summary={state.summary}
+            isSubmitting={isSubmitting}
+            onSummaryChange={onSummaryChange}
+            onSubmit={onSubmit}
+          />
+        )}
+      </div>
       {state.panel !== null && (
         <ReviewPanel
           panel={state.panel}
@@ -108,6 +140,7 @@ export function SessionShell({
           onKeepFinding={onKeepFinding}
         />
       )}
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/components/SessionShell.tsx
+++ b/apps/desktop/src/components/SessionShell.tsx
@@ -109,16 +109,15 @@ export function SessionShell({
               onComposerDiscard={onComposerDiscard}
             />
           )}
-          {state.snapshot.can_submit && (
-            <SubmitBar
-              readyCount={state.drafts.ready_count}
-              notAnchoredCount={state.drafts.not_anchored_count}
-              summary={state.summary}
-              isSending={isSending}
-              onSummaryChange={onSummaryChange}
-              onSubmit={onSubmit}
-            />
-          )}
+          <SubmitBar
+            readyCount={state.drafts.ready_count}
+            notAnchoredCount={state.drafts.not_anchored_count}
+            summary={state.summary}
+            canSubmit={state.snapshot.can_submit}
+            isSending={isSending}
+            onSummaryChange={onSummaryChange}
+            onSubmit={onSubmit}
+          />
         </div>
         {state.panel !== null && (
           <ReviewPanel

--- a/apps/desktop/src/components/SessionShell.tsx
+++ b/apps/desktop/src/components/SessionShell.tsx
@@ -64,84 +64,78 @@ export function SessionShell({
   const { empty_reason: emptyReason, rows } = state.file;
   const isEmpty = emptyReason !== null || rows.length === 0;
   const { phase } = state.submission;
-  // Nothing new may be asked for while one is in flight, which is what stops a
-  // second confirmation being built over a send that has not come back. A
-  // failure leaves the actions live, because retrying is exactly what it asks
-  // the reviewer to do.
+  // Nothing new may be started over a send that has not come back. A failure
+  // leaves the actions live, because retrying is what it asks the reviewer to do.
   const isSending = phase.state === "Sending";
 
   return (
     <div className="session-shell">
-      <SubmissionPanel
-        phase={phase}
-        onCancel={onCancelSubmission}
-        onSend={onSendSubmission}
-      />
+      <SubmissionPanel phase={phase} onCancel={onCancelSubmission} onSend={onSendSubmission} />
       <div className="session-shell__body">
-      <FileSidebar
-        onBack={onBack}
-        title={state.snapshot.title}
-        subtitle={state.snapshot.subtitle}
-        sidebar={state.snapshot.sidebar}
-        warnings={state.snapshot.warnings}
-        writeFailure={state.drafts.write_failure}
-        fileDraftCount={state.drafts.file_draft_count}
-        staleDrafts={state.drafts.stale}
-        cursor={state.cursor}
-        onSelect={onSelectFile}
-        onReanchorDraft={onReanchorDraft}
-      />
-      <div className="session-shell__main">
-        {isEmpty ? (
-          <EmptyDiffPane
-            label={emptyReason?.label ?? "No lines to show"}
-            detail={emptyReason?.detail ?? "This file has nothing to display."}
-          />
-        ) : (
-          <DiffList
-            rows={rows}
-            isShowing={isShowing}
-            fileIndex={state.file.index}
-            cursor={state.cursor}
-            selectionStart={selectionStart}
-            selectionEnd={selectionEnd}
-            drafts={state.drafts}
-            composer={state.composer}
-            composerPrefill={composerPrefill(state)}
-            onRowClick={onRowClick}
-            onOpenComposer={onOpenComposer}
-            onComposerChange={onComposerChange}
-            onComposerClose={onComposerClose}
-            onComposerDiscard={onComposerDiscard}
-          />
-        )}
-        {state.snapshot.can_submit && (
-          <SubmitBar
-            readyCount={state.drafts.ready_count}
-            notAnchoredCount={state.drafts.not_anchored_count}
-            summary={state.summary}
-            isSending={isSending}
-            onSummaryChange={onSummaryChange}
-            onSubmit={onSubmit}
-          />
-        )}
-      </div>
-      {state.panel !== null && (
-        <ReviewPanel
-          panel={state.panel}
-          notice={state.panelNotice}
-          findingConflict={state.findingConflict}
-          onRunReview={onRunReview}
-          onCancelReview={onCancelReview}
-          onToggleGuidanceSection={onToggleGuidanceSection}
-          onToggleGuidanceFile={onToggleGuidanceFile}
-          onRevealFinding={onRevealFinding}
-          onAcceptFinding={onAcceptFinding}
-          onDismissFinding={onDismissFinding}
-          onReplaceFinding={onReplaceFinding}
-          onKeepFinding={onKeepFinding}
+        <FileSidebar
+          onBack={onBack}
+          title={state.snapshot.title}
+          subtitle={state.snapshot.subtitle}
+          sidebar={state.snapshot.sidebar}
+          warnings={state.snapshot.warnings}
+          writeFailure={state.drafts.write_failure}
+          fileDraftCount={state.drafts.file_draft_count}
+          staleDrafts={state.drafts.stale}
+          cursor={state.cursor}
+          onSelect={onSelectFile}
+          onReanchorDraft={onReanchorDraft}
         />
-      )}
+        <div className="session-shell__main">
+          {isEmpty ? (
+            <EmptyDiffPane
+              label={emptyReason?.label ?? "No lines to show"}
+              detail={emptyReason?.detail ?? "This file has nothing to display."}
+            />
+          ) : (
+            <DiffList
+              rows={rows}
+              isShowing={isShowing}
+              fileIndex={state.file.index}
+              cursor={state.cursor}
+              selectionStart={selectionStart}
+              selectionEnd={selectionEnd}
+              drafts={state.drafts}
+              composer={state.composer}
+              composerPrefill={composerPrefill(state)}
+              onRowClick={onRowClick}
+              onOpenComposer={onOpenComposer}
+              onComposerChange={onComposerChange}
+              onComposerClose={onComposerClose}
+              onComposerDiscard={onComposerDiscard}
+            />
+          )}
+          {state.snapshot.can_submit && (
+            <SubmitBar
+              readyCount={state.drafts.ready_count}
+              notAnchoredCount={state.drafts.not_anchored_count}
+              summary={state.summary}
+              isSending={isSending}
+              onSummaryChange={onSummaryChange}
+              onSubmit={onSubmit}
+            />
+          )}
+        </div>
+        {state.panel !== null && (
+          <ReviewPanel
+            panel={state.panel}
+            notice={state.panelNotice}
+            findingConflict={state.findingConflict}
+            onRunReview={onRunReview}
+            onCancelReview={onCancelReview}
+            onToggleGuidanceSection={onToggleGuidanceSection}
+            onToggleGuidanceFile={onToggleGuidanceFile}
+            onRevealFinding={onRevealFinding}
+            onAcceptFinding={onAcceptFinding}
+            onDismissFinding={onDismissFinding}
+            onReplaceFinding={onReplaceFinding}
+            onKeepFinding={onKeepFinding}
+          />
+        )}
       </div>
     </div>
   );

--- a/apps/desktop/src/components/SubmissionPanel.css
+++ b/apps/desktop/src/components/SubmissionPanel.css
@@ -1,0 +1,136 @@
+.submission-panel {
+  flex-shrink: 0;
+  max-height: 420px;
+  overflow-y: auto;
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-bottom: 1px solid var(--border-default);
+  background: var(--surface-base);
+  font-family: var(--font-mono);
+  font-size: var(--size-body);
+}
+
+.submission-panel p {
+  margin: 0;
+}
+
+.submission-panel__heading {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.submission-panel__pinned {
+  color: var(--text-tertiary);
+  font-size: var(--size-label);
+}
+
+.submission-panel__body {
+  padding: 8px;
+  border-radius: 6px;
+  background: var(--surface-raised);
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+}
+
+.submission-panel__comments,
+.submission-panel__excluded-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.submission-panel__comment {
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border-left: 2px solid var(--accent-base);
+  border-radius: 6px;
+  background: var(--surface-raised);
+}
+
+.submission-panel__position {
+  color: var(--text-secondary);
+  font-size: var(--size-label);
+}
+
+.submission-panel__comment-body {
+  color: var(--text-primary);
+  white-space: pre-wrap;
+}
+
+.submission-panel__excluded {
+  margin-top: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.submission-panel__excluded-heading {
+  color: var(--severity-error-text);
+}
+
+.submission-panel__excluded-draft {
+  color: var(--text-secondary);
+  font-size: var(--size-label);
+}
+
+.submission-panel__actions {
+  margin-top: 8px;
+  display: flex;
+  gap: 8px;
+}
+
+.submission-panel__send,
+.submission-panel__cancel {
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: var(--size-body);
+  cursor: pointer;
+}
+
+.submission-panel__send {
+  border: none;
+  background: var(--accent-base);
+  color: var(--text-on-accent);
+}
+
+.submission-panel__cancel {
+  border: 1px solid var(--border-strong);
+  background: transparent;
+  color: var(--text-secondary);
+}
+
+.submission-panel__sending {
+  color: var(--accent-text);
+}
+
+.submission-panel__sent {
+  color: var(--severity-success-text);
+  font-weight: 600;
+}
+
+.submission-panel__url {
+  color: var(--text-secondary);
+  font-size: var(--size-label);
+}
+
+.submission-panel__failed {
+  color: var(--severity-error-text);
+  font-weight: 600;
+}
+
+.submission-panel__remediation {
+  color: var(--severity-warning-text);
+}
+
+.submission-panel__detail {
+  color: var(--text-secondary);
+  font-size: var(--size-label);
+}

--- a/apps/desktop/src/components/SubmissionPanel.tsx
+++ b/apps/desktop/src/components/SubmissionPanel.tsx
@@ -51,6 +51,13 @@ export function SubmissionPanel({
 
     case "Confirming":
       return <Confirmation request={phase.request} onCancel={onCancel} onSend={onSend} />;
+
+    default: {
+      // A submission state the backend grew that nothing here can draw. Drawing
+      // nothing would hide a review that may be in flight or may have failed.
+      const unknown: never = phase;
+      throw new Error(`the submission is in an unknown state ${JSON.stringify(unknown)}`);
+    }
   }
 }
 

--- a/apps/desktop/src/components/SubmissionPanel.tsx
+++ b/apps/desktop/src/components/SubmissionPanel.tsx
@@ -53,10 +53,20 @@ export function SubmissionPanel({
       return <Confirmation request={phase.request} onCancel={onCancel} onSend={onSend} />;
 
     default: {
-      // A submission state the backend grew that nothing here can draw. Drawing
-      // nothing would hide a review that may be in flight or may have failed.
+      // A submission state the backend grew that nothing here can draw. There is
+      // no error boundary above this, so throwing would blank the window, and
+      // drawing nothing would hide a review that may be in flight. The `never`
+      // is what turns a new state into a compile error rather than this line.
       const unknown: never = phase;
-      throw new Error(`the submission is in an unknown state ${JSON.stringify(unknown)}`);
+      return (
+        <section className="submission-panel">
+          <p className="submission-panel__failed">
+            This submission is in a state ZReview cannot show. Check the pull request on GitHub
+            before submitting again.
+          </p>
+          <p className="submission-panel__detail">{JSON.stringify(unknown)}</p>
+        </section>
+      );
     }
   }
 }

--- a/apps/desktop/src/components/SubmissionPanel.tsx
+++ b/apps/desktop/src/components/SubmissionPanel.tsx
@@ -1,0 +1,102 @@
+import type { SubmissionPhaseDto, SubmissionRequestDto } from "../bindings";
+import "./SubmissionPanel.css";
+
+/**
+ * Everything about the submission that belongs above the diff.
+ *
+ * A full panel rather than a small dialog, because the reviewer has to see every
+ * inline comment, the summary, the verdict, and the head it is pinned to before
+ * anything is posted.
+ */
+export function SubmissionPanel({
+  phase,
+  onCancel,
+  onSend,
+}: {
+  phase: SubmissionPhaseDto;
+  onCancel: () => void;
+  onSend: () => void;
+}) {
+  switch (phase.state) {
+    case "Idle":
+      return null;
+
+    case "Sending":
+      return (
+        <section className="submission-panel">
+          <p className="submission-panel__sending">Submitting the review...</p>
+        </section>
+      );
+
+    case "Sent":
+      return (
+        <section className="submission-panel">
+          <p className="submission-panel__sent">{phase.outcome.heading}</p>
+          <p className="submission-panel__url">{phase.outcome.url}</p>
+        </section>
+      );
+
+    case "Failed":
+      return (
+        <section className="submission-panel">
+          <p className="submission-panel__failed">{phase.failure.summary}</p>
+          {phase.failure.remediation !== null && (
+            <p className="submission-panel__remediation">{phase.failure.remediation}</p>
+          )}
+          {phase.failure.detail !== null && (
+            <p className="submission-panel__detail">{phase.failure.detail}</p>
+          )}
+        </section>
+      );
+
+    case "Confirming":
+      return <Confirmation request={phase.request} onCancel={onCancel} onSend={onSend} />;
+  }
+}
+
+/** The full request, laid out for approval. Nothing has been posted yet. */
+function Confirmation({
+  request,
+  onCancel,
+  onSend,
+}: {
+  request: SubmissionRequestDto;
+  onCancel: () => void;
+  onSend: () => void;
+}) {
+  return (
+    <section className="submission-panel">
+      <p className="submission-panel__heading">{request.heading}</p>
+      <p className="submission-panel__pinned">{request.pinned}</p>
+      {request.body !== "" && <p className="submission-panel__body">{request.body}</p>}
+      <ul className="submission-panel__comments">
+        {request.comments.map((comment, index) => (
+          <li key={`${comment.position}-${index}`} className="submission-panel__comment">
+            <span className="submission-panel__position">{comment.position}</span>
+            <span className="submission-panel__comment-body">{comment.body}</span>
+          </li>
+        ))}
+      </ul>
+      {request.excluded_heading !== null && (
+        <div className="submission-panel__excluded">
+          <p className="submission-panel__excluded-heading">{request.excluded_heading}</p>
+          <ul className="submission-panel__excluded-list">
+            {request.excluded.map((draft, index) => (
+              <li key={`${draft.position}-${index}`} className="submission-panel__excluded-draft">
+                {draft.position} ({draft.reason}): {draft.body}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <div className="submission-panel__actions">
+        <button type="button" className="submission-panel__send" onClick={onSend}>
+          Post this review to GitHub
+        </button>
+        <button type="button" className="submission-panel__cancel" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/apps/desktop/src/components/SubmitBar.css
+++ b/apps/desktop/src/components/SubmitBar.css
@@ -1,0 +1,63 @@
+.submit-bar {
+  flex-shrink: 0;
+  height: 92px;
+  padding: 8px 12px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border-top: 1px solid var(--border-default);
+  background: var(--surface-base);
+  font-family: var(--font-mono);
+  font-size: var(--size-body);
+}
+
+.submit-bar__counts {
+  width: 150px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.submit-bar__ready {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.submit-bar__stale {
+  color: var(--severity-error-text);
+  font-size: var(--size-label);
+}
+
+.submit-bar__actions {
+  flex-shrink: 0;
+  display: flex;
+  gap: 8px;
+}
+
+.submit-bar__action {
+  padding: 8px 12px;
+  border: none;
+  border-radius: 6px;
+  color: var(--text-on-accent);
+  font-family: inherit;
+  font-size: var(--size-label);
+  cursor: pointer;
+}
+
+.submit-bar__action:disabled {
+  opacity: var(--viewed-opacity);
+  cursor: default;
+}
+
+.submit-bar__action--comment {
+  background: var(--accent-base);
+}
+
+.submit-bar__action--approve {
+  background: var(--severity-success);
+}
+
+.submit-bar__action--changes {
+  background: var(--severity-error);
+}

--- a/apps/desktop/src/components/SubmitBar.tsx
+++ b/apps/desktop/src/components/SubmitBar.tsx
@@ -1,4 +1,5 @@
 import type { ReviewEventDto } from "../bindings";
+import type { SummaryState } from "../hooks/sessionReducer";
 import { SummaryEditor } from "./SummaryEditor";
 import "./SubmitBar.css";
 
@@ -26,8 +27,8 @@ export function SubmitBar({
 }: {
   readyCount: number;
   notAnchoredCount: number;
-  /** What the editor should hold, which moves only when the backend says so. */
-  summary: string;
+  /** What the editor holds, and how many times the backend has replaced it. */
+  summary: SummaryState;
   /** True while a review is in flight, when no other submission may be started. */
   isSending: boolean;
   onSummaryChange: (body: string) => void;
@@ -41,7 +42,7 @@ export function SubmitBar({
           <span className="submit-bar__stale">{notAnchoredCount} not anchored</span>
         )}
       </div>
-      <SummaryEditor summary={summary} onChange={onSummaryChange} />
+      <SummaryEditor body={summary.body} loads={summary.loads} onChange={onSummaryChange} />
       <div className="submit-bar__actions">
         {ACTIONS.map(({ event, label, tone }) => (
           <button

--- a/apps/desktop/src/components/SubmitBar.tsx
+++ b/apps/desktop/src/components/SubmitBar.tsx
@@ -1,0 +1,60 @@
+import type { ReviewEventDto } from "../bindings";
+import { SummaryEditor } from "./SummaryEditor";
+import "./SubmitBar.css";
+
+/** The three verdicts, in the order the GPUI bar offers them. */
+const ACTIONS: { event: ReviewEventDto; label: string; tone: string }[] = [
+  { event: "Comment", label: "Comment", tone: "comment" },
+  { event: "Approve", label: "Approve", tone: "approve" },
+  { event: "RequestChanges", label: "Request changes", tone: "changes" },
+];
+
+/**
+ * What would be submitted, the summary that goes with it, and the three ways to
+ * submit it.
+ *
+ * Choosing an action posts nothing. It opens the confirmation holding the exact
+ * request, so what the reviewer approves is what leaves the machine.
+ */
+export function SubmitBar({
+  readyCount,
+  notAnchoredCount,
+  summary,
+  isSubmitting,
+  onSummaryChange,
+  onSubmit,
+}: {
+  readyCount: number;
+  notAnchoredCount: number;
+  /** What the editor should hold, which moves only when the backend says so. */
+  summary: string;
+  /** True while a submission is confirming or in flight, when no new one may start. */
+  isSubmitting: boolean;
+  onSummaryChange: (body: string) => void;
+  onSubmit: (event: ReviewEventDto) => void;
+}) {
+  return (
+    <div className="submit-bar">
+      <div className="submit-bar__counts">
+        <span className="submit-bar__ready">{readyCount} to submit</span>
+        {notAnchoredCount > 0 && (
+          <span className="submit-bar__stale">{notAnchoredCount} not anchored</span>
+        )}
+      </div>
+      <SummaryEditor summary={summary} onChange={onSummaryChange} />
+      <div className="submit-bar__actions">
+        {ACTIONS.map(({ event, label, tone }) => (
+          <button
+            key={event}
+            type="button"
+            className={`submit-bar__action submit-bar__action--${tone}`}
+            disabled={isSubmitting}
+            onClick={() => onSubmit(event)}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/SubmitBar.tsx
+++ b/apps/desktop/src/components/SubmitBar.tsx
@@ -20,7 +20,7 @@ export function SubmitBar({
   readyCount,
   notAnchoredCount,
   summary,
-  isSubmitting,
+  isSending,
   onSummaryChange,
   onSubmit,
 }: {
@@ -28,8 +28,8 @@ export function SubmitBar({
   notAnchoredCount: number;
   /** What the editor should hold, which moves only when the backend says so. */
   summary: string;
-  /** True while a submission is confirming or in flight, when no new one may start. */
-  isSubmitting: boolean;
+  /** True while a review is in flight, when no other submission may be started. */
+  isSending: boolean;
   onSummaryChange: (body: string) => void;
   onSubmit: (event: ReviewEventDto) => void;
 }) {
@@ -48,7 +48,7 @@ export function SubmitBar({
             key={event}
             type="button"
             className={`submit-bar__action submit-bar__action--${tone}`}
-            disabled={isSubmitting}
+            disabled={isSending}
             onClick={() => onSubmit(event)}
           >
             {label}

--- a/apps/desktop/src/components/SubmitBar.tsx
+++ b/apps/desktop/src/components/SubmitBar.tsx
@@ -16,11 +16,16 @@ const ACTIONS: { event: ReviewEventDto; label: string; tone: string }[] = [
  *
  * Choosing an action posts nothing. It opens the confirmation holding the exact
  * request, so what the reviewer approves is what leaves the machine.
+ *
+ * The counts and the editor are here for every Session. Only the verdicts need
+ * somewhere to post to, and a Session without one still has a summary that a
+ * whole-change finding can be accepted into.
  */
 export function SubmitBar({
   readyCount,
   notAnchoredCount,
   summary,
+  canSubmit,
   isSending,
   onSummaryChange,
   onSubmit,
@@ -29,6 +34,8 @@ export function SubmitBar({
   notAnchoredCount: number;
   /** What the editor holds, and how many times the backend has replaced it. */
   summary: SummaryState;
+  /** Whether this Session has somewhere to post a review at all. */
+  canSubmit: boolean;
   /** True while a review is in flight, when no other submission may be started. */
   isSending: boolean;
   onSummaryChange: (body: string) => void;
@@ -43,19 +50,21 @@ export function SubmitBar({
         )}
       </div>
       <SummaryEditor body={summary.body} loads={summary.loads} onChange={onSummaryChange} />
-      <div className="submit-bar__actions">
-        {ACTIONS.map(({ event, label, tone }) => (
-          <button
-            key={event}
-            type="button"
-            className={`submit-bar__action submit-bar__action--${tone}`}
-            disabled={isSending}
-            onClick={() => onSubmit(event)}
-          >
-            {label}
-          </button>
-        ))}
-      </div>
+      {canSubmit && (
+        <div className="submit-bar__actions">
+          {ACTIONS.map(({ event, label, tone }) => (
+            <button
+              key={event}
+              type="button"
+              className={`submit-bar__action submit-bar__action--${tone}`}
+              disabled={isSending}
+              onClick={() => onSubmit(event)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/components/SummaryEditor.css
+++ b/apps/desktop/src/components/SummaryEditor.css
@@ -1,0 +1,14 @@
+.summary-editor {
+  flex: 1;
+  min-width: 0;
+}
+
+.summary-editor__field .cm-editor {
+  height: 76px;
+  border-radius: 6px;
+  border: 1px solid var(--border-default);
+}
+
+.summary-editor__field .cm-scroller {
+  overflow: auto;
+}

--- a/apps/desktop/src/components/SummaryEditor.tsx
+++ b/apps/desktop/src/components/SummaryEditor.tsx
@@ -5,24 +5,28 @@ import "./SummaryEditor.css";
 /**
  * The review summary, in the same Markdown editor the comment composer uses.
  *
- * Seeded once on mount from whatever storage restored, and written through on
- * every keystroke. `summary` is reloaded into it only when it moves, which the
- * backend does after a whole-change finding lands in it or a successful send
- * empties it. Typing never moves it, so the reviewer's cursor is left alone.
+ * Seeded once on mount from whatever storage restored, and reported on every
+ * keystroke. `body` is taken back into it only when `loads` moves, which the
+ * backend does after a whole-change finding is merged in or a landed review
+ * empties it. Typing never moves `loads`, so the reviewer's caret is never reset
+ * by their own keystrokes.
  */
 export function SummaryEditor({
-  summary,
+  body,
+  loads,
   onChange,
 }: {
-  summary: string;
+  body: string;
+  /** How many times the backend has replaced the text. */
+  loads: number;
   onChange: (body: string) => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<MarkdownEditorHandle | null>(null);
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
-  const loadedRef = useRef(summary);
-  const seedRef = useRef(summary);
+  const loadedRef = useRef(loads);
+  const seedRef = useRef(body);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -32,7 +36,7 @@ export function SummaryEditor({
     const handle = createMarkdownEditor({
       parent: container,
       initialText: seedRef.current,
-      onChange: (body) => onChangeRef.current(body),
+      onChange: (typed) => onChangeRef.current(typed),
       // The summary has nothing to close; Escape and Mod-Enter do nothing here.
       onClose: () => {},
     });
@@ -44,12 +48,12 @@ export function SummaryEditor({
   }, []);
 
   useEffect(() => {
-    if (summary === loadedRef.current) {
+    if (loads === loadedRef.current) {
       return;
     }
-    loadedRef.current = summary;
-    editorRef.current?.load(summary);
-  }, [summary]);
+    loadedRef.current = loads;
+    editorRef.current?.load(body);
+  }, [loads, body]);
 
   return (
     <div className="summary-editor" data-summary-editor>

--- a/apps/desktop/src/components/SummaryEditor.tsx
+++ b/apps/desktop/src/components/SummaryEditor.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from "react";
+import { createMarkdownEditor, type MarkdownEditorHandle } from "../editor/markdownEditor";
+import "./SummaryEditor.css";
+
+/**
+ * The review summary, in the same Markdown editor the comment composer uses.
+ *
+ * Seeded once on mount from whatever storage restored, and written through on
+ * every keystroke. `summary` is reloaded into it only when it moves, which the
+ * backend does after a whole-change finding lands in it or a successful send
+ * empties it. Typing never moves it, so the reviewer's cursor is left alone.
+ */
+export function SummaryEditor({
+  summary,
+  onChange,
+}: {
+  summary: string;
+  onChange: (body: string) => void;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const editorRef = useRef<MarkdownEditorHandle | null>(null);
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+  const loadedRef = useRef(summary);
+  const seedRef = useRef(summary);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    const handle = createMarkdownEditor({
+      parent: container,
+      initialText: seedRef.current,
+      onChange: (body) => onChangeRef.current(body),
+      // The summary has nothing to close; Escape and Mod-Enter do nothing here.
+      onClose: () => {},
+    });
+    editorRef.current = handle;
+    return () => {
+      editorRef.current = null;
+      handle.destroy();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (summary === loadedRef.current) {
+      return;
+    }
+    loadedRef.current = summary;
+    editorRef.current?.load(summary);
+  }, [summary]);
+
+  return (
+    <div className="summary-editor" data-summary-editor>
+      <div className="summary-editor__field" ref={containerRef} />
+    </div>
+  );
+}

--- a/apps/desktop/src/editor/markdownEditor.ts
+++ b/apps/desktop/src/editor/markdownEditor.ts
@@ -23,9 +23,9 @@ export function createMarkdownEditor({
   onChange: (text: string) => void;
   onClose: () => void;
 }): MarkdownEditorHandle {
-  // Set while `load` replaces the document, so text the model already holds is
-  // not written straight back to it as though the reviewer had typed it.
-  let isLoading = false;
+  // Set while `load` replaces the whole document, so text the model already
+  // holds is not reported back as though the reviewer had typed it.
+  let isReplacingDocument = false;
   const view = new EditorView({
     parent,
     state: EditorState.create({
@@ -53,7 +53,7 @@ export function createMarkdownEditor({
         ]),
         EditorView.lineWrapping,
         EditorView.updateListener.of((update) => {
-          if (update.docChanged && !isLoading) {
+          if (update.docChanged && !isReplacingDocument) {
             onChange(update.state.doc.toString());
           }
         }),
@@ -88,9 +88,9 @@ export function createMarkdownEditor({
   return {
     focus: () => view.focus(),
     load: (text) => {
-      isLoading = true;
+      isReplacingDocument = true;
       view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: text } });
-      isLoading = false;
+      isReplacingDocument = false;
     },
     destroy: () => view.destroy(),
   };

--- a/apps/desktop/src/editor/markdownEditor.ts
+++ b/apps/desktop/src/editor/markdownEditor.ts
@@ -6,6 +6,8 @@ import { EditorView, keymap } from "@codemirror/view";
 /** What a component gets back from the composer's editor; components never import CodeMirror directly. */
 export interface MarkdownEditorHandle {
   focus: () => void;
+  /** Replaces the whole document with text the model already holds, reporting no change for it. */
+  load: (text: string) => void;
   destroy: () => void;
 }
 
@@ -21,6 +23,9 @@ export function createMarkdownEditor({
   onChange: (text: string) => void;
   onClose: () => void;
 }): MarkdownEditorHandle {
+  // Set while `load` replaces the document, so text the model already holds is
+  // not written straight back to it as though the reviewer had typed it.
+  let isLoading = false;
   const view = new EditorView({
     parent,
     state: EditorState.create({
@@ -48,7 +53,7 @@ export function createMarkdownEditor({
         ]),
         EditorView.lineWrapping,
         EditorView.updateListener.of((update) => {
-          if (update.docChanged) {
+          if (update.docChanged && !isLoading) {
             onChange(update.state.doc.toString());
           }
         }),
@@ -82,6 +87,11 @@ export function createMarkdownEditor({
 
   return {
     focus: () => view.focus(),
+    load: (text) => {
+      isLoading = true;
+      view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: text } });
+      isLoading = false;
+    },
     destroy: () => view.destroy(),
   };
 }

--- a/apps/desktop/src/hooks/sessionReducer.test.ts
+++ b/apps/desktop/src/hooks/sessionReducer.test.ts
@@ -100,6 +100,22 @@ describe("sessionReducer", () => {
     expect(next).toMatchObject({ panel: { revision: 7, heading: "2 findings" } });
   });
 
+  it("drops a submission that was read before the one it already holds", () => {
+    const held = sessionReducer(readyState(1), {
+      type: "submission",
+      submission: makeSubmission({ state: "Sending" }, 7),
+    });
+
+    const next = sessionReducer(held, {
+      type: "submission",
+      submission: makeSubmission({ state: "Idle" }, 5),
+    });
+
+    expect(next).toMatchObject({
+      submission: { revision: 7, phase: { state: "Sending" } },
+    });
+  });
+
   it("keeps a panel read at the same revision, which carries the same state", () => {
     const held = sessionReducer(readyState(1), { type: "panel", panel: makePanel({ revision: 7 }) });
 

--- a/apps/desktop/src/hooks/sessionReducer.test.ts
+++ b/apps/desktop/src/hooks/sessionReducer.test.ts
@@ -8,6 +8,7 @@ import {
   makePanel,
   makeRow,
   makeSnapshot,
+  makeSubmission,
 } from "../test/fixtures";
 import {
   type ReadyState,
@@ -38,8 +39,8 @@ function readyState(rowCount: number, cursor = 0, anchor = 0): ReadyState {
     panel: null,
     panelNotice: null,
     findingConflict: null,
-    submission: { revision: 0, phase: { state: "Idle" } },
-    summary: "",
+    submission: makeSubmission({ state: "Idle" }, 0),
+    summary: { body: "", loads: 0 },
   };
 }
 

--- a/apps/desktop/src/hooks/sessionReducer.test.ts
+++ b/apps/desktop/src/hooks/sessionReducer.test.ts
@@ -38,6 +38,8 @@ function readyState(rowCount: number, cursor = 0, anchor = 0): ReadyState {
     panel: null,
     panelNotice: null,
     findingConflict: null,
+    submission: { revision: 0, phase: { state: "Idle" } },
+    summary: "",
   };
 }
 

--- a/apps/desktop/src/hooks/sessionReducer.ts
+++ b/apps/desktop/src/hooks/sessionReducer.ts
@@ -14,6 +14,9 @@ import { clamp } from "../lib/clamp";
 /** Shown under the composer when a span was refused rather than saved. */
 const REJECTED_NOTICE = "This selection cannot hold a comment";
 
+/** What the summary editor holds, with a count that moves only on a backend replacement. */
+export type SummaryState = { body: string; loads: number };
+
 /** The composer's frozen span and any notice it is showing, or absent when closed. */
 export type ComposerState = { rows: [number, number]; notice: string | null } | null;
 
@@ -54,14 +57,18 @@ export type SessionState =
        */
       submission: SubmissionDto;
       /**
-       * The text the backend last said the summary editor should hold.
+       * What the summary editor holds, and how many times the backend has
+       * replaced it.
        *
-       * Typing does not change this. It moves only when the backend hands back
-       * text of its own, which is a whole-change finding accepted into the
-       * summary or a successful send emptying it, and that is what tells the
-       * editor to reload rather than fighting the reviewer's cursor.
+       * `body` moves with every keystroke, so this is never a stale copy of what
+       * is on screen. `loads` moves only when the backend replaces the text,
+       * which is a whole-change finding merged in or a landed review emptying
+       * it, and is what tells the editor to take the new text. Comparing the
+       * text itself cannot do that job, because React state trails the editor by
+       * a keystroke and an equality check ends up loading an older document over
+       * a newer one, eating what was just typed.
        */
-      summary: string;
+      summary: SummaryState;
     };
 
 export type ReadyState = Extract<SessionState, { status: "ready" }>;
@@ -85,6 +92,7 @@ export type SessionAction =
   | { type: "panel"; panel: ReviewPanelDto | null }
   | { type: "submission"; submission: SubmissionDto }
   | { type: "summary"; body: string }
+  | { type: "summaryLoaded"; body: string }
   | { type: "panelNotice"; notice: string }
   | { type: "findingConflict"; conflict: FindingConflict }
   | { type: "file"; file: FileDetailDto }
@@ -95,6 +103,7 @@ export type SessionAction =
   | { type: "openComposer"; index: number }
   | { type: "closeComposer" }
   | { type: "drafts"; drafts: DraftsDto }
+  | { type: "writeFailure"; failure: string | null }
   | { type: "editRejected" };
 
 /** Clamps a cursor into a row range, or to zero when the file has no rows. */
@@ -132,7 +141,7 @@ export function sessionReducer(state: SessionState, action: SessionAction): Sess
         panelNotice: null,
         findingConflict: null,
         submission: { revision: 0, phase: { state: "Idle" } },
-        summary: action.snapshot.summary,
+        summary: { body: action.snapshot.summary, loads: 0 },
       };
 
     case "submission": {
@@ -153,7 +162,18 @@ export function sessionReducer(state: SessionState, action: SessionAction): Sess
       if (state.status !== "ready") {
         return state;
       }
-      return { ...state, summary: action.body };
+      // Typed, so the editor already shows it and must not be handed it back.
+      return { ...state, summary: { ...state.summary, body: action.body } };
+
+    case "summaryLoaded":
+      if (state.status !== "ready") {
+        return state;
+      }
+      // Replaced by the backend, so the editor is told to take it.
+      return {
+        ...state,
+        summary: { body: action.body, loads: state.summary.loads + 1 },
+      };
 
     case "panel": {
       if (state.status !== "ready") {
@@ -258,6 +278,15 @@ export function sessionReducer(state: SessionState, action: SessionAction): Sess
         drafts: action.drafts,
         composer: state.composer ? { ...state.composer, notice: null } : null,
       };
+
+    case "writeFailure": {
+      if (state.status !== "ready" || state.drafts.write_failure === action.failure) {
+        return state;
+      }
+      // The same session-wide reason a drafts answer carries, from the one
+      // command a reviewer writing only a summary ever calls.
+      return { ...state, drafts: { ...state.drafts, write_failure: action.failure } };
+    }
 
     case "editRejected":
       if (state.status !== "ready" || !state.composer) {

--- a/apps/desktop/src/hooks/sessionReducer.ts
+++ b/apps/desktop/src/hooks/sessionReducer.ts
@@ -7,6 +7,7 @@ import type {
   SessionFailureDto,
   SessionSnapshotDto,
   SidebarDto,
+  SubmissionDto,
 } from "../bindings";
 import { clamp } from "../lib/clamp";
 
@@ -45,6 +46,22 @@ export type SessionState =
       panelNotice: string | null;
       /** The confirmation accepting a finding onto an occupied line is asking. */
       findingConflict: FindingConflict;
+      /**
+       * How far a submission has got, held in memory only.
+       *
+       * Never persisted, so a fresh Session starts idle however the last one
+       * ended.
+       */
+      submission: SubmissionDto;
+      /**
+       * The text the backend last said the summary editor should hold.
+       *
+       * Typing does not change this. It moves only when the backend hands back
+       * text of its own, which is a whole-change finding accepted into the
+       * summary or a successful send emptying it, and that is what tells the
+       * editor to reload rather than fighting the reviewer's cursor.
+       */
+      summary: string;
     };
 
 export type ReadyState = Extract<SessionState, { status: "ready" }>;
@@ -66,6 +83,8 @@ export type SessionAction =
       panel: ReviewPanelDto | null;
     }
   | { type: "panel"; panel: ReviewPanelDto | null }
+  | { type: "submission"; submission: SubmissionDto }
+  | { type: "summary"; body: string }
   | { type: "panelNotice"; notice: string }
   | { type: "findingConflict"; conflict: FindingConflict }
   | { type: "file"; file: FileDetailDto }
@@ -112,7 +131,29 @@ export function sessionReducer(state: SessionState, action: SessionAction): Sess
         panel: action.panel,
         panelNotice: null,
         findingConflict: null,
+        submission: { revision: 0, phase: { state: "Idle" } },
+        summary: action.snapshot.summary,
       };
+
+    case "submission": {
+      if (state.status !== "ready") {
+        return state;
+      }
+      // Several submission commands answer with the whole state and they can be
+      // in flight at once. One that read the model before a change must not land
+      // on top of one that carries it, which would show a confirmation for a
+      // verdict the model is no longer holding.
+      if (action.submission.revision < state.submission.revision) {
+        return state;
+      }
+      return { ...state, submission: action.submission };
+    }
+
+    case "summary":
+      if (state.status !== "ready") {
+        return state;
+      }
+      return { ...state, summary: action.body };
 
     case "panel": {
       if (state.status !== "ready") {

--- a/apps/desktop/src/hooks/useDraftQueue.ts
+++ b/apps/desktop/src/hooks/useDraftQueue.ts
@@ -6,7 +6,8 @@ import type { SessionAction } from "./sessionReducer";
 type DraftCommand =
   | { kind: "edit"; fileIndex: number; start: number; end: number; body: string }
   | { kind: "discard"; fileIndex: number; row: number }
-  | { kind: "reanchor"; fileIndex: number; path: string; side: DiffSideDto; line: number; row: number };
+  | { kind: "reanchor"; fileIndex: number; path: string; side: DiffSideDto; line: number; row: number }
+  | { kind: "summary"; body: string };
 
 function send(command: DraftCommand) {
   switch (command.kind) {
@@ -22,6 +23,8 @@ function send(command: DraftCommand) {
         command.line,
         command.row,
       );
+    case "summary":
+      return commands.editSummary(command.body);
   }
 }
 
@@ -32,13 +35,28 @@ function outcome(command: DraftCommand, data: DraftsDto | { accepted: boolean; d
     : { accepted: true, drafts: data as DraftsDto };
 }
 
-/** Serialises draft edits, discards, and reanchors, at most one in flight, consecutive edits coalescing while a discard or reanchor is always sent in order. */
+/** Whether two consecutive commands may collapse into the later one, which only per-keystroke writes of the same text may. */
+function coalesces(command: DraftCommand, previous: DraftCommand | undefined): boolean {
+  if (command.kind === "edit") {
+    return previous?.kind === "edit";
+  }
+  if (command.kind === "summary") {
+    return previous?.kind === "summary";
+  }
+  return false;
+}
+
+/** Serialises draft edits, discards, reanchors, and summary writes, at most one in flight, consecutive writes of one text coalescing while a discard or reanchor is always sent in order. */
 export function useDraftQueue(dispatch: (action: SessionAction) => void) {
   const inFlight = useRef(false);
   const pending = useRef<DraftCommand[]>([]);
 
   const settle = useCallback(
-    (command: DraftCommand, data: DraftsDto | { accepted: boolean; drafts: DraftsDto }) => {
+    (command: DraftCommand, data: DraftsDto | { accepted: boolean; drafts: DraftsDto } | null) => {
+      // The summary answers with nothing. The editor already holds what it sent.
+      if (command.kind === "summary" || data === null) {
+        return;
+      }
       const { accepted, drafts } = outcome(command, data);
       dispatch({ type: "drafts", drafts });
       if (!accepted) {
@@ -76,8 +94,7 @@ export function useDraftQueue(dispatch: (action: SessionAction) => void) {
         return;
       }
       const queue = pending.current;
-      const last = queue[queue.length - 1];
-      if (command.kind === "edit" && last?.kind === "edit") {
+      if (coalesces(command, queue[queue.length - 1])) {
         queue[queue.length - 1] = command;
       } else {
         queue.push(command);
@@ -103,5 +120,7 @@ export function useDraftQueue(dispatch: (action: SessionAction) => void) {
     [enqueue],
   );
 
-  return { editDraft, discardDraft, reanchorDraft };
+  const editSummary = useCallback((body: string) => enqueue({ kind: "summary", body }), [enqueue]);
+
+  return { editDraft, discardDraft, reanchorDraft, editSummary };
 }

--- a/apps/desktop/src/hooks/useDraftQueue.ts
+++ b/apps/desktop/src/hooks/useDraftQueue.ts
@@ -28,8 +28,11 @@ function send(command: DraftCommand) {
   }
 }
 
-/** Whichever `DraftsDto` a settled command hands back, and whether it was accepted. */
-function outcome(command: DraftCommand, data: DraftsDto | { accepted: boolean; drafts: DraftsDto }) {
+/** Whatever a settled command hands back, before it is narrowed by its kind. */
+type CommandData = DraftsDto | { accepted: boolean; drafts: DraftsDto } | string | null;
+
+/** Whichever `DraftsDto` a settled draft command hands back, and whether it was accepted. */
+function outcome(command: DraftCommand, data: CommandData) {
   return command.kind === "edit"
     ? (data as { accepted: boolean; drafts: DraftsDto })
     : { accepted: true, drafts: data as DraftsDto };
@@ -52,9 +55,15 @@ export function useDraftQueue(dispatch: (action: SessionAction) => void) {
   const pending = useRef<DraftCommand[]>([]);
 
   const settle = useCallback(
-    (command: DraftCommand, data: DraftsDto | { accepted: boolean; drafts: DraftsDto } | null) => {
-      // The summary answers with nothing. The editor already holds what it sent.
-      if (command.kind === "summary" || data === null) {
+    (command: DraftCommand, data: CommandData) => {
+      // A summary write does not echo the text back, because the editor already
+      // holds it. What it answers with is whatever is stopping writes landing,
+      // which for a reviewer touching no draft is the only way they are told.
+      if (command.kind === "summary") {
+        dispatch({ type: "writeFailure", failure: data as string | null });
+        return;
+      }
+      if (data === null) {
         return;
       }
       const { accepted, drafts } = outcome(command, data);

--- a/apps/desktop/src/hooks/useDraftQueue.ts
+++ b/apps/desktop/src/hooks/useDraftQueue.ts
@@ -7,9 +7,14 @@ type DraftCommand =
   | { kind: "edit"; fileIndex: number; start: number; end: number; body: string }
   | { kind: "discard"; fileIndex: number; row: number }
   | { kind: "reanchor"; fileIndex: number; path: string; side: DiffSideDto; line: number; row: number }
-  | { kind: "summary"; body: string };
+  | { kind: "summary"; body: string }
+  /** Work that must not be overtaken by the writes above, reporting for itself. */
+  | { kind: "job"; run: () => Promise<unknown> };
 
-function send(command: DraftCommand) {
+/** Everything but a job, which the queue runs rather than sends. */
+type SentCommand = Exclude<DraftCommand, { kind: "job" }>;
+
+function send(command: SentCommand) {
   switch (command.kind) {
     case "edit":
       return commands.editDraft(command.fileIndex, command.start, command.end, command.body);
@@ -32,7 +37,7 @@ function send(command: DraftCommand) {
 type CommandData = DraftsDto | { accepted: boolean; drafts: DraftsDto } | string | null;
 
 /** Whichever `DraftsDto` a settled draft command hands back, and whether it was accepted. */
-function outcome(command: DraftCommand, data: CommandData) {
+function outcome(command: SentCommand, data: CommandData) {
   return command.kind === "edit"
     ? (data as { accepted: boolean; drafts: DraftsDto })
     : { accepted: true, drafts: data as DraftsDto };
@@ -49,13 +54,13 @@ function coalesces(command: DraftCommand, previous: DraftCommand | undefined): b
   return false;
 }
 
-/** Serialises draft edits, discards, reanchors, and summary writes, at most one in flight, consecutive writes of one text coalescing while a discard or reanchor is always sent in order. */
+/** Serialises draft edits, discards, reanchors, summary writes, and any job that must not be overtaken by them, at most one in flight, consecutive writes of one text coalescing while everything else is sent in order. */
 export function useDraftQueue(dispatch: (action: SessionAction) => void) {
   const inFlight = useRef(false);
   const pending = useRef<DraftCommand[]>([]);
 
   const settle = useCallback(
-    (command: DraftCommand, data: CommandData) => {
+    (command: SentCommand, data: CommandData) => {
       // A summary write does not echo the text back, because the editor already
       // holds it. What it answers with is whatever is stopping writes landing,
       // which for a reviewer touching no draft is the only way they are told.
@@ -85,6 +90,12 @@ export function useDraftQueue(dispatch: (action: SessionAction) => void) {
         }
       };
       inFlight.current = true;
+      if (command.kind === "job") {
+        // The job answers to its caller; the queue only holds the slot so no
+        // write it was meant to follow can land on top of it.
+        command.run().then(advance, advance);
+        return;
+      }
       send(command).then((result) => {
         if (result.status === "ok") {
           settle(command, result.data);
@@ -131,5 +142,11 @@ export function useDraftQueue(dispatch: (action: SessionAction) => void) {
 
   const editSummary = useCallback((body: string) => enqueue({ kind: "summary", body }), [enqueue]);
 
-  return { editDraft, discardDraft, reanchorDraft, editSummary };
+  /** Runs `work` once every write queued before it has landed, holding the queue while it does. */
+  const runInOrder = useCallback(
+    (work: () => Promise<unknown>) => enqueue({ kind: "job", run: work }),
+    [enqueue],
+  );
+
+  return { editDraft, discardDraft, reanchorDraft, editSummary, runInOrder };
 }

--- a/apps/desktop/src/hooks/useSession.ts
+++ b/apps/desktop/src/hooks/useSession.ts
@@ -192,7 +192,7 @@ export function useSession(
    * state.
    */
   const applyFindingResult = useCallback(
-    <T,>(promise: Promise<CommandResult<T>>, onData: (data: T) => void) => {
+    <T,>(promise: Promise<CommandResult<T>>, onData: (data: T) => void) =>
       promise.then((result) => {
         if (result.status === "error") {
           dispatch({ type: "panelNotice", notice: toFailure(result.error).summary });
@@ -202,8 +202,7 @@ export function useSession(
           return;
         }
         onData(result.data);
-      });
-    },
+      }),
     [],
   );
 
@@ -257,28 +256,35 @@ export function useSession(
    * When the anchor already holds the reviewer's own draft, neither text is
    * written; the panel asks whether to replace it instead, first revealing the
    * row so the reviewer can see what they are being asked about.
+   *
+   * Run behind whatever the summary queue is holding. A finding about the whole
+   * change is merged into the summary by the backend and retires either way, so
+   * a keystroke still in flight landing on top of the merge would lose the
+   * proposal for good.
    */
   const acceptFinding = useCallback(
     (id: number) => {
-      applyFindingResult(commands.acceptFinding(id), (data) => {
-        const { panel, drafts, disposition } = data;
-        dispatch({ type: "panel", panel });
-        dispatch({ type: "drafts", drafts });
-        if (disposition.outcome === "Occupied") {
-          applyLocation(disposition.location);
-          dispatch({
-            type: "findingConflict",
-            conflict: { id, existing: disposition.existing, proposed: disposition.proposed },
-          });
-        }
-        // A finding about the change as a whole has nowhere to anchor, so its
-        // proposal goes into the summary editor for the reviewer to edit or clear.
-        if (disposition.outcome === "Summary") {
-          dispatch({ type: "summaryLoaded", body: disposition.body });
-        }
-      });
+      draftQueue.runInOrder(() =>
+        applyFindingResult(commands.acceptFinding(id), (data) => {
+          const { panel, drafts, disposition } = data;
+          dispatch({ type: "panel", panel });
+          dispatch({ type: "drafts", drafts });
+          if (disposition.outcome === "Occupied") {
+            applyLocation(disposition.location);
+            dispatch({
+              type: "findingConflict",
+              conflict: { id, existing: disposition.existing, proposed: disposition.proposed },
+            });
+          }
+          // A finding about the change as a whole has nowhere to anchor, so its
+          // proposal goes into the summary editor for the reviewer to edit or clear.
+          if (disposition.outcome === "Summary") {
+            dispatch({ type: "summaryLoaded", body: disposition.body });
+          }
+        }),
+      );
     },
-    [applyFindingResult, applyLocation],
+    [applyFindingResult, applyLocation, draftQueue],
   );
 
   const dismissFinding = useCallback(

--- a/apps/desktop/src/hooks/useSession.ts
+++ b/apps/desktop/src/hooks/useSession.ts
@@ -1,7 +1,13 @@
 import { useCallback, useEffect, useReducer, useRef } from "react";
 import { Channel } from "@tauri-apps/api/core";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
-import type { DiffSideDto, FindingLocationDto, ReviewPanelDto } from "../bindings";
+import type {
+  DiffSideDto,
+  FindingLocationDto,
+  ReviewEventDto,
+  ReviewPanelDto,
+  SubmissionDto,
+} from "../bindings";
 import { commands } from "../bindings";
 import { clamp } from "../lib/clamp";
 import { toFailure } from "../lib/failure";
@@ -13,6 +19,11 @@ type CommandResult<T> = { status: "ok"; data: T | null } | { status: "error"; er
 
 /** What a command answering with the review panel hands back. */
 type PanelResult = CommandResult<ReviewPanelDto>;
+
+/** What a command answering with the submission hands back. */
+type SubmissionResult =
+  | { status: "ok"; data: SubmissionDto }
+  | { status: "error"; error: unknown };
 
 /**
  * Loads one session and exposes every action the UI can take on it.
@@ -259,6 +270,11 @@ export function useSession(
             conflict: { id, existing: disposition.existing, proposed: disposition.proposed },
           });
         }
+        // A finding about the change as a whole has nowhere to anchor, so its
+        // proposal goes into the summary editor for the reviewer to edit or clear.
+        if (disposition.outcome === "Summary") {
+          dispatch({ type: "summary", body: disposition.body });
+        }
       });
     },
     [applyFindingResult, applyLocation],
@@ -297,6 +313,75 @@ export function useSession(
 
   /** Leaves the reviewer's draft and the finding both exactly as they were. */
   const keepFinding = useCallback(() => dispatch({ type: "findingConflict", conflict: null }), []);
+
+  /** Persists the summary, on the same queue the drafts use, on every keystroke. */
+  const summaryChange = useCallback(
+    (body: string) => draftQueue.editSummary(body),
+    [draftQueue],
+  );
+
+  /**
+   * Runs a submission command, showing a refusal in the panel.
+   *
+   * A command that never answered is about the review, not the sitting.
+   * Replacing the Session with a failure screen would throw away the diff and
+   * every draft over it.
+   */
+  const onSubmission = useCallback((call: Promise<SubmissionResult>) => {
+    call
+      .then((answered) => {
+        if (answered.status === "error") {
+          dispatch({ type: "panelNotice", notice: toFailure(answered.error).summary });
+          return;
+        }
+        dispatch({ type: "submission", submission: answered.data });
+      })
+      .catch((error: unknown) => {
+        dispatch({ type: "panelNotice", notice: toFailure(error).summary });
+      });
+  }, []);
+
+  /**
+   * Assembles what submitting would post and opens the confirmation.
+   *
+   * Posts nothing. What comes back is the exact request, which the reviewer
+   * approves before anything leaves the machine.
+   */
+  const submit = useCallback(
+    (event: ReviewEventDto) => onSubmission(commands.requestSubmission(event)),
+    [onSubmission],
+  );
+
+  /** Puts the confirmation away, leaving every draft and the summary as they were. */
+  const cancelSubmission = useCallback(
+    () => onSubmission(commands.cancelSubmission()),
+    [onSubmission],
+  );
+
+  /**
+   * Posts the confirmed review.
+   *
+   * The backend refuses a second send while one is in flight, and the panel is
+   * put into its sending state first so the confirmation's own buttons go with
+   * it. A failure keeps every draft and the summary exactly where they were.
+   */
+  const sendSubmission = useCallback(() => {
+    commands
+      .sendSubmission()
+      .then((sent) => {
+        if (sent.status === "error") {
+          dispatch({ type: "panelNotice", notice: toFailure(sent.error).summary });
+          return;
+        }
+        dispatch({ type: "submission", submission: sent.data.submission });
+        dispatch({ type: "drafts", drafts: sent.data.drafts });
+        // Only now is it safe for the editor to forget what was posted.
+        dispatch({ type: "summary", body: sent.data.summary });
+      })
+      .catch((error: unknown) => {
+        dispatch({ type: "panelNotice", notice: toFailure(error).summary });
+      });
+  }, []);
 
   const clickRow = useCallback((index: number) => dispatch({ type: "click", index }), []);
 
@@ -344,8 +429,12 @@ export function useSession(
     }
 
     function handleKeydown(event: KeyboardEvent) {
-      // The composer is a real text editor, so global shortcuts yield to it entirely.
-      if (event.target instanceof HTMLElement && event.target.closest("[data-composer]")) {
+      // The composer and the summary are real text editors, so global shortcuts
+      // yield to either of them entirely.
+      if (
+        event.target instanceof HTMLElement &&
+        event.target.closest("[data-composer], [data-summary-editor]")
+      ) {
         return;
       }
 
@@ -385,8 +474,7 @@ export function useSession(
       if (event.metaKey && event.shiftKey && key === "y") {
         event.preventDefault();
         const finding = selectedFinding(current.panel);
-        // No summary editor yet, so a whole-change finding cannot be accepted.
-        if (finding !== null && finding.position !== null) {
+        if (finding !== null) {
           acceptFinding(finding.id);
         }
         return;
@@ -456,5 +544,9 @@ export function useSession(
     dismissFinding,
     replaceFinding,
     keepFinding,
+    summaryChange,
+    submit,
+    cancelSubmission,
+    sendSubmission,
   };
 }

--- a/apps/desktop/src/hooks/useSession.ts
+++ b/apps/desktop/src/hooks/useSession.ts
@@ -46,6 +46,9 @@ export function useSession(
   // Held here rather than read off the panel, because a second trigger can arrive
   // before the first run's own "Running" panel has come back over the channel.
   const isRunning = useRef(false);
+  // The same, for the send. A double press must not reach the backend twice,
+  // even though the backend refuses the second one anyway.
+  const isSending = useRef(false);
 
   const isReviewRunning = state.status === "ready" && state.panel?.run.state === "Running";
   useEffect(() => {
@@ -366,21 +369,39 @@ export function useSession(
    * it. A failure keeps every draft and the summary exactly where they were.
    */
   const sendSubmission = useCallback(() => {
-    commands
-      .sendSubmission()
-      .then((sent) => {
-        if (sent.status === "error") {
-          dispatch({ type: "panelNotice", notice: toFailure(sent.error).summary });
-          return;
-        }
-        dispatch({ type: "submission", submission: sent.data.submission });
-        dispatch({ type: "drafts", drafts: sent.data.drafts });
-        // Only now is it safe for the editor to forget what was posted.
-        dispatch({ type: "summary", body: sent.data.summary });
-      })
-      .catch((error: unknown) => {
-        dispatch({ type: "panelNotice", notice: toFailure(error).summary });
-      });
+    if (isSending.current) {
+      return;
+    }
+    isSending.current = true;
+
+    try {
+      const channel = new Channel<SubmissionDto>();
+      channel.onmessage = (submission) => dispatch({ type: "submission", submission });
+
+      commands
+        .sendSubmission(channel)
+        .then((sent) => {
+          if (sent.status === "error") {
+            dispatch({ type: "panelNotice", notice: toFailure(sent.error).summary });
+            return;
+          }
+          dispatch({ type: "submission", submission: sent.data.submission });
+          dispatch({ type: "drafts", drafts: sent.data.drafts });
+          // Only now is it safe for the editor to forget what was posted.
+          dispatch({ type: "summary", body: sent.data.summary });
+        })
+        .catch((error: unknown) => {
+          dispatch({ type: "panelNotice", notice: toFailure(error).summary });
+        })
+        .finally(() => {
+          isSending.current = false;
+        });
+    } catch (error: unknown) {
+      // A throw before the promise exists would otherwise leave the flag set and
+      // nothing sendable for the rest of the sitting.
+      isSending.current = false;
+      dispatch({ type: "panelNotice", notice: toFailure(error).summary });
+    }
   }, []);
 
   const clickRow = useCallback((index: number) => dispatch({ type: "click", index }), []);

--- a/apps/desktop/src/hooks/useSession.ts
+++ b/apps/desktop/src/hooks/useSession.ts
@@ -274,7 +274,7 @@ export function useSession(
         // A finding about the change as a whole has nowhere to anchor, so its
         // proposal goes into the summary editor for the reviewer to edit or clear.
         if (disposition.outcome === "Summary") {
-          dispatch({ type: "summary", body: disposition.body });
+          dispatch({ type: "summaryLoaded", body: disposition.body });
         }
       });
     },
@@ -315,8 +315,19 @@ export function useSession(
   /** Leaves the reviewer's draft and the finding both exactly as they were. */
   const keepFinding = useCallback(() => dispatch({ type: "findingConflict", conflict: null }), []);
 
-  /** Persists the summary, on the same queue the drafts use, on every keystroke. */
-  const summaryChange = useCallback((body: string) => draftQueue.editSummary(body), [draftQueue]);
+  /**
+   * Persists the summary on every keystroke, on the same queue the drafts use.
+   *
+   * Held in state as well as sent, so what the editor holds is never guessed at
+   * from an older answer.
+   */
+  const summaryChange = useCallback(
+    (body: string) => {
+      dispatch({ type: "summary", body });
+      draftQueue.editSummary(body);
+    },
+    [draftQueue],
+  );
 
   /**
    * Runs a submission command, showing a refusal in the panel.
@@ -386,7 +397,7 @@ export function useSession(
           // it alone, because the backend's copy of the summary can be a
           // keystroke behind what the reviewer is still typing.
           if (sent.data.submission.phase.state === "Sent") {
-            dispatch({ type: "summary", body: sent.data.summary });
+            dispatch({ type: "summaryLoaded", body: sent.data.summary });
           }
         })
         .catch((error: unknown) => {

--- a/apps/desktop/src/hooks/useSession.ts
+++ b/apps/desktop/src/hooks/useSession.ts
@@ -387,8 +387,12 @@ export function useSession(
           }
           dispatch({ type: "submission", submission: sent.data.submission });
           dispatch({ type: "drafts", drafts: sent.data.drafts });
-          // Only now is it safe for the editor to forget what was posted.
-          dispatch({ type: "summary", body: sent.data.summary });
+          // Only a review that landed empties the editor. A failed send must
+          // leave it alone: its text is the reviewer's, and the backend's copy
+          // can be a keystroke behind what they are still typing.
+          if (sent.data.submission.phase.state === "Sent") {
+            dispatch({ type: "summary", body: sent.data.summary });
+          }
         })
         .catch((error: unknown) => {
           dispatch({ type: "panelNotice", notice: toFailure(error).summary });

--- a/apps/desktop/src/hooks/useSession.ts
+++ b/apps/desktop/src/hooks/useSession.ts
@@ -21,9 +21,7 @@ type CommandResult<T> = { status: "ok"; data: T | null } | { status: "error"; er
 type PanelResult = CommandResult<ReviewPanelDto>;
 
 /** What a command answering with the submission hands back. */
-type SubmissionResult =
-  | { status: "ok"; data: SubmissionDto }
-  | { status: "error"; error: unknown };
+type SubmissionResult = { status: "ok"; data: SubmissionDto } | { status: "error"; error: unknown };
 
 /**
  * Loads one session and exposes every action the UI can take on it.
@@ -318,10 +316,7 @@ export function useSession(
   const keepFinding = useCallback(() => dispatch({ type: "findingConflict", conflict: null }), []);
 
   /** Persists the summary, on the same queue the drafts use, on every keystroke. */
-  const summaryChange = useCallback(
-    (body: string) => draftQueue.editSummary(body),
-    [draftQueue],
-  );
+  const summaryChange = useCallback((body: string) => draftQueue.editSummary(body), [draftQueue]);
 
   /**
    * Runs a submission command, showing a refusal in the panel.
@@ -387,9 +382,9 @@ export function useSession(
           }
           dispatch({ type: "submission", submission: sent.data.submission });
           dispatch({ type: "drafts", drafts: sent.data.drafts });
-          // Only a review that landed empties the editor. A failed send must
-          // leave it alone: its text is the reviewer's, and the backend's copy
-          // can be a keystroke behind what they are still typing.
+          // Only a review that landed empties the editor. A failed send leaves
+          // it alone, because the backend's copy of the summary can be a
+          // keystroke behind what the reviewer is still typing.
           if (sent.data.submission.phase.state === "Sent") {
             dispatch({ type: "summary", body: sent.data.summary });
           }

--- a/apps/desktop/src/test/fixtures.ts
+++ b/apps/desktop/src/test/fixtures.ts
@@ -15,6 +15,8 @@ import type {
   SessionSnapshotDto,
   SidebarDto,
   StaleDraftDto,
+  SubmissionDto,
+  SubmissionRequestDto,
 } from "../bindings";
 
 /** The guidance section once discovery has found something. */
@@ -58,6 +60,8 @@ export function makeDrafts(overrides: Partial<DraftsDto> = {}): DraftsDto {
     anchored: [],
     stale: [],
     file_draft_count: 0,
+    ready_count: 0,
+    not_anchored_count: 0,
     write_failure: null,
     ...overrides,
   };
@@ -104,8 +108,32 @@ export function makeSnapshot(overrides: Partial<SessionSnapshotDto> = {}): Sessi
     subtitle: "Diff virtualization demo",
     sidebar: makeSidebar(),
     warnings: [],
+    can_submit: false,
+    summary: "",
     ...overrides,
   };
+}
+
+export function makeSubmissionRequest(
+  overrides: Partial<SubmissionRequestDto> = {},
+): SubmissionRequestDto {
+  return {
+    heading: "Comment with 1 inline comment",
+    pinned: "pinned to abc1234",
+    body: "Two notes.",
+    comments: [{ position: "src/review_fixture_00.rs RIGHT line 2", body: "needs a test" }],
+    excluded: [],
+    excluded_heading: null,
+    ...overrides,
+  };
+}
+
+/** The submission at whatever phase a test needs, one revision on from idle. */
+export function makeSubmission(
+  phase: SubmissionDto["phase"] = { state: "Idle" },
+  revision = 1,
+): SubmissionDto {
+  return { revision, phase };
 }
 
 export function makeGuidanceEntry(overrides: Partial<GuidanceEntryDto> = {}): GuidanceEntryDto {

--- a/crates/app/src/session.rs
+++ b/crates/app/src/session.rs
@@ -68,6 +68,16 @@ pub struct SessionModel {
     /// request, in which case submitting is not offered at all.
     submitter: Option<Arc<dyn ReviewSubmitter>>,
     submission: SubmissionState,
+    /// How many times the submission has changed.
+    ///
+    /// A front end learns about this through whole-state snapshots, from several
+    /// commands running at once. One read before a change can be delivered after
+    /// a snapshot that carries it, which would show a confirmation for a verdict
+    /// the model is no longer holding. This is how the receiver tells which of
+    /// two snapshots is older.
+    ///
+    /// Saturating rather than wrapping, so it can never go backwards.
+    submission_revision: u32,
 }
 
 impl SessionModel {
@@ -82,6 +92,7 @@ impl SessionModel {
             review_sink: None,
             submitter: None,
             submission: SubmissionState::Idle,
+            submission_revision: 0,
         }
     }
 
@@ -514,17 +525,18 @@ impl SessionModel {
         let SessionPhase::Ready(review) = &self.phase else {
             return;
         };
-        self.submission = match review.session.prepare_submission(event) {
+        let next = match review.session.prepare_submission(event) {
             Ok(submission) => SubmissionState::Confirming(Box::new(submission)),
             Err(refused) => SubmissionState::Failed(
                 SessionFailure::new("This review cannot be submitted yet")
                     .with_remediation(refused.to_string()),
             ),
         };
+        self.set_submission(next);
     }
 
     pub fn cancel_submission(&mut self) {
-        self.submission = SubmissionState::Idle;
+        self.set_submission(SubmissionState::Idle);
     }
 
     /// Takes the confirmed review, so it can be posted away from the UI thread.
@@ -540,7 +552,7 @@ impl SessionModel {
             return None;
         };
         let submission = (**submission).clone();
-        self.submission = SubmissionState::Sending;
+        self.set_submission(SubmissionState::Sending);
         Some(PendingSend {
             submission,
             submitter,
@@ -565,7 +577,7 @@ impl SessionModel {
             Ok(outcome) => outcome,
             // Nothing local was touched, so every draft is still there.
             Err(failure) => {
-                self.submission = SubmissionState::Failed(failure);
+                self.set_submission(SubmissionState::Failed(failure));
                 return;
             }
         };
@@ -583,13 +595,35 @@ impl SessionModel {
         {
             sink.clear_submitted(head_sha, &anchors);
         }
-        self.submission = SubmissionState::Sent(outcome);
+        self.set_submission(SubmissionState::Sent(outcome));
     }
 
     /// How far a submission has got.
     #[must_use]
     pub const fn submission(&self) -> &SubmissionState {
         &self.submission
+    }
+
+    /// How many times the submission has changed, so a snapshot read before a
+    /// change can be told from one that carries it.
+    #[must_use]
+    pub const fn submission_revision(&self) -> u32 {
+        self.submission_revision
+    }
+
+    /// Whether this session has somewhere to post a review.
+    ///
+    /// False for the generated fixture and a local comparison, neither of which
+    /// is offered submission at all.
+    #[must_use]
+    pub const fn is_submittable(&self) -> bool {
+        self.submitter.is_some()
+    }
+
+    /// Moves the submission on, recording that it moved.
+    fn set_submission(&mut self, state: SubmissionState) {
+        self.submission = state;
+        self.submission_revision = self.submission_revision.saturating_add(1);
     }
 
     /// Tells storage what now sits at an anchor, which may be nothing.
@@ -1739,6 +1773,53 @@ mod tests {
         assert_eq!(
             sink.calls(),
             ["summary o".to_owned(), "summary ok".to_owned()],
+        );
+    }
+
+    /// Only a session with somewhere to post is offered submission at all.
+    #[test]
+    fn a_session_with_no_submitter_cannot_be_submitted() {
+        let with_submitter = loaded_model(
+            submittable_session(),
+            None,
+            Some(Arc::new(RecordingSubmitter::default())),
+        );
+        assert!(with_submitter.is_submittable());
+
+        let without = loaded_model(submittable_session(), None, None);
+        assert!(!without.is_submittable());
+        // A local comparison has a head commit but nowhere to post to.
+        assert!(!ready_model(None).is_submittable());
+    }
+
+    /// Two submission commands can be in flight at once, so a receiver has to be
+    /// able to tell which of two answers was read later.
+    #[test]
+    fn every_submission_change_carries_a_higher_revision() {
+        let mut session = submittable_session();
+        session.set_summary("Two notes.");
+        let mut model = loaded_model(session, None, Some(Arc::new(RecordingSubmitter::default())));
+        let idle = model.submission_revision();
+
+        model.request_submission(ReviewEvent::Comment);
+        let confirming = model.submission_revision();
+        assert!(confirming > idle, "confirming is later than idle");
+
+        let pending = model.begin_send().expect("the review is confirmed");
+        let sending = model.submission_revision();
+        assert!(sending > confirming, "sending is later than confirming");
+
+        let posted = pending.submitter.submit(&pending.submission);
+        model.complete_send(&pending.submission, posted);
+        assert!(
+            model.submission_revision() > sending,
+            "the outcome is later than sending",
+        );
+
+        model.cancel_submission();
+        assert!(
+            model.submission_revision() > sending,
+            "cancelling is later still",
         );
     }
 

--- a/crates/app/src/session.rs
+++ b/crates/app/src/session.rs
@@ -521,7 +521,14 @@ impl SessionModel {
     /// Deliberately stops here. PLAN requires that nothing is ever posted without
     /// an explicit human submission action, so building the request and sending it
     /// are two separate steps with a person in between.
+    ///
+    /// Refused outright while a send is in flight. A review already on its way to
+    /// the forge cannot be re-aimed, and holding a fresh confirmation over one
+    /// would let a second review be posted on top of the first.
     pub fn request_submission(&mut self, event: ReviewEvent) {
+        if self.is_sending() {
+            return;
+        }
         let SessionPhase::Ready(review) = &self.phase else {
             return;
         };
@@ -535,8 +542,25 @@ impl SessionModel {
         self.set_submission(next);
     }
 
+    /// Puts the confirmation away, leaving every draft and the summary as they were.
+    ///
+    /// Refused while a send is in flight. Cancelling cannot call a review back
+    /// once it has left, so it must not say it did.
     pub fn cancel_submission(&mut self) {
+        if self.is_sending() {
+            return;
+        }
         self.set_submission(SubmissionState::Idle);
+    }
+
+    /// Records a send that never reported an outcome, so one can be tried again.
+    ///
+    /// Ignored unless a send is in flight, so a caller that died after the
+    /// outcome was recorded cannot overwrite it.
+    pub fn abandon_send(&mut self, failure: SessionFailure) {
+        if self.is_sending() {
+            self.set_submission(SubmissionState::Failed(failure));
+        }
     }
 
     /// Takes the confirmed review, so it can be posted away from the UI thread.
@@ -566,13 +590,18 @@ impl SessionModel {
     ///
     /// # Panics
     ///
-    /// Panics if the phase is not `Ready`. `begin_send` only ever hands out a
-    /// submission while it is, and the phase cannot regress.
+    /// Panics if no send is in flight, or if the phase is not `Ready`.
+    /// `begin_send` only ever hands out a submission while both hold, and
+    /// neither can regress.
     pub fn complete_send(
         &mut self,
         submission: &ReviewSubmission,
         posted: Result<SubmissionOutcome, SessionFailure>,
     ) {
+        assert!(
+            self.is_sending(),
+            "a submission completed while none was being sent",
+        );
         let outcome = match posted {
             Ok(outcome) => outcome,
             // Nothing local was touched, so every draft is still there.
@@ -609,6 +638,17 @@ impl SessionModel {
     #[must_use]
     pub const fn submission_revision(&self) -> u32 {
         self.submission_revision
+    }
+
+    /// Whether a confirmed review is on its way to the forge.
+    const fn is_sending(&self) -> bool {
+        match self.submission {
+            SubmissionState::Sending => true,
+            SubmissionState::Idle
+            | SubmissionState::Confirming(_)
+            | SubmissionState::Sent(_)
+            | SubmissionState::Failed(_) => false,
+        }
     }
 
     /// Whether this session has somewhere to post a review.
@@ -890,6 +930,29 @@ mod tests {
             review_sink,
             None,
         )
+    }
+
+    /// A model that has handed out a send and is waiting on it, which is where
+    /// the submission spends the whole of a network call.
+    fn sending_model(submitter: &RecordingSubmitter) -> SessionModel {
+        let mut session = submittable_session();
+        session.set_draft(0, 6, "needs a test");
+        session.set_summary("Two notes.");
+        let mut model = loaded_model(session, None, Some(Arc::new(submitter.clone())));
+        model.request_submission(ReviewEvent::Comment);
+        let pending = model.begin_send().expect("the review is confirmed");
+        // Deliberately dropped without completing, which is what a caller holding
+        // it across a network call looks like from here.
+        drop(pending);
+        model
+    }
+
+    /// The request a sending model is waiting on, rebuilt from the same session.
+    fn only_confirmed(model: &SessionModel) -> ReviewSubmission {
+        review(model)
+            .session()
+            .prepare_submission(ReviewEvent::Comment)
+            .expect("the session assembled one already")
     }
 
     /// The loaded review, which every one of these tests has.
@@ -1792,34 +1855,70 @@ mod tests {
         assert!(!ready_model(None).is_submittable());
     }
 
-    /// Two submission commands can be in flight at once, so a receiver has to be
-    /// able to tell which of two answers was read later.
+    /// A review already on its way to the forge cannot be re-aimed. Without this
+    /// the reviewer could pick a second verdict mid-send and confirm it, posting
+    /// twice.
     #[test]
-    fn every_submission_change_carries_a_higher_revision() {
-        let mut session = submittable_session();
-        session.set_summary("Two notes.");
-        let mut model = loaded_model(session, None, Some(Arc::new(RecordingSubmitter::default())));
-        let idle = model.submission_revision();
+    fn a_verdict_cannot_be_chosen_while_the_review_is_being_sent() {
+        let submitter = RecordingSubmitter::default();
+        let mut model = sending_model(&submitter);
 
-        model.request_submission(ReviewEvent::Comment);
-        let confirming = model.submission_revision();
-        assert!(confirming > idle, "confirming is later than idle");
+        model.request_submission(ReviewEvent::Approve);
 
-        let pending = model.begin_send().expect("the review is confirmed");
-        let sending = model.submission_revision();
-        assert!(sending > confirming, "sending is later than confirming");
-
-        let posted = pending.submitter.submit(&pending.submission);
-        model.complete_send(&pending.submission, posted);
         assert!(
-            model.submission_revision() > sending,
-            "the outcome is later than sending",
+            matches!(model.submission(), SubmissionState::Sending),
+            "a send in flight outranks a new verdict",
         );
+        assert!(model.begin_send().is_none(), "nothing new to confirm");
+        assert!(submitter.posted().is_empty());
+    }
+
+    /// Cancelling cannot call a review back once it has left, and must not say it
+    /// did.
+    #[test]
+    fn a_send_in_flight_cannot_be_cancelled() {
+        let submitter = RecordingSubmitter::default();
+        let mut model = sending_model(&submitter);
 
         model.cancel_submission();
+
         assert!(
-            model.submission_revision() > sending,
-            "cancelling is later still",
+            matches!(model.submission(), SubmissionState::Sending),
+            "cancelling must not claim a send was called back",
+        );
+    }
+
+    /// A send whose task died never reported an outcome, and would otherwise
+    /// leave the submission stuck on sending, refusing every retry.
+    #[test]
+    fn a_send_that_never_reported_back_leaves_something_that_can_be_retried() {
+        let submitter = RecordingSubmitter::default();
+        let mut model = sending_model(&submitter);
+
+        model.abandon_send(SessionFailure::new("The review was not sent"));
+
+        let SubmissionState::Failed(failure) = model.submission() else {
+            panic!("an abandoned send should be shown as failed");
+        };
+        assert_eq!(failure.summary, "The review was not sent");
+        // Retrying is exactly what the reviewer is now free to do.
+        model.request_submission(ReviewEvent::Comment);
+        assert!(matches!(model.submission(), SubmissionState::Confirming(_)));
+    }
+
+    /// A task that died after recording its outcome must not overwrite it.
+    #[test]
+    fn abandoning_a_send_that_already_landed_leaves_the_outcome_alone() {
+        let submitter = RecordingSubmitter::default();
+        let mut model = sending_model(&submitter);
+        let posted = submitter.submit(&only_confirmed(&model));
+        model.complete_send(&only_confirmed(&model), posted);
+
+        model.abandon_send(SessionFailure::new("The review was not sent"));
+
+        assert!(
+            matches!(model.submission(), SubmissionState::Sent(_)),
+            "a landed review stays landed",
         );
     }
 

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -211,6 +211,17 @@ fn attach_draft_storage(
     {
         session.restore_dismissed(dismissed.into_iter().collect());
     }
+    // The summary is the reviewer's own words, like the drafts, so a read that
+    // fails is worth saying rather than quietly starting them on an empty editor.
+    // Keyed by head as well as scope, so a branch that was pushed to restores
+    // nothing rather than words written about code that has moved.
+    if let Some(head_sha) = session.source().head_sha() {
+        match reader.load_summary(&scope, head_sha) {
+            Ok(Some(summary)) => session.set_summary(summary),
+            Ok(None) => {}
+            Err(error) => session.push_warning(review_storage_warning(&error)),
+        }
+    }
 
     match ReviewStore::open(&path) {
         Ok(writer) => Some(Box::new(ReviewStateWriter::spawn(writer, scope))),


### PR DESCRIPTION
Closes #36

The desktop Session could review a pull request but not finish one. This is migration stage 5, the last functional stage, and after it the only work left is the design token sweep and deleting the GPUI crates.

What changed:
- A submit bar with the count ready to submit, the count no longer anchored, a summary editor, and Comment, Approve, and Request changes
- The summary is written on every keystroke and restored when a Session reopens on the same pull request and head, which had never been wired
- Choosing a verdict posts nothing. It opens a confirmation holding the exact request, the verdict, the summary, every draft with its file and line, and every draft that will not be posted with its reason
- Confirming sends once on a background task, with the sending state, the outcome, and a failure that keeps every draft and the summary so a retry works
- Accepting a Finding about the whole change is re-enabled, since there is now somewhere to show its proposal

Notes:
Start with the submission state machine in the session model and the send command, which drops the model lock before the post. The model refuses a verdict change, a cancel, and a second send while one is in flight, so the guard does not depend on the frontend. Nothing was posted to GitHub from any test. Please make one real review by hand before relying on it, since every test stops at a recording submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189um4LrckqAAq5fgnixT1p
